### PR TITLE
Checks that post params is not empty for update and create

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -323,9 +323,9 @@ class ApplicationController < ActionController::Base
     # an empty body parsed as json will have the form {model => {}}
     # json body with application/x-www-form-urlencoded content type will have the form {json_string => {}}
     # json or form encoded with text/plain content type will have the form {}
-    if request.POST.values.all? { |val| val.nil? || (val.is_a?(Hash) && val.empty?) }
+    if request.POST.values.all? { |val| val.blank? }
 
-      if (request.body.string == "")
+      if (request.body.string.blank?)
         message = "Request body was empty"
         status = :bad_request
         # include link to 'new' endpoint if body was empty
@@ -341,7 +341,7 @@ class ApplicationController < ActionController::Base
           message = "Failed to parse the request body. Ensure that it is formed correctly and matches the content-type (#{request.content_type})"
         end
       end
-      render_error(status, message,nil,'validate_contains_params', options)
+      render_error(status, message, nil, 'validate_contains_params', options)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,8 @@ class ApplicationController < ActionController::Base
   before_action :current_user, unless: :devise_controller?
   before_action :authenticate_user!, if: :devise_controller?
 
+  before_action :validate_contains_post_params, only: [:create, :update]
+
   # CanCan - always check authorization
   check_authorization if: :should_check_authorization?
 
@@ -312,6 +314,37 @@ class ApplicationController < ActionController::Base
   def store_location(path)
     super
   end
+
+  # all create and update actions should have post parameters. If not, in addition to not doing anything,
+  # they might cause errors where these parameters are expected
+  def validate_contains_post_params
+
+    # post values should be in the form {model => {attr => value, attr2 => value}}
+    # an empty body parsed as json will have the form {model => {}}
+    # json body with application/x-www-form-urlencoded content type will have the form {json_string => {}}
+    # json or form encoded with text/plain content type will have the form {}
+    if request.POST.values.all? { |val| val.nil? || (val.is_a?(Hash) && val.empty?) }
+
+      if (request.body.string == "")
+        message = "Request body was empty"
+        status = :bad_request
+        # include link to 'new' endpoint if body was empty
+        options = {should_notify_error: true, error_links: [{text: "New Resource", url: self.send("new_#{resource_name}_path")}]}
+      else
+        options = {should_notify_error: true}
+        status = :unsupported_media_type
+        if request.content_type == "text/plain"
+          message = "Request content-type text/plain not supported"
+        else
+          # Catch anything else, but should not reach here because body parsing will have already crashed for
+          # malformed encoding for anything other than text/plain
+          message = "Failed to parse the request body. Ensure that it is formed correctly and matches the content-type (#{request.content_type})"
+        end
+      end
+      render_error(status, message,nil,'validate_contains_params', options)
+    end
+  end
+
 
   private
 

--- a/app/controllers/dataset_items_controller.rb
+++ b/app/controllers/dataset_items_controller.rb
@@ -49,6 +49,7 @@ class DatasetItemsController < ApplicationController
 
   # POST /datasets/:dataset_id/items
   def create
+
     do_new_resource
     do_set_attributes(dataset_item_params)
 

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -1,3 +1,4 @@
 class ProgressEventsController < ApplicationController
+
   # todo
 end

--- a/lib/modules/api/response.rb
+++ b/lib/modules/api/response.rb
@@ -175,12 +175,18 @@ module Api
       error_hash
     end
 
+    # @param [mixed] link_ids either a symbol that corresponds to predefined links
+    #                         or a hash with the keys :text and :url
     def response_error_links(link_ids)
       result = {}
       unless link_ids.blank?
         error_links = error_links_hash
         link_ids.each do |id|
