### PR TITLE
Adds support downloading original audio files

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,7 +141,7 @@ class ApplicationController < ActionController::Base
     render layout: false
   end
 
-  def auth_custom_audio_recording(request_params)
+  def auth_custom_audio_recording(request_params, action = :show)
     # do auth manually
     #authorize! :show, @audio_recording
 
@@ -149,7 +149,7 @@ class ApplicationController < ActionController::Base
     fail CustomErrors::ItemNotFoundError, "Could not find audio recording with id #{request_params[:audio_recording_id]}." if audio_recording.blank?
 
     # can? also checks for admin access
-    can_access_audio_recording = can? :show, audio_recording
+    can_access_audio_recording = can? action, audio_recording
 
     # Can't do anything if can't access audio recording and no audio event id given
     has_any_permission = can_access_audio_recording || !request_params[:audio_event_id].blank?

--- a/app/controllers/audio_recordings_controller.rb
+++ b/app/controllers/audio_recordings_controller.rb
@@ -18,7 +18,6 @@ class AudioRecordingsController < ApplicationController
   end
 
   # GET /audio_recordings/:id
-
   def show
     do_load_resource
     do_authorize_instance

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -124,7 +124,8 @@ class Ability
 
   def for_harvester
     # actions used for harvesting. See baw-workers.
-    can [:new, :create, :check_uploader, :update_status, :update], AudioRecording
+    # :original is the permission to download an original audio file
+    can [:new, :create, :check_uploader, :update_status, :update, :original], AudioRecording
 
     # omitted: :new, :create,
     # applied by default: :index, :show, :filter
@@ -257,7 +258,7 @@ class Ability
   def to_audio_recording(user, is_guest)
     # cannot use block for #index, #filter
     # See permissions for harvester (#for_harvester)
-    # Only admin and harvester can #create, #check_uploader, #update_status, #update
+    #   - Only admin and harvester can #create, #check_uploader, #update_status, #update
     # permissions are also checked in controller actions
     # GET       /projects/:project_id/sites/:site_id/audio_recordings/check_uploader/:uploader_id audio_recordings#check_uploader {:format=>"json"}
     # POST      /projects/:project_id/sites/:site_id/audio_recordings                             audio_recordings#create {:format=>"json"}
@@ -521,6 +522,10 @@ class Ability
     # available to any user, including guest
     # skips CanCan auth
     can [:show], :media
+
+    # See permissions for harvester:
+    #   - Only admin and harvester can download original recording (#original)
+    # GET       /audio_recordings/:id/original     media#original
   end
 
   def to_error(user, is_guest)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,9 @@ Rails.application.routes.draw do
   # API audio recording item
   resources :audio_recordings, only: [:index, :show, :new, :update], defaults: {format: 'json'} do
     match 'media.:format' => 'media#show', defaults: {format: 'json'}, as: :media, via: [:get, :head]
+    scope defaults: {format: false} do
+      match 'original' => 'media#original', as: :media_original, via: [:get, :head]
+    end
     resources :audio_events, except: [:edit], defaults: {format: 'json'} do
       collection do
         get 'download', defaults: {format: 'csv'}

--- a/spec/acceptance/media_spec.rb
+++ b/spec/acceptance/media_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 require 'helpers/acceptance_spec_helper'
 require 'helpers/resque_helper'
+# For some reason this patch is not loaded and I can't work out why
+require (File.expand_path(__FILE__ + "/../../../lib/patches/mime_type.rb"))
 
 # https://github.com/zipmark/rspec_api_documentation
 resource 'Media' do
@@ -27,6 +29,7 @@ resource 'Media' do
 
   let(:audio_file_mono) { File.join(File.dirname(__FILE__), '..', 'media_tools', 'test-audio-mono.ogg') }
   let(:audio_file_mono_media_type) { Mime::Type.lookup('audio/ogg') }
+  let(:audio_file_mono_size_bytes) { 822281 }
   let(:audio_file_mono_sample_rate) { 44100 }
   let(:audio_file_mono_channels) { 1 }
   let(:audio_file_mono_duration_seconds) { 70 }
@@ -864,4 +867,109 @@ resource 'Media' do
     end
   end
 
