### PR TITLE
Default to native sample rate when filtering out invalid available

### DIFF
--- a/spec/acceptance/media_spec.rb
+++ b/spec/acceptance/media_spec.rb
@@ -702,13 +702,17 @@ resource 'Media' do
       let(:authentication_token) { reader_token }
       let(:format) { 'json' }
 
-      example 'MEDIA (as reader) checking json valid sample rates for audio recording with non-standard original sample rate - 200', document: true do
+      example 'MEDIA (as reader) checking available and formats valid sample rates for audio recording with non-standard original sample rate - 200', document: true do
         do_request
         expect(status).to eq(200), "expected status #{200} but was #{status}. Response body was #{response_body}"
 
         mp3_valid_sample_rates = (JsonSpec::Helpers::parse_json(response_body)["data"]["options"]["audio"]["formats"].select { | vsr | vsr["name"] == 'mp3'})[0]["valid_sample_rates"]
         wav_valid_sample_rates = (JsonSpec::Helpers::parse_json(response_body)["data"]["options"]["audio"]["formats"].select { | vsr | vsr["name"] == 'wav'})[0]["valid_sample_rates"]
 
+        available = JsonSpec::Helpers::parse_json(response_body)["data"]["available"]["audio"].keys
+
+        # mp3 not included in available because native sample of 7777 rate not supported by mp3
+        expect(available).to eq(["webm", "ogg", "flac", "wav"])
         expect(mp3_valid_sample_rates).to eq([8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000])
         expect(wav_valid_sample_rates).to eq([8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 96000, 7777])
 


### PR DESCRIPTION
In the API response to json request for media, when filtering available formats to only include formats that support the specified sample rate, native sample rate is used if no sample rate is specified in request parameters.
That is, if no sample rate is specified in the request, available formats will only include those that support the native sample rate.

The actual change to `api_response` is really small, but, due to subsequent references to `available` for the options, this change meant rearranging the method quite a bit. 

Added one extra test within and existing example.