-          link_info = error_links[id]
+          if id.is_a?(Symbol)
+            link_info = error_links[id]
+          else
+            link_info = id
+          end
           result[link_info[:text]] = link_info[:url]
         end
       end

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+require 'rspec/mocks'
+
+describe "Dataset Items" do
+
+  create_entire_hierarchy
+
+  let(:dataset_item_attributes) {
+    FactoryGirl.attributes_for(:dataset_item, {audio_recording_id: audio_recording.id})
+  }
+
+  let(:update_dataset_item_attributes) {
+    {end_time_seconds: (dataset_item.end_time_seconds + 5) }
+  }
+
+  before(:each) do
+    @env ||= {}
+    @env['HTTP_AUTHORIZATION'] = admin_token
+
+    @create_dataset_item_url = "/datasets/" + dataset.id.to_s + "/items"
+    @update_dataset_item_url = "/datasets/" + dataset_item.dataset_id.to_s + "/items/" + dataset_item.id.to_s
+  end
+
+  describe 'Creating a dataset item' do
+
+    it 'does not allow text/plain content-type' do
+      @env['CONTENT_TYPE'] = "text/plain"
+      params = {dataset_item: dataset_item_attributes}.to_json
+      post @create_dataset_item_url, params, @env
+      expect(response).to have_http_status(415)
+    end
+
+    it 'does not allow application/x-www-form-urlencoded content-type with json data' do
+      # use default form content type
+      params = {dataset_item: dataset_item_attributes}.to_json
+      post @create_dataset_item_url, params, @env
+      expect(response).to have_http_status(415)
+    end
+
+    it 'allows application/json content-type with json data' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = {dataset_item: dataset_item_attributes}.to_json
+      post @create_dataset_item_url, params, @env
+      expect(response).to have_http_status(201)
+    end
+
+    it 'allows application/json content-type with unnested json data' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = dataset_item_attributes.to_json
+      post @create_dataset_item_url, params, @env
+      expect(response).to have_http_status(201)
+    end
+
+    # can't catch json content with multipart/form-data content type
+    # because the middleware errors when trying to parse it
+
+    it 'does not allow empty body (nil, json)' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = nil
+      post @create_dataset_item_url, params, @env
+      expect(response).to have_http_status(400)
+    end
+
+    it 'does not allow empty body (empty string, json)' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = ""
+      post @create_dataset_item_url, params, @env
+      expect(response).to have_http_status(400)
+      expect(response.content_type).to eq "application/json"
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['meta']['error']['links']).to eq({"New Resource"=>"/datasets/2/items/new"})
+    end
+
+  end
+
+
+  describe 'Updating a dataset item' do
+
+    it 'does not allow text/plain content-type' do
+      @env['CONTENT_TYPE'] = "text/plain"
+      params = {dataset_item: update_dataset_item_attributes}.to_json
+
+      put @update_dataset_item_url, params, @env
+      expect(response).to have_http_status(415)
+    end
+
+    it 'does not allow application/x-www-form-urlencoded with json body' do
+      # use default form content type
+      params = {dataset_item: update_dataset_item_attributes}.to_json
+
+      put @update_dataset_item_url, params, @env
+      expect(response).to have_http_status(415)
+    end
+
+    it 'allows application/json content-type with json body' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = {dataset_item: update_dataset_item_attributes}.to_json
+
+      put @update_dataset_item_url, params, @env
+      expect(response).to have_http_status(200)
+    end
+
+  end
+
+end
+
+
+

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -17,8 +17,8 @@ describe "Dataset Items" do
     @env ||= {}
     @env['HTTP_AUTHORIZATION'] = admin_token
 
-    @create_dataset_item_url = "/datasets/" + dataset.id.to_s + "/items"
-    @update_dataset_item_url = "/datasets/" + dataset_item.dataset_id.to_s + "/items/" + dataset_item.id.to_s
+    @create_dataset_item_url = "/datasets/#{dataset.id}/items"
+    @update_dataset_item_url = "/datasets/#{dataset_item.dataset_id}/items/#{dataset_item.id}"
   end
 
   describe 'Creating a dataset item' do
@@ -59,6 +59,8 @@ describe "Dataset Items" do
       params = nil
       post @create_dataset_item_url, params, @env
       expect(response).to have_http_status(400)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['meta']['error']['links']).to eq({"New Resource"=>"/datasets/2/items/new"})
     end
 
     it 'does not allow empty body (empty string, json)' do
@@ -98,6 +100,25 @@ describe "Dataset Items" do
 
       put @update_dataset_item_url, params, @env
       expect(response).to have_http_status(200)