+  ################################
+  # ORIGINAL
+  ################################
+  describe "original audio download" do
+
+    let(:start_offset) { nil }
+    let(:end_offset) { nil }
+
+    before(:each) do
+      # the standard media route only allows short recordings, purposely mock a long duration to make sure long
+      # original recordings succeed.
+      audio_recording.update_attribute(:duration_seconds, 3600) # one hour
+      create_media_options(audio_recording)
+    end
+
+    after(:each) do
+      remove_media_dirs
+    end
+
+    def full_file_result(context, opts)
+      filename = context.audio_recording.canonical_filename
+      opts.merge!({
+          expected_response_content_type: context.audio_recording.media_type,
+          expected_response_has_content: true,
+          expected_response_header_values_match: false,
+          expected_response_header_values: {
+            'Content-Length' => context.audio_file_mono_size_bytes.to_s,
+            'Content-Disposition' => "attachment; filename=\"#{filename}\"",
+            'Digest' => 'SHA256=' + context.audio_recording.split_file_hash[1]
+          },
+          is_range_request: false
+      })
+    end
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { reader_token }
+
+      standard_request_options(:get, 'ORIGINAL (as reader)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    end
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { writer_token }
+
+      standard_request_options(:get, 'ORIGINAL (as writer)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    end
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { no_access_token }
+
+      standard_request_options(:get, 'ORIGINAL (as no access)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    end
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { invalid_token }
+
+      standard_request_options(:get, 'ORIGINAL (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_in)})
+    end
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { owner_token }
+
+      standard_request_options(:get, 'ORIGINAL (as owner token)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    end
+
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { admin_token }
+
+      standard_request_options(
+          :get,
+          'ORIGINAL (as admin token)',
+          :ok,
+          {},
+          &proc { |context, opts|
+            context.full_file_result(context, opts)
+          })
+    end
+
+    get '/audio_recordings/:audio_recording_id/original' do
+      parameter :audio_recording_id, 'Requested audio recording id (in path/route)', required: true
+
+      let(:authentication_token) { harvester_token }
+
+      standard_request_options(
+          :get,
+          'ORIGINAL (as harvester token)',
+          :ok,
+          {},
+          &proc { |context, opts|
+            context.full_file_result(context, opts)
+          })
+    end
+  end
 end

--- a/spec/helpers/acceptance_spec_helper.rb
+++ b/spec/helpers/acceptance_spec_helper.rb
@@ -161,7 +161,11 @@ def acceptance_checks_shared(request, opts = {})
   # don't document because it returns binary data that can't be json encoded
   #is_documentation_run = !!(ENV['GENERATE_DOC'])
 
-  actual_response = response_body
+  if http_method == :get && response_headers['Content-Transfer-Encoding'] == 'binary'
+    actual_response = response_body[0...100] + ' <TRIMMED>'
+  else
+    actual_response = response_body
+  end
 
   # info hash
   opts.merge!(
@@ -209,7 +213,7 @@ def acceptance_checks_shared(request, opts = {})
     if (opts[:actual_response_content_type].start_with?('image/') || opts[:actual_response_content_type].start_with?('audio/')) &&
         !opts[:actual_response_headers].include?('X-Error-Type')
       expect(opts[:actual_response_headers]['Content-Transfer-Encoding']).to eq('binary'), "Mismatch: content transfer encoding. #{opts[:msg]}"
-      expect(opts[:actual_response_headers]['Content-Disposition']).to start_with('inline; filename='), "Mismatch: content disposition. #{opts[:msg]}"
+      expect(opts[:actual_response_headers]['Content-Disposition']).to match(/(inline|attachment); filename=/), "Mismatch: content disposition. #{opts[:msg]}"
     end
   end
 

--- a/spec/models/audio_recording_spec.rb
+++ b/spec/models/audio_recording_spec.rb
@@ -373,4 +373,29 @@ describe AudioRecording, :type => :model do
     ar2.file_hash = MiscHelper.new.create_sha_256_hash
     ar2.save!
   end
+
+  it 'provides a hash split function to return the file_hash components' do
+    ar = FactoryGirl.build(:audio_recording, file_hash: 'SHA256::abc123')
+
+    protocol, value = ar.split_file_hash
+
+    expect(protocol).to eq('SHA256')
+    expect(value).to eq('abc123')
+
+    expect {
+      ar = FactoryGirl.build(:audio_recording, file_hash: 'SHA256::abc::123')
+      ar.split_file_hash
+    }.to raise_error(RuntimeError, 'Invalid file hash detected (more than one "::" found)' )
+  end
+
+  it 'can return a canonical filename for an audio recording' do
+    uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    date = '20180226-222930Z'
+
+    ar = FactoryGirl.build(:audio_recording, uuid: uuid, recorded_date: DateTime.strptime(date, '%Y%m%d-%H%M%S%z'), media_type: "audio/wav")
+
+    actual = ar.canonical_filename
+
+    expect(actual).to eq("#{uuid}_#{date}.wav")
+  end
 end

--- a/spec/routing/audio_recordings_routing_spec.rb
+++ b/spec/routing/audio_recordings_routing_spec.rb
@@ -10,8 +10,6 @@ describe AudioRecordingsController, :type => :routing do
 
     it { expect(get('/audio_recordings/new')).to route_to('audio_recordings#new', format: 'json') }
 
-
-
     # used by harvester
     it { expect(get('/audio_recordings/3')).to route_to('audio_recordings#show', id: '3', format: 'json') }
     it { expect(post('/projects/1/sites/2/audio_recordings')).to route_to('audio_recordings#create', project_id: '1', site_id: '2', format: 'json') }

--- a/spec/routing/media_routing_spec.rb
+++ b/spec/routing/media_routing_spec.rb
@@ -25,5 +25,9 @@ describe MediaController, :type => :routing do
     it { expect(head('/audio_recordings/3/media.mp3')).to route_to('media#show', audio_recording_id: '3', format: 'mp3') }
     it { expect(head('/audio_recordings/3/media')).to route_to('errors#route_error', requested_route: 'audio_recordings/3/media') }
 
+
+    # original audio download routes
+    it { expect(get('/audio_recordings/3/original')).to route_to('media#original', audio_recording_id: '3', format: false) }
+
   end
 end


### PR DESCRIPTION
Closes #353

Extends the Media controller so that original audio files can be downloaded. Currently limited to harvester or admin only (as enabling this generally could be expensive in terms of bandwidth).

Also:
- Supports range requests for original audio
- Adds two helper funtions to AudioRecording model: a split hash function that reliably splits the hash protocol from the hash value; and a canonical filename function that can generate ideal storage names for audio recordings
- Also fixes `original_file_paths` and `original_format_calculated` methods on AudioRecording
- Adds support to range request for configuring download names and content disposition types
- Patches acceptance spec helper so that large binary blobs are not printed when tests fail