+    end
+
+    it 'does not allow empty body (nil, json)' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = nil
+      put @update_dataset_item_url, params, @env
+      expect(response).to have_http_status(400)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['meta']['error']['links']).to eq({"New Resource"=>"/datasets/2/items/new"})
+    end
+
+    it 'does not allow empty body (empty string, json)' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = ""
+      put @update_dataset_item_url, params, @env
+      expect(response).to have_http_status(400)
+      expect(response.content_type).to eq "application/json"
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['meta']['error']['links']).to eq({"New Resource"=>"/datasets/2/items/new"})
     end
 
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+require 'rspec/mocks'
+
+# Creates a simplified multipart/form-data message string
+def form_data (attributes, boundary)
+  message = "\r\n\r\n"
+  attributes.each do |key,val|
+    message += "--"+boundary+"\r\n\r\n"
+    message += "Content-Disposition: form-data; name=\"project["+key.to_s+"]\"\r\n\r\n"
+    message += val.to_s+"\r\n"
+  end
+  message += "--"+boundary+"--\r\n\r\n"
+  return message
+end
+
+form_boundary = 'simple_boundary'
+form_content_type_string = "multipart/form-data; boundary="+form_boundary
+
+
+
+describe "Projects" do
+
+  prepare_users
+  prepare_project
+
+  let(:project_attributes) {
+    FactoryGirl.attributes_for(:project)
+  }
+
+  let(:update_project_attributes) {
+    {name: (project[:name] + "modified")}
+  }
+
+  let(:form_project_data) {
+    project_attributes = FactoryGirl.attributes_for(:project)
+    form_data(project_attributes,form_boundary)
+  }
+
+  let(:form_project_data_update) {
+    form_data(update_project_attributes,form_boundary)
+  }
+
+  before(:each) do
+    @env ||= {}
+    @env['HTTP_AUTHORIZATION'] = admin_token
+
+    @create_project_url = "/projects"
+    @update_project_url = "/projects/"+project.id.to_s
+  end
+
+
+  # projects update/create actions expect payload from html form as well as json
+  describe 'Creating a project' do
+
+    it 'does allows multipart/form-data content-type' do
+      @env['CONTENT_TYPE'] = form_content_type_string
+      post @create_project_url, form_project_data, @env
+      # 302 because html requests are redirected to the newly created record
+      expect(response).to have_http_status(302)
+    end
+
+    it 'allows application/json content-type' do
+      @env['CONTENT_TYPE'] = "application/json"
+      @env['ACCEPT'] = "application/json"
+      params = {project: project_attributes}.to_json
+      post @create_project_url, params, @env
+      expect(response).to have_http_status(201)
+    end
+
+    it 'rejects text/plain content-type with valid json multipart-form body' do
+      @env['CONTENT_TYPE'] = "text/plain"
+      post @create_project_url, form_project_data, @env
+      expect(response).to have_http_status(415)
+    end
+
+    it 'rejects text/plain content-type with empty body' do
+      @env['CONTENT_TYPE'] = "application/json"
+      params = nil
+      post @create_project_url, params, @env
+      expect(response).to have_http_status(400)
+      # projects#create does not have json as default response format,
+      # so, we get a html response
+      # check that the link to new is in the error message
+      expect(response.body).to match "projects/new"
+    end
+
+    # can't test empty body with multipart/form-data content type
+    # because middleware errors when trying to parse it
+
+  end
+
+  describe 'Updating a project' do
+
+    it 'does allows multipart/form-data content-type' do
+      @env['CONTENT_TYPE'] = form_content_type_string
+      put @update_project_url, form_project_data_update, @env
+      expect(response).to have_http_status(302)
+    end
+
+    it 'allows application/json content-type' do
+      @env['CONTENT_TYPE'] = "application/json"
+      @env['ACCEPT'] = "application/json"
+      params = {project: update_project_attributes}.to_json
+      put @update_project_url, params, @env
+      expect(response).to have_http_status(200)
+    end
+
+  end
+
+end
+
+
+


### PR DESCRIPTION
Fixes #366. Fixes #361.

If there are no params, determines whether the request body was empty or if it just was not parsed properly, and responds with approprtiate error code depending on the situation.
If the body was empty, includes an error link to the new action.
If the body was not empty, responds with unsupported_media_type.