### PR TITLE
Feature progress events endpoints

### DIFF
--- a/app/controllers/dataset_items_controller.rb
+++ b/app/controllers/dataset_items_controller.rb
@@ -55,6 +55,7 @@ class DatasetItemsController < ApplicationController
       # todo: ensure not vulnerable to sql injection through current_user.id
       priority_algorithm.push "(SELECT count(*) FROM progress_events WHERE dataset_item_id = dataset_items.id AND progress_events.activity = 'viewed' AND progress_events.creator_id = #{current_user.id}) ASC"
     end
+    priority_algorithm.push "dataset_items.order ASC"
     priority_algorithm.push "dataset_items.id ASC"
     priority_algorithm = priority_algorithm.join(", ")
 

--- a/app/controllers/dataset_items_controller.rb
+++ b/app/controllers/dataset_items_controller.rb
@@ -38,33 +38,23 @@ class DatasetItemsController < ApplicationController
     respond_filter(filter_response, opts)
   end
 
-  # GET datasets/:dataset_id/dataset_items/filter_todo
-  def filter_todo
+  # GET datasets/:dataset_id/dataset_items/next_for_me
+  # TODO: remove this in favour of next_for_me (below)
+  def next_for_me_filter
 
     # items from a dataset with priority given to not viewed
 
     do_authorize_class
 
-    params[:sorting] = {
-        order_by: :priority
-    }
+    filter_params = params.slice(:format, :controller, :action, :dataset_id, :page, :items)
+    filter_params[:sorting] = {"order_by"=>:priority}
 
-    # sort by least viewed, then least viewed by current user, then id
-    priority_algorithm = ["(SELECT count(*) FROM progress_events" +
-                              " WHERE dataset_item_id = dataset_items.id AND progress_events.activity = 'viewed') ASC"]
-    if (current_user)
-      # todo: ensure not vulnerable to sql injection through current_user.id
-      priority_algorithm.push "(SELECT count(*) FROM progress_events" +
-                                  " WHERE dataset_item_id = dataset_items.id" +
-                                  " AND progress_events.activity = 'viewed'" +
-                                  " AND progress_events.creator_id = #{current_user.id}) ASC"
-    end
-    priority_algorithm.push "dataset_items.order ASC"
-    priority_algorithm.push "dataset_items.id ASC"
-    priority_algorithm = priority_algorithm.join(", ")
+    current_user_id = current_user ? current_user.id : nil
+
+    priority_algorithm = DatasetItem.next_for_user current_user_id
 
     filter_response, opts = Settings.api_response.response_advanced(
-        api_filter_params,
+        filter_params,
         Access::ByPermission.dataset_items(current_user, params[:dataset_id]),
         DatasetItem,
         DatasetItem.filter_settings(priority_algorithm)
@@ -72,9 +62,37 @@ class DatasetItemsController < ApplicationController
 
     respond_filter(filter_response, opts)
 
-
   end
 
+  # GET datasets/:dataset_id/dataset_items/next_for_me
+  def next_for_me
+
+    do_authorize_class
+    priority_algorithm = DatasetItem.next_for_user(current_user_id = current_user ? current_user.id : nil)
+
+    # All dataset items that the user has permission to see
+    query = Access::ByPermission.dataset_items(current_user, params[:dataset_id])
+    num_items = query.size
+
+    # sort by priority
+    query = query.order(priority_algorithm)
+
+    # paging must come after calculating num_items
+    paging = Filter::Parse::parse_paging_only(params)
+    query = query.offset(paging[:offset]).limit(paging[:limit])
+
+    # craft opts for response. This is a subset of
+    opts = params.slice(:controller, :action)
+    opts[:total] =num_items
+    opts[:items] = paging[:items]
+    opts[:page] = paging[:page]
+    opts[:additional_params] = { dataset_id: params[:dataset_id] }
+
+    # sort is not user supplied, so don't include it in the opts
+
+    respond_filter(query, opts)
+
+  end
 
   # GET /datasets/:dataset_id/items/new
   def new

--- a/app/controllers/dataset_items_controller.rb
+++ b/app/controllers/dataset_items_controller.rb
@@ -50,10 +50,14 @@ class DatasetItemsController < ApplicationController
     }
 
     # sort by least viewed, then least viewed by current user, then id
-    priority_algorithm = ["(SELECT count(*) FROM progress_events WHERE dataset_item_id = dataset_items.id AND progress_events.activity = 'viewed') ASC"]
+    priority_algorithm = ["(SELECT count(*) FROM progress_events" +
+                              " WHERE dataset_item_id = dataset_items.id AND progress_events.activity = 'viewed') ASC"]
     if (current_user)
       # todo: ensure not vulnerable to sql injection through current_user.id
-      priority_algorithm.push "(SELECT count(*) FROM progress_events WHERE dataset_item_id = dataset_items.id AND progress_events.activity = 'viewed' AND progress_events.creator_id = #{current_user.id}) ASC"
+      priority_algorithm.push "(SELECT count(*) FROM progress_events" +
+                                  " WHERE dataset_item_id = dataset_items.id" +
+                                  " AND progress_events.activity = 'viewed'" +
+                                  " AND progress_events.creator_id = #{current_user.id}) ASC"
     end
     priority_algorithm.push "dataset_items.order ASC"
     priority_algorithm.push "dataset_items.id ASC"

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -66,6 +66,8 @@ class ProgressEventsController < ApplicationController
 
     # find dataset_item
 
+
+
     dataset_item_params = {
         dataset_id: params[:dataset_id].to_i,
         audio_recording_id: params[:audio_recording_id],
@@ -73,12 +75,16 @@ class ProgressEventsController < ApplicationController
         end_time_seconds: params[:end_time_seconds]
     }
 
+    if params['dataset_id'] == 'default'
+      dataset_item_params[:dataset_id] = Dataset.default_dataset_id
+    end
+
     dataset_item = DatasetItem.find_by(dataset_item_params)
 
     resource_params = progress_event_params
     if dataset_item
       resource_params[:dataset_item_id] = dataset_item.id
-    elsif dataset_item_params[:dataset_id].to_i == 1
+    elsif params['dataset_id'] == 'default'
 
       # is for the default dataset, so create the dataset item
       dataset_item = DatasetItem.new(dataset_item_params)

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -59,57 +59,22 @@ class ProgressEventsController < ApplicationController
     end
   end
 
+
   # POST /datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds
   # create a progress event without specifying a dataset item id by specifying the datset, audio_recording and offsets
   # will create an item in the default dataset if it does not exist
   def create_by_dataset_item_params
 
-    # find dataset_item
-
-
-
-    dataset_item_params = {
-        dataset_id: params[:dataset_id].to_i,
-        audio_recording_id: params[:audio_recording_id],
-        start_time_seconds: params[:start_time_seconds],
-        end_time_seconds: params[:end_time_seconds]
-    }
-
-    if params['dataset_id'] == 'default'
-      dataset_item_params[:dataset_id] = Dataset.default_dataset_id
-    end
-
-    dataset_item = DatasetItem.find_by(dataset_item_params)
-
     resource_params = progress_event_params
-    if dataset_item
-      resource_params[:dataset_item_id] = dataset_item.id
-    elsif params['dataset_id'] == 'default'
+    dataset_item = find_or_create_dataset_item
+    resource_params[:dataset_item_id] = dataset_item.id
 
-      # is for the default dataset, so create the dataset item
-      dataset_item = DatasetItem.new(dataset_item_params)
-      do_authorize_instance :create, dataset_item
-
-      if !dataset_item.save
-        fail CustomErrors::UnprocessableEntityError.new(
-            'Can not add progress event. Dataset item parameters were invalid.',
-            dataset_item.errors.messages
-        )
-      end
-
-      resource_params[:dataset_item_id] = dataset_item.id
-
-    else
-      fail CustomErrors::UnprocessableEntityError.new(
-          'Can not add progress event. Dataset item not found.',
-          dataset_item_params
-      )
-    end
-
+    # create a progress event instance, set its attributes and authorize it
     do_new_resource
     do_set_attributes(resource_params)
     do_authorize_instance :create
 
+    # finally, save the progress event
     if @progress_event.save
       respond_create_success(progress_event_path(@progress_event))
     else
@@ -144,6 +109,65 @@ class ProgressEventsController < ApplicationController
   end
 
   private
+
+
+  # finds a dataset item from attributes
+  # if it cant find it and it's the default dataset, creates it
+  def find_or_create_dataset_item
+
+    is_default_dataset = params['dataset_id'] == 'default'
+
+    dataset_item_params = params.slice(:dataset_id, :audio_recording_id, :start_time_seconds, :end_time_seconds).symbolize_keys
+
+    if is_default_dataset
+      dataset_item_params[:dataset_id] = Dataset.default_dataset_id
+    end
+
+    dataset_item = DatasetItem.find_by(dataset_item_params)
+
+
+    # if the dataset item was found (whether default dataset item or not), return it
+    # otherwise, if it's for the default dataset, create it and return it
+    # otherwise, error because user is trying to create a progress event for a dataset item
+    # that does not exist.
+    if dataset_item
+
+      return dataset_item
+
+    elsif is_default_dataset
+
+      return create_default_dataset_item(dataset_item_params)
+
+    else
+
+      fail CustomErrors::UnprocessableEntityError.new(
+          'Can not add progress event. Dataset item not found.',
+          dataset_item_params
+      )
+
+    end
+
+  end
+
+
+  # create a dataset item in the default dataset
+  def create_default_dataset_item(dataset_item_params)
+
+    dataset_item = DatasetItem.new(dataset_item_params)
+
+    do_authorize_instance :create, dataset_item
+
+    if !dataset_item.save
+      fail CustomErrors::UnprocessableEntityError.new(
+          'Can not add progress event. Dataset item parameters were invalid.',
+          dataset_item.errors.messages
+      )
+    end
+
+    dataset_item
+
+  end
+
 
   def progress_event_params
 

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -76,9 +76,9 @@ class ProgressEventsController < ApplicationController
     dataset_item = DatasetItem.find_by(dataset_item_params)
 
     resource_params = progress_event_params
-    if (dataset_item)
+    if dataset_item
       resource_params[:dataset_item_id] = dataset_item.id
-    elsif (dataset_item_params[:dataset_id].to_i == 1)
+    elsif dataset_item_params[:dataset_id].to_i == 1
 
       # is for the default dataset, so create the dataset item
       dataset_item = DatasetItem.new(dataset_item_params)

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -1,4 +1,95 @@
 class ProgressEventsController < ApplicationController
 
-  # todo
+  include Api::ControllerHelper
+
+  # GET /progress_events
+  def index
+    do_authorize_class
+
+    @progress_events, opts = Settings.api_response.response_advanced(
+        api_filter_params,
+        Access::ByPermission.progress_events(current_user, params[:dataset_item_id]),
+        ProgressEvent,
+        ProgressEvent.filter_settings
+    )
+
+    respond_index(opts)
+  end
+
+  # GET /progress_events/:progress_event_id
+  def show
+    do_load_resource
+    do_authorize_instance
+    respond_show
+  end
+
+  # GET|POST /progress_events/filter
+  def filter
+    do_authorize_class
+
+    filter_response, opts = Settings.api_response.response_advanced(
+        api_filter_params,
+        Access::ByPermission.progress_events(current_user, params[:dataset_item_id]),
+        ProgressEvent,
+        ProgressEvent.filter_settings
+    )
+
+    respond_filter(filter_response, opts)
+  end
+
+  # GET /progress_events/new
+  def new
+    do_new_resource
+    do_set_attributes
+    do_authorize_instance
+    respond_show
+  end
+
+  # POST /progress_events/items
+  def create
+
+    do_new_resource
+    do_set_attributes(progress_event_params)
+    do_authorize_instance
+
+    if @progress_event.save
+      respond_create_success(progress_event_path(@progress_event))
+    else
+      respond_change_fail
+    end
+  end
+
+  # PUT|PATCH /progress_events/:progress_event_id
+  def update
+
+    do_load_resource
+    do_set_attributes(progress_event_params)
+    do_authorize_instance
+
+    if @progress_event.update_attributes(progress_event_params)
+      respond_show
+    else
+      respond_change_fail
+    end
+
+  end
+
+  # DELETE /progress_events/:progress_event_id
+  def destroy
+
+    do_load_resource
+    do_authorize_instance
+    @progress_event.destroy
+    respond_destroy
+
+  end
+
+  private
+
+  def progress_event_params
+
+    params.require(:progress_event).permit(:dataset_item_id, :activity)
+
+  end
+
 end

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -45,7 +45,7 @@ class ProgressEventsController < ApplicationController
     respond_show
   end
 
-  # POST /progress_events
+  # POST /progress_events/items
   def create
 
     do_new_resource
@@ -91,5 +91,7 @@ class ProgressEventsController < ApplicationController
     params.require(:progress_event).permit(:dataset_item_id, :activity)
 
   end
+
+
 
 end

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -59,6 +59,59 @@ class ProgressEventsController < ApplicationController
     end
   end
 
+  # POST /datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds
+  # create a progress event without specifying a dataset item id by specifying the datset, audio_recording and offsets
+  # will create an item in the default dataset if it does not exist
+  def create_by_dataset_item_params
+
+    # find dataset_item
+
+    dataset_item_params = {
+        dataset_id: params[:dataset_id].to_i,
+        audio_recording_id: params[:audio_recording_id],
+        start_time_seconds: params[:start_time_seconds],
+        end_time_seconds: params[:end_time_seconds]
+    }
+
+    dataset_item = DatasetItem.find_by(dataset_item_params)
+
+    resource_params = progress_event_params
+    if (dataset_item)
+      resource_params[:dataset_item_id] = dataset_item.id
+    elsif (dataset_item_params[:dataset_id].to_i == 1)
+
+      # is for the default dataset, so create the dataset item
+      dataset_item = DatasetItem.new(dataset_item_params)
+      do_authorize_instance :create, dataset_item
+
+      if !dataset_item.save
+        fail CustomErrors::UnprocessableEntityError.new(
+            'Can not add progress event. Dataset item parameters were invalid.',
+            dataset_item.errors.messages
+        )
+      end
+
+      resource_params[:dataset_item_id] = dataset_item.id
+
+    else
+      fail CustomErrors::UnprocessableEntityError.new(
+          'Can not add progress event. Dataset item not found.',
+          dataset_item_params
+      )
+    end
+
+    do_new_resource
+    do_set_attributes(resource_params)
+    do_authorize_instance :create
+
+    if @progress_event.save
+      respond_create_success(progress_event_path(@progress_event))
+    else
+      respond_change_fail
+    end
+
+  end
+
   # PUT|PATCH /progress_events/:progress_event_id
   def update
 

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -45,7 +45,7 @@ class ProgressEventsController < ApplicationController
     respond_show
   end
 
-  # POST /progress_events/items
+  # POST /progress_events
   def create
 
     do_new_resource

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -455,9 +455,8 @@ class Ability
     # only admin can create, unless it is the default dataset
     # if default dataset, must have read permission or higher to create
     can [:create], DatasetItem do |dataset_item|
-      if dataset_item.dataset_id == 1
+      if dataset_item.dataset_id == Dataset.default_dataset_id
         check_model(dataset_item)
-        #Access::Core.check_orphan_site!(audio_event.audio_recording.site)
         Access::Core.can_any?(user, :reader, dataset_item.audio_recording.site.projects)
       else
         false

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -95,6 +95,7 @@ class Ability
       to_analysis_jobs_item(user)
       to_dataset(user, is_guest)
       to_dataset_item(user, is_guest)
+      to_progress_event(user, is_guest)
       to_saved_search(user, is_guest)
       to_script(user, is_guest)
       to_tag(user, is_guest)
@@ -465,6 +466,29 @@ class Ability
 
     # actions any logged in user can access
     can [:new, :index, :filter], DatasetItem
+
+  end
+
+
+  def to_progress_event(user, is_guest)
+
+    # anyone can create as long as they have read access on the ancestor project of the dataset item
+    can [:create], ProgressEvent do |progress_event|
+      check_model(progress_event)
+      Access::Core.can_any?(user, :reader, progress_event.dataset_item.audio_recording.site.projects)
+    end
+
+    # must have read permissions or be creator to view
+    can [:show, :index, :filter], ProgressEvent do |progress_event|
+      check_model(progress_event)
+      Access::Core.can_any?(user, :reader, progress_event.dataset_item.audio_recording.site.projects) ||
+          progress_event.creator_id === user.id
+    end
+
+    can :new, ProgressEvent
+
+    # update and edit are admin only
+    cannot [:update, :destroy]
 
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -476,7 +476,7 @@ class Ability
     end
 
     # actions any logged in user can access
-    can [:new, :index, :filter, :filter_todo], DatasetItem
+    can [:new, :index, :filter, :next_for_me], DatasetItem
 
   end
 
@@ -488,11 +488,11 @@ class Ability
       check_model(progress_event)
 
       # the dataset_item may not be valid and therefore may not be associated with a project
-      begin
-        Access::Core.can_any?(user, :reader, progress_event.dataset_item.audio_recording.site.projects)
-      rescue
+      audio_recording = progress_event.dataset_item.try(:audio_recording)
+      if audio_recording
+        Access::Core.can_any?(user, :reader, audio_recording.site.projects)
+      else
         fail CustomErrors::UnprocessableEntityError.new('Invalid dataset item')
-        false
       end
 
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -465,7 +465,7 @@ class Ability
     end
 
     # actions any logged in user can access
-    can [:new, :index, :filter], DatasetItem
+    can [:new, :index, :filter, :filter_todo], DatasetItem
 
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -455,7 +455,7 @@ class Ability
     # only admin can create, unless it is the default dataset
     # if default dataset, must have read permission or higher to create
     can [:create], DatasetItem do |dataset_item|
-      if (dataset_item.dataset_id == 1)
+      if dataset_item.dataset_id == 1
         check_model(dataset_item)
         #Access::Core.check_orphan_site!(audio_event.audio_recording.site)
         Access::Core.can_any?(user, :reader, dataset_item.audio_recording.site.projects)
@@ -488,6 +488,7 @@ class Ability
     can [:create], ProgressEvent do |progress_event|
       check_model(progress_event)
 
+      # the dataset_item may not be valid and therefore may not be associated with a project
       begin
         Access::Core.can_any?(user, :reader, progress_event.dataset_item.audio_recording.site.projects)
       rescue

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -15,8 +15,16 @@ class Dataset < ActiveRecord::Base
   validates :creator, existence: true
 
   # validation
-  validates :name, presence: true, length: {minimum: 2}
+  # validates :name, presence: true, length: {minimum: 2}
+  validates :name, presence: true, length: {minimum: 2}, exclusion: { in: ['default'], message: "%{value} is a reserved dataset name" }
 
+
+  # lookup the default dataset id
+  # This will potentially be hit very often, maybe multiple times per request
+  # and therefore is a possible avenue for future optimization if necessary
+  def self.default_dataset_id
+    Dataset.where(name: 'default').first.id
+  end
 
   # Define filter api settings
   def self.filter_settings

--- a/app/models/dataset_item.rb
+++ b/app/models/dataset_item.rb
@@ -27,10 +27,12 @@ class DatasetItem < ActiveRecord::Base
   def self.filter_settings (priority_algorithm = nil, current_user_id = nil)
     result = {
         valid_fields: [
-            :id, :dataset_id, :audio_recording_id, :start_time_seconds, :end_time_seconds, :order, :creator_id, :created_at, :priority
+            :id, :dataset_id, :audio_recording_id, :start_time_seconds,
+            :end_time_seconds, :order, :creator_id, :created_at, :priority
         ],
         render_fields: [
-            :id, :dataset_id, :audio_recording_id, :start_time_seconds, :end_time_seconds, :order, :creator_id, :created_at
+            :id, :dataset_id, :audio_recording_id, :start_time_seconds,
+            :end_time_seconds, :order, :creator_id, :created_at
         ],
         new_spec_fields: lambda { |user|
           {
@@ -102,7 +104,8 @@ class DatasetItem < ActiveRecord::Base
   }
 
   # scope :num_views, lambda {
-  #   joins(:progress_events).select("dataset_items.*, count(DISTINCT progress_events.id) as num_views").group('dataset_items.id')
+  #   joins(:progress_events).select("dataset_items.*, count(DISTINCT progress_events.id) as num_views")
+  #      .group('dataset_items.id')
   # }
 
 

--- a/app/models/dataset_item.rb
+++ b/app/models/dataset_item.rb
@@ -7,7 +7,7 @@ class DatasetItem < ActiveRecord::Base
   belongs_to :dataset, inverse_of: :dataset_items
   belongs_to :audio_recording, inverse_of: :dataset_items
   belongs_to :creator, class_name: 'User', foreign_key: :creator_id, inverse_of: :created_dataset_items
-  has_many :progress_events, inverse_of: :dataset_item
+  has_many :progress_events, inverse_of: :dataset_item, dependent: :destroy
 
   # We have not enabled soft deletes yet since we do not support deleting dataset items
   # This may change in the future

--- a/app/models/dataset_item.rb
+++ b/app/models/dataset_item.rb
@@ -121,10 +121,10 @@ class DatasetItem < ActiveRecord::Base
   def self.next_for_user (user_id = nil)
 
     # sort by least viewed, then least viewed by current user, then id
-    priority_algorithm = []
+    order_by_clauses = []
 
     # first order by the number of views, ascending
-    priority_algorithm.push <<~SQL
+    order_by_clauses.push <<~SQL
         (SELECT count(*) FROM progress_events
          WHERE dataset_item_id = dataset_items.id AND progress_events.activity = 'viewed') ASC
       SQL
@@ -133,7 +133,7 @@ class DatasetItem < ActiveRecord::Base
     # Anonymous users are permitted to list dataset items, and only items that are associated with permitted
     # projects are shown.
     if user_id
-      priority_algorithm.push <<~SQL
+      order_by_clauses.push <<~SQL
           (SELECT count(*) FROM progress_events
            WHERE dataset_item_id = dataset_items.id
            AND progress_events.activity = 'viewed'
@@ -143,9 +143,9 @@ class DatasetItem < ActiveRecord::Base
 
     # finally, sort by the order field, and then to keep consistent ordering in the case of identical order field
     # sort by id
-    priority_algorithm.push "dataset_items.order ASC"
-    priority_algorithm.push "dataset_items.id ASC"
-    priority_algorithm = priority_algorithm.join(", ")
+    order_by_clauses.push "dataset_items.order ASC"
+    order_by_clauses.push "dataset_items.id ASC"
+    priority_algorithm = order_by_clauses.join(", ")
 
     priority_algorithm
 

--- a/app/models/progress_event.rb
+++ b/app/models/progress_event.rb
@@ -8,8 +8,8 @@ class ProgressEvent < ActiveRecord::Base
   belongs_to :dataset_item, inverse_of: :progress_events
 
   # association validations
-  validates :creator, existence: true
-  validates :dataset_item, existence: true
+  validates_presence_of :dataset_item
+  validates_presence_of :creator
 
   # field validations
 

--- a/app/models/progress_event.rb
+++ b/app/models/progress_event.rb
@@ -17,4 +17,35 @@ class ProgressEvent < ActiveRecord::Base
   # restriction removed altogether
   validates :activity, inclusion: { in: ['viewed', 'played', 'annotated'] }
 
+  # Define filter api settings
+  def self.filter_settings
+    return {
+        valid_fields: [
+            :id, :dataset_item_id, :activity, :creator_id, :created_at
+        ],
+        render_fields: [
+            :id, :dataset_item_id, :activity, :creator_id, :created_at
+        ],
+        new_spec_fields: lambda { |user|
+          {
+              dataset_item_id: nil,
+              activity: nil
+          }
+        },
+        controller: :progress_events,
+        action: :filter,
+        defaults: {
+            order_by: :created_at,
+            direction: :desc
+        },
+        valid_associations: [
+            {
+                join: DatasetItem,
+                on: ProgressEvent.arel_table[:dataset_item_id].eq(DatasetItem.arel_table[:id]),
+                available: true
+            }
+        ]
+    }
+  end
+
 end

--- a/app/models/progress_event.rb
+++ b/app/models/progress_event.rb
@@ -42,7 +42,12 @@ class ProgressEvent < ActiveRecord::Base
             {
                 join: DatasetItem,
                 on: ProgressEvent.arel_table[:dataset_item_id].eq(DatasetItem.arel_table[:id]),
-                available: true
+                available: true,
+                associations: [
+                    join: Dataset,
+                    on: DatasetItem.arel_table[:dataset_id].eq(Dataset.arel_table[:id]),
+                    available: true
+                ]
             }
         ]
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,10 @@ Rails.application.routes.draw do
     resources :items, controller: 'dataset_items', defaults: {format: 'json'}
   end
 
+  # progress events
+  match 'progress_events/filter' => 'progress_events#filter', via: [:get, :post], defaults: {format: 'json'}
+  resources :progress_events, defaults:  {format: 'json'}
+
   # route to the home page of site
   root to: 'public#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Rails.application.routes.draw do
   match 'datasets/filter' => 'datasets#filter', via: [:get, :post], defaults: {format: 'json'}
   match 'dataset_items/filter' => 'dataset_items#filter', via: [:get, :post], defaults: {format: 'json'}
   match 'datasets/:dataset_id/dataset_items/filter' => 'dataset_items#filter', via: [:get, :post], defaults: {format: 'json'}
+  match 'datasets/:dataset_id/dataset_items/filter_todo' => 'dataset_items#filter_todo', via: [:get], defaults: {format: 'json'}
   resources :datasets, except: :destroy, defaults:  {format: 'json'} do
     resources :items, controller: 'dataset_items', defaults: {format: 'json'}
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -255,14 +255,25 @@ Rails.application.routes.draw do
   get '/sites/:id' => 'sites#show_shallow', defaults: {format: 'json'}, as: 'shallow_site'
 
 
-  match 'datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds' => 'progress_events#create_by_dataset_item_params', :constraints => { :dataset_id => /\d+/, :audio_recording_id => /\d+/, :start_time_seconds => /\d+(\.\d+)?/, :end_time_seconds => /\d+(\.\d+)?/ }, via: [:post], defaults: {format: 'json'}
+  match 'datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds' => 'progress_events#create_by_dataset_item_params',
+        :constraints => {
+            :dataset_id => /\d+/,
+            :audio_recording_id => /\d+/,
+            :start_time_seconds => /\d+(\.\d+)?/,
+            :end_time_seconds => /\d+(\.\d+)?/ },
+        via: [:post],
+        defaults: {format: 'json'}
 
 
   # datasets, dataset_items
   match 'datasets/filter' => 'datasets#filter', via: [:get, :post], defaults: {format: 'json'}
   match 'dataset_items/filter' => 'dataset_items#filter', via: [:get, :post], defaults: {format: 'json'}
-  match 'datasets/:dataset_id/dataset_items/filter' => 'dataset_items#filter', via: [:get, :post], defaults: {format: 'json'}
-  match 'datasets/:dataset_id/dataset_items/filter_todo' => 'dataset_items#filter_todo', via: [:get], defaults: {format: 'json'}
+  match 'datasets/:dataset_id/dataset_items/filter' => 'dataset_items#filter',
+        via: [:get, :post],
+        defaults: {format: 'json'}
+  match 'datasets/:dataset_id/dataset_items/filter_todo' => 'dataset_items#filter_todo',
+        via: [:get],
+        defaults: {format: 'json'}
   resources :datasets, except: :destroy, defaults:  {format: 'json'} do
     resources :items, controller: 'dataset_items', defaults: {format: 'json'}
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,7 +257,7 @@ Rails.application.routes.draw do
 
   match 'datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds' => 'progress_events#create_by_dataset_item_params',
         :constraints => {
-            :dataset_id => /\d+/,
+            :dataset_id => /(\d+|default)/,
             :audio_recording_id => /\d+/,
             :start_time_seconds => /\d+(\.\d+)?/,
             :end_time_seconds => /\d+(\.\d+)?/ },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,7 +271,7 @@ Rails.application.routes.draw do
   match 'datasets/:dataset_id/dataset_items/filter' => 'dataset_items#filter',
         via: [:get, :post],
         defaults: {format: 'json'}
-  match 'datasets/:dataset_id/dataset_items/filter_todo' => 'dataset_items#filter_todo',
+  match 'datasets/:dataset_id/dataset_items/next_for_me' => 'dataset_items#next_for_me',
         via: [:get],
         defaults: {format: 'json'}
   resources :datasets, except: :destroy, defaults:  {format: 'json'} do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,6 +254,10 @@ Rails.application.routes.draw do
   # shallow path to sites
   get '/sites/:id' => 'sites#show_shallow', defaults: {format: 'json'}, as: 'shallow_site'
 
+
+  match 'datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds' => 'progress_events#create_by_dataset_item_params', :constraints => { :dataset_id => /\d+/, :audio_recording_id => /\d+/, :start_time_seconds => /\d+(\.\d+)?/, :end_time_seconds => /\d+(\.\d+)?/ }, via: [:post], defaults: {format: 'json'}
+
+
   # datasets, dataset_items
   match 'datasets/filter' => 'datasets#filter', via: [:get, :post], defaults: {format: 'json'}
   match 'dataset_items/filter' => 'dataset_items#filter', via: [:get, :post], defaults: {format: 'json'}

--- a/lib/modules/access/by_permission.rb
+++ b/lib/modules/access/by_permission.rb
@@ -202,13 +202,7 @@ module Access
           query = query.where(dataset_items: {id: dataset_item_id})
         end
 
-        or_conditions = nil
-        unless (user.blank?)
-          pe = ProgressEvent.arel_table
-          or_conditions = pe[:creator_id].eq(user.id)
-        end
-
-        permission_sites(user, levels, query, nil, or_conditions)
+        permission_sites(user, levels, query)
 
       end
 
@@ -367,11 +361,13 @@ module Access
           end
         else
 
-          if (or_conditions.blank?)
-            query.where(permissions_by_site)
-          else
-            query.where(permissions_by_site.or(or_conditions))
-          end
+          # if at some stage, we want to have exceptions to permissions inherited from projects
+          # e.g. the creator of progress_events or audio_events can view them after progress is revoked
+          # we can add an "OR" clause like this:
+          #  progress_event = ProgressEvent.arel_table
+          #  query.where(permissions_by_site.or(progress_event[:creator_id].eq(user.id)))
+
+          query.where(permissions_by_site)
 
         end
 

--- a/lib/modules/access/by_permission.rb
+++ b/lib/modules/access/by_permission.rb
@@ -175,15 +175,41 @@ module Access
       def dataset_items(user, dataset_id = nil, levels = Access::Core.levels)
 
         query = DatasetItem
-                      .joins(audio_recording: :site)
-                      .order(audio_recording_id: :asc)
-                      .joins(:dataset) # this join ensures only non-deleted results are returned
+                    .joins(audio_recording: :site)
+                    .order(audio_recording_id: :asc)
+                    .joins(:dataset) # this join ensures only non-deleted results are returned
 
         if dataset_id
           query = query.where(datasets: {id: dataset_id})
         end
 
         permission_sites(user, levels, query)
+      end
+
+      # Get all progress_events for which this user has these access levels
+      # Or for which this user is the creator
+      # @param [User] user
+      # @param [Int] dataset_item_id
+      # @param [Symbol, Array<Symbol>] levels
+      # @return [ActiveRecord::Relation] progress_events
+      def progress_events(user, dataset_item_id = nil, levels = Access::Core.levels)
+
+        query = ProgressEvent
+                    .joins(dataset_item: {audio_recording: :site})
+                    .order(created_at: :asc)
+
+        if dataset_item_id
+          query = query.where(dataset_items: {id: dataset_item_id})
+        end
+
+        or_conditions = nil
+        unless (user.blank?)
+          pe = ProgressEvent.arel_table
+          or_conditions = pe[:creator_id].eq(user.id)
+        end
+
+        permission_sites(user, levels, query, nil, or_conditions)
+
       end
 
       private
@@ -259,8 +285,9 @@ module Access
       # @param [Array<Symbol>] levels
       # @param [ActiveRecord::Relation] query
       # @param [Array<Integer>] project_ids
+      # @param [Object] or_conditions result of any Arel::Predications method
       # @return [ActiveRecord::Relation]
-      def permission_sites(user, levels, query, project_ids = nil)
+      def permission_sites(user, levels, query, project_ids = nil, or_conditions = nil)
 
         is_admin, query = permission_admin(user, levels, query)
 
@@ -339,7 +366,13 @@ module Access
             query.where(permissions_by_site.and(reference_audio_events))
           end
         else
-          query.where(permissions_by_site)
+
+          if (or_conditions.blank?)
+            query.where(permissions_by_site)
+          else
+            query.where(permissions_by_site.or(or_conditions))
+          end
+
         end
 
       end

--- a/lib/modules/access/by_permission.rb
+++ b/lib/modules/access/by_permission.rb
@@ -176,7 +176,6 @@ module Access
 
         query = DatasetItem
                     .joins(audio_recording: :site)
-                    .order(audio_recording_id: :asc)
                     .joins(:dataset) # this join ensures only non-deleted results are returned
 
         if dataset_id

--- a/lib/modules/api/response.rb
+++ b/lib/modules/api/response.rb
@@ -282,6 +282,12 @@ module Api
         # execute a count against entire set without paging
         total = new_query.size
 
+        # if query involves aggregation, size returns the size of each group.
+        # and what we need is the number of groups
+        if total.is_a? Hash
+          total = total.length
+        end
+
         # add paging
         new_query = filter_query.query_paging(new_query)
         items = filter_query.is_paging_disabled? ? total : filter_query.paging[:items]

--- a/lib/modules/api/response.rb
+++ b/lib/modules/api/response.rb
@@ -258,7 +258,8 @@ module Api
           model.to_s.underscore.to_sym,
           :filter, :projection,
           :action, :controller,
-          :format, :paging, :sorting)
+          :format, :paging, :sorting,
+          :page, :items)
 
       [paged_sorted_query, opts]
     end
@@ -282,8 +283,9 @@ module Api
         # execute a count against entire set without paging
         total = new_query.size
 
-        # if query involves aggregation, size returns the size of each group.
-        # and what we need is the number of groups
+        # if new_query involves aggregation, size returns the size of each group as a hash,
+        # and what we need is the number of groups, so check if it is a hash and if so
+        # use its length for the value of total.
         if total.is_a? Hash
           total = total.length
         end
@@ -317,11 +319,13 @@ module Api
       [new_query, opts]
     end
 
+    # if lower is higher than upper, lower will have priority
     def restrict_to_bounds(value, lower = 1, upper = nil)
       value_i = value.to_i
 
-      value_i = lower if !lower.blank? && value_i < lower
       value_i = upper if !upper.blank? && value_i > upper
+      value_i = lower if !lower.blank? && value_i < lower
+
       value_i
     end
 

--- a/lib/modules/filter/query.rb
+++ b/lib/modules/filter/query.rb
@@ -308,11 +308,17 @@ module Filter
       sort_field = @build.build_custom_field(column_name)
       sort_field = table[column_name] if sort_field.blank?
 
-      if direction == :desc
-        sort_field_by = Arel::Nodes::Descending.new(sort_field)
+      if (sort_field.is_a? String)
+        sort_field_by = sort_field
       else
-        #direction == :asc
-        sort_field_by = Arel::Nodes::Ascending.new(sort_field)
+
+        if direction == :desc
+          sort_field_by = Arel::Nodes::Descending.new(sort_field)
+        else
+          #direction == :asc
+          sort_field_by = Arel::Nodes::Ascending.new(sort_field)
+        end
+
       end
 
       query.order(sort_field_by)

--- a/lib/modules/filter/query.rb
+++ b/lib/modules/filter/query.rb
@@ -308,7 +308,7 @@ module Filter
       sort_field = @build.build_custom_field(column_name)
       sort_field = table[column_name] if sort_field.blank?
 
-      if (sort_field.is_a? String)
+      if sort_field.is_a? String
         sort_field_by = sort_field
       else
 

--- a/lib/modules/filter/validate.rb
+++ b/lib/modules/filter/validate.rb
@@ -337,7 +337,7 @@ module Filter
         value[:field_mappings].each do |field_mapping_hash|
           validate_hash(field_mapping_hash)
           validate_hash_key(field_mapping_hash, :name, Symbol)
-          validate_hash_key(field_mapping_hash, :value, Arel::Nodes::Node)
+          validate_hash_key(field_mapping_hash, :value, [Arel::Nodes::Node, String])
         end
       end
 

--- a/spec/acceptance/audio_events_spec.rb
+++ b/spec/acceptance/audio_events_spec.rb
@@ -591,6 +591,39 @@ resource 'AudioEvents' do
     end
   end
 
+  context 'filter with paging' do
+
+    post '/audio_events/filter' do
+
+      let(:authentication_token) { reader_token }
+      create_entire_hierarchy
+
+      let!(:new_audio_event) {
+        30.times do
+          audio_event_2 = Creation::Common.create_audio_event(writer_user, audio_recording)
+          audio_event_2.is_reference = true
+          audio_event_2.save!
+        end
+      }
+
+      let(:raw_post) {
+        {"filter"=>{"is_reference"=>{"eq"=>true}},"paging"=>{"items"=>10,"page"=>2}}.to_json
+      }
+      standard_request_options(:post, 'FILTER (as reader, page 2 showing 10 items', :ok,
+                               {
+                                   expected_json_path: 'data/0/is_reference',
+                                   data_item_count: 10,
+                                   response_body_content: [
+                                       '"paging":{"page":2,"items":10,"total":30,"max_page":3',
+                                       '"previous":"http://localhost:3000/audio_events/filter?direction=desc\u0026items=10\u0026order_by=created_at\u0026page=1"'
+                                   ]
+                               })
+
+    end
+
+
+  end
+
   post '/audio_events/filter' do
     let(:authentication_token) { reader_token }
     create_entire_hierarchy
@@ -633,6 +666,8 @@ resource 'AudioEvents' do
                              })
   end
 
+
+
   post '/audio_events/filter' do
     let(:authentication_token) { reader_token }
     let(:raw_post) { {
@@ -660,7 +695,7 @@ resource 'AudioEvents' do
     }.to_json }
     standard_request_options(:post, 'FILTER (as anonymous user)', :ok, {
         remove_auth: true,
-        response_body_content: '{"meta":{"status":200,"message":"OK","filter":{"audio_events_tags.tag_id":{"gt":0}},"sorting":{"order_by":"created_at","direction":"desc"},"paging":{"page":1,"items":25,"total":0,"max_page":0,"current":"http://localhost:3000/audio_events/filter?direction=desc\u0026items=25\u0026order_by=created_at\u0026page=0","previous":null,"next":null}},"data":[]}'})
+        response_body_content: '{"meta":{"status":200,"message":"OK","filter":{"audio_events_tags.tag_id":{"gt":0}},"sorting":{"order_by":"created_at","direction":"desc"},"paging":{"page":1,"items":25,"total":0,"max_page":0,"current":"http://localhost:3000/audio_events/filter?direction=desc\u0026items=25\u0026order_by=created_at\u0026page=1","previous":null,"next":null}},"data":[]}'})
   end
 
   post '/audio_events/filter' do

--- a/spec/acceptance/dataset_items_spec.rb
+++ b/spec/acceptance/dataset_items_spec.rb
@@ -123,19 +123,19 @@ resource 'DatasetItems' do
   get '/datasets/:dataset_id/items' do
     let(:authentication_token) { owner_token }
     let(:dataset_id) { dataset.id }
-    standard_request_options(:get,'INDEX (as owner)',:ok, non_admin_opts)
+    standard_request_options(:get, 'INDEX (as owner)', :ok, non_admin_opts)
   end
 
   get '/datasets/:dataset_id/items' do
     let(:authentication_token) { writer_token }
     let(:dataset_id) { dataset.id }
-    standard_request_options(:get,'INDEX (as writer)',:ok, non_admin_opts)
+    standard_request_options(:get, 'INDEX (as writer)', :ok, non_admin_opts)
   end
 
   get '/datasets/:dataset_id/items' do
     let(:authentication_token) { reader_token }
     let(:dataset_id) { dataset.id }
-    standard_request_options(:get,'INDEX (as reader)',:ok, non_admin_opts)
+    standard_request_options(:get, 'INDEX (as reader)', :ok, non_admin_opts)
   end
 
 
@@ -191,7 +191,6 @@ resource 'DatasetItems' do
         'CREATE (as admin)',
         :created,
         {expected_json_path: 'data/end_time_seconds/', response_body_content: ['"end_time_seconds":234.0']}
-         # {expected_json_path: 'data/end_time_seconds/', response_body_content: ['"end_time_seconds":234.0', "\"dataset_id\":#{dataset.id}"]}
     )
   end
 
@@ -203,7 +202,11 @@ resource 'DatasetItems' do
     let(:authentication_token) { owner_token }
     let(:dataset_id) { dataset.id }
     let(:audio_recording_id) { audio_recording.id }
-    standard_request_options(:post,'CREATE (as owner)',:forbidden, non_admin_opts)
+    standard_request_options(
+        :post,
+        'CREATE (as owner)',
+        :forbidden,
+        non_admin_opts)
   end
 
   post '/datasets/:dataset_id/items' do
@@ -212,7 +215,11 @@ resource 'DatasetItems' do
     let(:authentication_token) { writer_token }
     let(:dataset_id) { dataset.id }
     let(:audio_recording_id) { audio_recording.id }
-    standard_request_options(:post,'CREATE (as writer)',:forbidden, non_admin_opts)
+    standard_request_options(
+        :post,
+        'CREATE (as writer)',
+        :forbidden,
+        non_admin_opts)
   end
 
   post '/datasets/:dataset_id/items' do
@@ -221,7 +228,11 @@ resource 'DatasetItems' do
     let(:authentication_token) { reader_token }
     let(:dataset_id) { dataset.id }
     let(:audio_recording_id) { audio_recording.id }
-    standard_request_options(:post,'CREATE (as reader)',:forbidden, non_admin_opts)
+    standard_request_options(
+        :post,
+        'CREATE (as reader)',
+        :forbidden,
+        non_admin_opts)
   end
 
   post '/datasets/:dataset_id/items' do
@@ -722,7 +733,7 @@ resource 'DatasetItems' do
     )
   end
 
-  # permissions will be the same for reader,writer,owner so they will have
+  # permissions will be the same for reader, writer, owner so they will have
   # the same response for the same filter params. Should return 7 items
   # from the two datasets, but not the dataset item from the no-access hierarchy
   regular_user_opts = {
@@ -733,17 +744,17 @@ resource 'DatasetItems' do
 
   post '/dataset_items/filter' do
     let(:authentication_token) { owner_token }
-    standard_request_options(:post,'FILTER (as owner)',:ok,regular_user_opts)
+    standard_request_options(:post, 'FILTER (as owner)', :ok, regular_user_opts)
   end
 
   post '/dataset_items/filter' do
     let(:authentication_token) { writer_token }
-    standard_request_options(:post,'FILTER (as writer)',:ok,regular_user_opts)
+    standard_request_options(:post, 'FILTER (as writer)', :ok, regular_user_opts)
   end
 
   post '/dataset_items/filter' do
     let(:authentication_token) { reader_token }
-    standard_request_options(:post,'FILTER (as reader)',:ok,regular_user_opts)
+    standard_request_options(:post, 'FILTER (as reader)', :ok, regular_user_opts)
   end
 
   # reader user using nested path, which will filter out the no access item and also the
@@ -886,7 +897,7 @@ resource 'DatasetItems' do
             data_item_count: 3,
             order: {
                 property: 'start_time_seconds',
-                values: [1,8,3]
+                values: [1, 8, 3]
             }
         }
     )
@@ -918,7 +929,7 @@ resource 'DatasetItems' do
       )
     end
 
-    # permissions will be the same for reader,writer,owner so they will have
+    # permissions will be the same for reader, writer, owner so they will have
     # the same response for the same filter params.
     # Using nested path, which will filter out the no access item and also the
     # item from a different dataset, leaving 5 dataset items
@@ -931,19 +942,31 @@ resource 'DatasetItems' do
     get '/datasets/:dataset_id/dataset_items/filter_todo' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { owner_token }
-      standard_request_options(:get,'FILTER TODO (as owner)',:ok,regular_user_opts)
+      standard_request_options(
+          :get,
+          'FILTER TODO (as owner)',
+          :ok,
+          regular_user_opts)
     end
 
     get '/datasets/:dataset_id/dataset_items/filter_todo' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { writer_token }
-      standard_request_options(:get,'FILTER TODO (as writer)',:ok,regular_user_opts)
+      standard_request_options(
+          :get,
+          'FILTER TODO (as writer)',
+          :ok,
+          regular_user_opts)
     end
 
     get '/datasets/:dataset_id/dataset_items/filter_todo' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { reader_token }
-      standard_request_options(:get,'FILTER TODO (as reader)',:ok,regular_user_opts)
+      standard_request_options(
+          :get,
+          'FILTER TODO (as reader)',
+          :ok,
+          regular_user_opts)
     end
 
     get '/datasets/:dataset_id/dataset_items/filter_todo' do

--- a/spec/acceptance/dataset_items_spec.rb
+++ b/spec/acceptance/dataset_items_spec.rb
@@ -43,11 +43,12 @@ resource 'DatasetItems' do
   # we include some dataset items for audio recordings that the user can not access
   #
   # After this, the dataset_items will be
-  # - 1 created by the create_entire_hierarchy
+  # - 2 created by the create_entire_hierarchy
+  #   - including one in the default dataset
   # - 1 created by create_no_access_hierarchy
   # - 1 created under a different dataset to test the dataset id path parameter
   # - 4 created with custom field values to test sorting and filtering
-  # - total: 7 dataset items
+  # - total: 8 dataset items
   #
 
   create_no_access_hierarchy
@@ -688,7 +689,7 @@ resource 'DatasetItems' do
   ################################
 
   # with shallow route (no dataset id)
-  # admin finds all 7 items
+  # admin finds all 8 items
   post '/dataset_items/filter' do
     let(:authentication_token) { admin_token }
     standard_request_options(
@@ -698,7 +699,7 @@ resource 'DatasetItems' do
         {
             response_body_content: ['"start_time_seconds":11.0'],
             expected_json_path: 'data/0/start_time_seconds',
-            data_item_count: 7
+            data_item_count: 8
         }
     )
   end
@@ -722,12 +723,12 @@ resource 'DatasetItems' do
   end
 
   # permissions will be the same for reader,writer,owner so they will have
-  # the same response for the same filter params. Should return 6 items
+  # the same response for the same filter params. Should return 7 items
   # from the two datasets, but not the dataset item from the no-access hierarchy
   regular_user_opts = {
       response_body_content: ['"start_time_seconds":11.0'],
       expected_json_path: 'data/0/start_time_seconds',
-      data_item_count: 6
+      data_item_count: 7
   }
 
   post '/dataset_items/filter' do

--- a/spec/acceptance/dataset_items_spec.rb
+++ b/spec/acceptance/dataset_items_spec.rb
@@ -893,4 +893,104 @@ resource 'DatasetItems' do
 
   end
 
+
+  ################################
+  # FILTER TODO
+  ################################
+
+  context 'filter todo' do
+
+    # with deep route including dataset id
+    # One item has a different dataset id, so only 6 items
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      dataset_id_param
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { admin_token }
+      standard_request_options(
+          :get,
+          'FILTER TODO (as admin)',
+          :ok,
+          {
+              response_body_content: ['"start_time_seconds":11.0'],
+              expected_json_path: 'data/0/start_time_seconds',
+              data_item_count: 6
+          }
+      )
+    end
+
+    # permissions will be the same for reader,writer,owner so they will have
+    # the same response for the same filter params.
+    # Using nested path, which will filter out the no access item and also the
+    # item from a different dataset, leaving 5 dataset items
+    regular_user_opts = {
+        response_body_content: ['"start_time_seconds":11.0'],
+        expected_json_path: 'data/0/start_time_seconds',
+        data_item_count: 5
+    }
+
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { owner_token }
+      standard_request_options(:get,'FILTER TODO (as owner)',:ok,regular_user_opts)
+    end
+
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { writer_token }
+      standard_request_options(:get,'FILTER TODO (as writer)',:ok,regular_user_opts)
+    end
+
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { reader_token }
+      standard_request_options(:get,'FILTER TODO (as reader)',:ok,regular_user_opts)
+    end
+
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { no_access_token }
+      standard_request_options(
+          :get,
+          'FILTER TODO (as no access)',
+          :ok,
+          {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 0}
+      )
+    end
+
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { invalid_token }
+      standard_request_options(
+          :get,
+          'FILTER TODO (as invalid token)',
+          :unauthorized,
+          {expected_json_path: get_json_error_path(:sign_up)}
+      )
+    end
+
+    # not logged in users can filter dataset items, but they won't get any items that they don't have permission for
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      standard_request_options(
+          :get,
+          'FILTER TODO (as not logged in)',
+          :ok,
+          {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 0}
+      )
+    end
+
+    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+      let(:dataset_id) { dataset.id }
+      let(:authentication_token) { harvester_token }
+      standard_request_options(
+          :get,
+          'FILTER TODO (as harvester)',
+          :forbidden,
+          {response_body_content: ['"data":null'], expected_json_path: get_json_error_path(:permissions)}
+      )
+    end
+
+
+  end
+
 end

--- a/spec/acceptance/dataset_items_spec.rb
+++ b/spec/acceptance/dataset_items_spec.rb
@@ -906,20 +906,20 @@ resource 'DatasetItems' do
 
 
   ################################
-  # FILTER TODO
+  # NEXT FOR ME
   ################################
 
-  context 'filter todo' do
+  context 'next for me' do
 
     # with deep route including dataset id
     # One item has a different dataset id, so only 6 items
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       dataset_id_param
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { admin_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as admin)',
+          'NEXT FOR ME (as admin)',
           :ok,
           {
               response_body_content: ['"start_time_seconds":11.0'],
@@ -939,75 +939,86 @@ resource 'DatasetItems' do
         data_item_count: 5
     }
 
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { owner_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as owner)',
+          'NEXT FOR ME (as owner)',
           :ok,
           regular_user_opts)
     end
 
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { writer_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as writer)',
+          'NEXT FOR ME (as writer)',
           :ok,
           regular_user_opts)
     end
 
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { reader_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as reader)',
+          'NEXT FOR ME (as reader)',
           :ok,
           regular_user_opts)
     end
 
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { no_access_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as no access)',
+          'NEXT FOR ME (as no access)',
           :ok,
           {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 0}
       )
     end
 
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { invalid_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as invalid token)',
+          'NEXT FOR ME (as invalid token)',
           :unauthorized,
           {expected_json_path: get_json_error_path(:sign_up)}
       )
     end
 
     # not logged in users can filter dataset items, but they won't get any items that they don't have permission for
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       standard_request_options(
           :get,
-          'FILTER TODO (as not logged in)',
+          'NEXT FOR ME (as not logged in)',
           :ok,
           {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 0}
       )
     end
 
-    get '/datasets/:dataset_id/dataset_items/filter_todo' do
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
+      create_anon_hierarchy
+      let(:dataset_id) { dataset.id }
+      standard_request_options(
+          :get,
+          'NEXT FOR ME (as not logged in) with public project',
+          :ok,
+          {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 1}
+      )
+    end
+
+    get '/datasets/:dataset_id/dataset_items/next_for_me' do
       let(:dataset_id) { dataset.id }
       let(:authentication_token) { harvester_token }
       standard_request_options(
           :get,
-          'FILTER TODO (as harvester)',
+          'NEXT FOR ME (as harvester)',
           :forbidden,
           {response_body_content: ['"data":null'], expected_json_path: get_json_error_path(:permissions)}
       )

--- a/spec/acceptance/dataset_items_spec.rb
+++ b/spec/acceptance/dataset_items_spec.rb
@@ -976,7 +976,7 @@ resource 'DatasetItems' do
           :get,
           'NEXT FOR ME (as no access)',
           :ok,
-          {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 0}
+          {expected_json_path: 'meta/paging/total', expected_json_path: 'data', data_item_count: 0}
       )
     end
 
@@ -998,7 +998,7 @@ resource 'DatasetItems' do
           :get,
           'NEXT FOR ME (as not logged in)',
           :ok,
-          {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 0}
+          {expected_json_path: 'meta/paging/total', expected_json_path: 'data', data_item_count: 0}
       )
     end
 
@@ -1009,7 +1009,7 @@ resource 'DatasetItems' do
           :get,
           'NEXT FOR ME (as not logged in) with public project',
           :ok,
-          {response_body_content: ['"order_by":"priority"'], expected_json_path: 'data', data_item_count: 1}
+          {expected_json_path: 'meta/paging/total', expected_json_path: 'data', data_item_count: 1}
       )
     end
 

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -257,7 +257,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { admin_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -274,7 +274,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { owner_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -289,7 +289,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { writer_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -304,7 +304,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { reader_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -319,7 +319,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { no_access_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -334,7 +334,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { invalid_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -348,7 +348,7 @@ resource 'ProgressEvents' do
     post create_by_dataset_item_params_url do
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
@@ -363,7 +363,7 @@ resource 'ProgressEvents' do
       let(:authentication_token) { harvester_token }
       body_params_2
       let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
-      let(:dataset_id) { 1 }
+      let(:dataset_id) { 'default' }
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -81,9 +81,9 @@ resource 'ProgressEvents' do
     let(:authentication_token) { no_access_token }
     standard_request_options(
         :get,
-        'INDEX (as reader)',
+        'INDEX (as no access user)',
         :ok,
-        {expected_json_path: 'data/0/dataset_item_id', data_item_count: 1}
+        {response_body_content: ['"order_by":"created_at","direction":"desc"'], data_item_count: 0}
     )
   end
 
@@ -673,17 +673,16 @@ resource 'ProgressEvents' do
       standard_request_options(:post,'FILTER (as reader)',:ok,regular_user_opts)
     end
 
-    # no-access user has is the creator of 1 progress event for a dataset_item that
-    # this user does not have access to, to simulate access to a progress event if the
-    # user has had access to the project revoked.
+    # no-access user is the creator of 1 progress event for a dataset_item that
+    # this user does not have access to. User can not access the record even if
+    # they are creator
     post '/progress_events/filter' do
       let(:authentication_token) { no_access_token }
-      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
       standard_request_options(
           :post,
           'FILTER (as no access)',
           :ok,
-          {response_body_content: ['"order_by":"created_at"'], expected_json_path: 'data', data_item_count: 1})
+          {response_body_content: ['"order_by":"created_at"'], expected_json_path: 'data', data_item_count: 0})
     end
 
     post '/progress_events/filter' do
@@ -770,20 +769,7 @@ resource 'ProgressEvents' do
       )
     end
 
-    # users can view progress events they created, even if they don't have access to the dataset item
-    post '/progress_events/filter' do
-      let(:authentication_token) { no_access_token }
-      standard_request_options(
-          :post,
-          'FILTER (as no access user)',
-          :ok,
-          {
-              response_body_content: ['"activity":"played"'],
-              expected_json_path: 'data/0/dataset_item_id',
-              data_item_count: 1
-          }
-      )
-    end
+
 
   end
 

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -132,7 +132,7 @@ resource 'ProgressEvents' do
   # CREATE
   ################################
 
-  # any user can create a dataset item if they have read-access on the project
+  # any user can create a progress event they have read-access on the project
 
   create_success_opts = {expected_json_path: 'data/activity/', response_body_content: ['"activity":"viewed"'] }
 
@@ -239,7 +239,7 @@ resource 'ProgressEvents' do
   # CREATE BY DATASET ITEM PARAMS
   ################################
 
-  # any user can create a dataset item if they have read-access on the project
+  # any user can create a progress event if they have read-access on the project
 
   context 'CREATE BY DATASET ITEM PARAMS' do
 
@@ -874,8 +874,8 @@ resource 'ProgressEvents' do
     end
 
     # permissions will be the same for reader, writer, owner so they will have
-    # the same response for the same filter params. Should return 6 items
-    # from the two datasets, but not the dataset item from the no-access hierarchy
+    # the same response for the same filter params. Should return all progress events
+    # except those for the dataset item from the no-access hierarchy
     regular_user_opts = {
         response_body_content: ['"activity":"viewed"'],
         expected_json_path: 'data/0/dataset_item_id',

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 require 'helpers/acceptance_spec_helper'
 
+
 def progress_event_id_param
   parameter :progress_event_id, 'Progress Event id in request url', required: true
 end
@@ -9,6 +10,10 @@ end
 def body_params
   parameter :activity, 'type of progress event', scope: :progress_event, :required => true
   parameter :dataset_item_id, 'id of dataset item', scope: :progress_event, :required => true
+end
+
+def body_params_2
+  parameter :activity, 'type of progress event', scope: :progress_event, :required => true
 end
 
 # https://github.com/zipmark/rspec_api_documentation
@@ -212,6 +217,121 @@ resource 'ProgressEvents' do
         :forbidden,
         {expected_json_path: get_json_error_path(:permissions)})
   end
+
+
+  ################################
+  # CREATE BY DATASET ITEM PARAMS
+  ################################
+
+  # any user can create a dataset item if they have read-access on the project
+
+  context 'CREATE BY DATASET ITEM PARAMS' do
+
+    create_success_opts = {expected_json_path: 'data/activity/', response_body_content: ['"activity":"viewed"'] }
+
+    let(:post_attributes_2) {
+      post_attributes_2 = FactoryGirl.attributes_for(:progress_event)
+      post_attributes_2 = post_attributes_2.except(:dataset_item_id)
+      post_attributes_2
+    }
+
+    create_by_dataset_item_params_url = '/datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds'
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { admin_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+
+      standard_request_options(
+          :post,
+          'CREATE (as admin)',
+          :created,
+          create_success_opts
+      )
+    end
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { owner_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (as owner)',:created, create_success_opts)
+    end
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { writer_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (as writer)',:created, create_success_opts)
+    end
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { reader_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (as reader)',:created, create_success_opts)
+    end
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { no_access_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (as no access user)',:forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    end
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { invalid_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (invalid token)',:unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    end
+
+    post create_by_dataset_item_params_url do
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (anonymous user)',:unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    end
+
+    post create_by_dataset_item_params_url do
+      let(:authentication_token) { harvester_token }
+      body_params_2
+      let(:raw_post) { {'progress_event' => post_attributes_2}.to_json }
+      let(:dataset_id) { 1 }
+      let(:audio_recording_id) { audio_recording.id }
+      let(:start_time_seconds) { 1234 }
+      let(:end_time_seconds) { 1245 }
+      standard_request_options(:post,'CREATE (as harvester)',:forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    end
+
+  end
+
 
   # ################################
   # # NEW

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -71,17 +71,17 @@ resource 'ProgressEvents' do
 
   get '/progress_events' do
     let(:authentication_token) { owner_token }
-    standard_request_options(:get,'INDEX (as owner)',:ok, non_admin_opts)
+    standard_request_options(:get, 'INDEX (as owner)', :ok, non_admin_opts)
   end
 
   get '/progress_events' do
     let(:authentication_token) { writer_token }
-    standard_request_options(:get,'INDEX (as writer)',:ok, non_admin_opts)
+    standard_request_options(:get, 'INDEX (as writer)', :ok, non_admin_opts)
   end
 
   get '/progress_events' do
     let(:authentication_token) { reader_token }
-    standard_request_options(:get,'INDEX (as reader)',:ok, non_admin_opts)
+    standard_request_options(:get, 'INDEX (as reader)', :ok, non_admin_opts)
   end
 
   get '/progress_events' do
@@ -109,7 +109,11 @@ resource 'ProgressEvents' do
         :get,
         'INDEX (as anonymous user)',
         :ok,
-        {remove_auth: true, response_body_content: ['"order_by":"created_at","direction":"desc"'], data_item_count: 0}
+        {
+            remove_auth: true,
+            response_body_content: ['"order_by":"created_at","direction":"desc"'],
+            data_item_count: 0
+        }
     )
   end
 
@@ -149,7 +153,11 @@ resource 'ProgressEvents' do
     let(:raw_post) { {'progress_event' => post_attributes}.to_json }
     let(:authentication_token) { owner_token }
     let(:dataset_item_id) { dataset_item.id }
-    standard_request_options(:post,'CREATE (as owner)',:created, create_success_opts)
+    standard_request_options(
+        :post,
+        'CREATE (as owner)',
+        :created,
+        create_success_opts)
   end
 
   post '/progress_events' do
@@ -157,7 +165,11 @@ resource 'ProgressEvents' do
     let(:raw_post) { {'progress_event' => post_attributes}.to_json }
     let(:authentication_token) { writer_token }
     let(:dataset_item_id) { dataset_item.id }
-    standard_request_options(:post,'CREATE (as writer)',:created, create_success_opts)
+    standard_request_options(
+        :post,
+        'CREATE (as writer)',
+        :created,
+        create_success_opts)
   end
 
   post '/progress_events' do
@@ -165,7 +177,11 @@ resource 'ProgressEvents' do
     let(:raw_post) { {'progress_event' => post_attributes}.to_json }
     let(:authentication_token) { reader_token }
     let(:dataset_item_id) { dataset_item.id }
-    standard_request_options(:post,'CREATE (as reader)',:created, create_success_opts)
+    standard_request_options(
+        :post,
+        'CREATE (as reader)',
+        :created,
+        create_success_opts)
   end
 
   post '/progress_events' do
@@ -262,7 +278,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (as owner)',:created, create_success_opts)
+      standard_request_options(
+          :post,
+          'CREATE (as owner)',
+          :created,
+          create_success_opts)
     end
 
     post create_by_dataset_item_params_url do
@@ -273,7 +293,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (as writer)',:created, create_success_opts)
+      standard_request_options(
+          :post,
+          'CREATE (as writer)',
+          :created,
+          create_success_opts)
     end
 
     post create_by_dataset_item_params_url do
@@ -284,7 +308,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (as reader)',:created, create_success_opts)
+      standard_request_options(
+          :post,
+          'CREATE (as reader)',
+          :created,
+          create_success_opts)
     end
 
     post create_by_dataset_item_params_url do
@@ -295,7 +323,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (as no access user)',:forbidden, {expected_json_path: get_json_error_path(:permissions)})
+      standard_request_options(
+          :post,
+          'CREATE (as no access user)',
+          :forbidden,
+          {expected_json_path: get_json_error_path(:permissions)})
     end
 
     post create_by_dataset_item_params_url do
@@ -306,7 +338,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (invalid token)',:unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+      standard_request_options(
+          :post,
+          'CREATE (invalid token)',
+          :unauthorized,
+          {expected_json_path: get_json_error_path(:sign_up)})
     end
 
     post create_by_dataset_item_params_url do
@@ -316,7 +352,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (anonymous user)',:unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+      standard_request_options(
+          :post,
+          'CREATE (anonymous user)',
+          :unauthorized,
+          {expected_json_path: get_json_error_path(:sign_up)})
     end
 
     post create_by_dataset_item_params_url do
@@ -327,7 +367,11 @@ resource 'ProgressEvents' do
       let(:audio_recording_id) { audio_recording.id }
       let(:start_time_seconds) { 1234 }
       let(:end_time_seconds) { 1245 }
-      standard_request_options(:post,'CREATE (as harvester)',:forbidden, {expected_json_path: get_json_error_path(:permissions)})
+      standard_request_options(
+          :post,
+          'CREATE (as harvester)',
+          :forbidden,
+          {expected_json_path: get_json_error_path(:permissions)})
     end
 
   end
@@ -571,7 +615,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
     let(:authentication_token) { owner_token }
-    standard_request_options(:put, 'UPDATE (as owner)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :put,
+        'UPDATE (as owner)',
+        :forbidden,
+        forbidden_opts)
   end
 
   put '/progress_events/:id' do
@@ -580,7 +628,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
     let(:authentication_token) { writer_token }
-    standard_request_options(:put, 'UPDATE (as writer)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :put,
+        'UPDATE (as writer)',
+        :forbidden,
+        forbidden_opts)
   end
 
   put '/progress_events/:id' do
@@ -589,7 +641,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
     let(:authentication_token) { reader_token }
-    standard_request_options(:put, 'UPDATE (as reader)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :put,
+        'UPDATE (as reader)',
+        :forbidden,
+        forbidden_opts)
   end
 
   put '/progress_events/:id' do
@@ -598,7 +654,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:put, 'UPDATE (as no access user)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :put,
+        'UPDATE (as no access user)',
+        :forbidden,
+        forbidden_opts)
   end
 
   # can not update the progress event, even through is the creator
@@ -608,7 +668,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event_for_no_access_user.id }
     let(:raw_post) {  {progress_event: {activity: "viewed"}}.to_json }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:put, 'UPDATE (as no access user)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :put,
+        'UPDATE (as no access user)',
+        :forbidden,
+        forbidden_opts)
   end
 
   put '/progress_events/:id' do
@@ -617,7 +681,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:put, 'UPDATE (as invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(
+        :put,
+        'UPDATE (as invalid token)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)})
   end
 
   put '/progress_events/:id' do
@@ -625,7 +693,11 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
-    standard_request_options(:put, 'UPDATE (as not logged in)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(
+        :put,
+        'UPDATE (as not logged in)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)})
   end
 
   put '/progress_events/:id' do
@@ -634,7 +706,11 @@ resource 'ProgressEvents' do
     let(:id) { progress_event.id }
     let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
     let(:authentication_token) { harvester_token }
-    standard_request_options(:put, 'UPDATE (as harvester)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :put,
+        'UPDATE (as harvester)',
+        :forbidden,
+        forbidden_opts)
   end
 
   # ################################
@@ -662,7 +738,10 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:authentication_token) { owner_token }
-    standard_request_options(:delete, 'DELETE (as owner)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :delete,
+        'DELETE (as owner)',
+        :forbidden, forbidden_opts)
   end
 
   delete '/progress_events/:id' do
@@ -670,7 +749,10 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:authentication_token) { writer_token }
-    standard_request_options(:delete, 'DELETE (as writer)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :delete,
+        'DELETE (as writer)',
+        :forbidden, forbidden_opts)
   end
 
   delete '/progress_events/:id' do
@@ -678,7 +760,11 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:authentication_token) { reader_token }
-    standard_request_options(:delete, 'DELETE (as reader)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :delete,
+        'DELETE (as reader)',
+        :forbidden,
+        forbidden_opts)
   end
 
   delete '/progress_events/:id' do
@@ -686,7 +772,11 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:delete, 'DELETE (as no access user)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :delete,
+        'DELETE (as no access user)',
+        :forbidden,
+        forbidden_opts)
   end
 
   # can not delete the progress event, even through is the creator
@@ -695,7 +785,11 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event_for_no_access_user.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:delete, 'DELETE (as no access user)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :delete,
+        'DELETE (as no access user)',
+        :forbidden,
+        forbidden_opts)
   end
 
   delete '/progress_events/:id' do
@@ -703,14 +797,22 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:delete, 'DELETE (as invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(
+        :delete,
+        'DELETE (as invalid token)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)})
   end
 
   delete '/progress_events/:id' do
     progress_event_id_param
     body_params
     let(:id) { progress_event.id }
-    standard_request_options(:delete, 'DELETE (as not logged in)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(
+        :delete,
+        'DELETE (as not logged in)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)})
   end
 
   delete '/progress_events/:id' do
@@ -718,7 +820,10 @@ resource 'ProgressEvents' do
     body_params
     let(:id) { progress_event.id }
     let(:authentication_token) { harvester_token }
-    standard_request_options(:delete, 'DELETE (as harvester)', :forbidden, forbidden_opts)
+    standard_request_options(
+        :delete,
+        'DELETE (as harvester)',
+        :forbidden, forbidden_opts)
   end
 
   # ################################
@@ -768,7 +873,7 @@ resource 'ProgressEvents' do
       )
     end
 
-    # permissions will be the same for reader,writer,owner so they will have
+    # permissions will be the same for reader, writer, owner so they will have
     # the same response for the same filter params. Should return 6 items
     # from the two datasets, but not the dataset item from the no-access hierarchy
     regular_user_opts = {
@@ -780,19 +885,19 @@ resource 'ProgressEvents' do
     post '/progress_events/filter' do
       let(:authentication_token) { owner_token }
       let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
-      standard_request_options(:post,'FILTER (as owner)',:ok,regular_user_opts)
+      standard_request_options(:post, 'FILTER (as owner)', :ok, regular_user_opts)
     end
 
     post '/progress_events/filter' do
       let(:authentication_token) { writer_token }
       let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
-      standard_request_options(:post,'FILTER (as writer)',:ok,regular_user_opts)
+      standard_request_options(:post, 'FILTER (as writer)', :ok, regular_user_opts)
     end
 
     post '/progress_events/filter' do
       let(:authentication_token) { reader_token }
       let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
-      standard_request_options(:post,'FILTER (as reader)',:ok,regular_user_opts)
+      standard_request_options(:post, 'FILTER (as reader)', :ok, regular_user_opts)
     end
 
     # no-access user is the creator of 1 progress event for a dataset_item that

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -33,8 +33,10 @@ resource 'ProgressEvents' do
   # create some progress events
   #
   # After this, the dataset_items and progress events are:
-  # - 1 dataset item created by the create_entire_hierarchy
-  #   - with 2 progress events, one created by admin and one by no_access_user
+  # - 1 dataset item created by writer_user (create_entire_hierarchy)
+  #   - with 1 progress event created by no_access_user
+  # - 1 dataset item in the default dataset, created by writer_user
+  #   - with 1 progress event created by admin_user
   # - 1 dataset item created by create_no_access_hierarchy
   #   - with 1 progress event, created by a different user
   # -> 3 progress events total
@@ -769,7 +771,27 @@ resource 'ProgressEvents' do
       )
     end
 
-
+    # filter progress events by dataset id
+    post '/progress_events/filter' do
+      let(:authentication_token) { reader_token }
+      let(:raw_post) { {
+          'filter' => {
+              'datasets.id' => {
+                  'eq' => 1
+              }
+          }
+      }.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as reader) by dataset id',
+          :ok,
+          {
+              expected_json_path: 'data/0/creator_id',
+              data_item_count: 1,
+              response_body_content: '"created_at":'
+          }
+      )
+    end
 
   end
 

--- a/spec/acceptance/progress_events_spec.rb
+++ b/spec/acceptance/progress_events_spec.rb
@@ -1,0 +1,790 @@
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+require 'helpers/acceptance_spec_helper'
+
+def progress_event_id_param
+  parameter :progress_event_id, 'Progress Event id in request url', required: true
+end
+
+def body_params
+  parameter :activity, 'type of progress event', scope: :progress_event, :required => true
+  parameter :dataset_item_id, 'id of dataset item', scope: :progress_event, :required => true
+end
+
+# https://github.com/zipmark/rspec_api_documentation
+resource 'ProgressEvents' do
+
+  header 'Accept', 'application/json'
+  header 'Content-Type', 'application/json'
+  header 'Authorization', :authentication_token
+
+  let(:format) { 'json' }
+
+  create_entire_hierarchy
+
+  # Create post parameters from factory
+  # add the audio recording id as a post parameter
+  let(:post_attributes) {
+    post_attributes = FactoryGirl.attributes_for(:progress_event)
+    post_attributes[:dataset_item_id] = dataset_item[:id]
+    post_attributes
+  }
+
+  # create some progress events
+  #
+  # After this, the dataset_items and progress events are:
+  # - 1 dataset item created by the create_entire_hierarchy
+  #   - with 2 progress events, one created by admin and one by no_access_user
+  # - 1 dataset item created by create_no_access_hierarchy
+  #   - with 1 progress event, created by a different user
+  # -> 3 progress events total
+
+  create_no_access_hierarchy
+
+  ################################
+  # INDEX
+  ################################
+
+  # users have read access on progress events if they have read
+  # access on the project via project/site/audio_recording/dataset_item/progress_event
+  # or if they are the creator
+
+  get '/progress_events' do
+    let(:authentication_token) { admin_token }
+    standard_request_options(
+        :get,
+        'INDEX (as admin)',
+        :ok,
+        {expected_json_path: 'data/0/dataset_item_id', data_item_count: 3}
+    )
+  end
+
+  # permissions for owner, writer and reader are the same as each other
+  non_admin_opts = {expected_json_path: 'data/0/dataset_item_id', data_item_count: 2}
+
+  get '/progress_events' do
+    let(:authentication_token) { owner_token }
+    standard_request_options(:get,'INDEX (as owner)',:ok, non_admin_opts)
+  end
+
+  get '/progress_events' do
+    let(:authentication_token) { writer_token }
+    standard_request_options(:get,'INDEX (as writer)',:ok, non_admin_opts)
+  end
+
+  get '/progress_events' do
+    let(:authentication_token) { reader_token }
+    standard_request_options(:get,'INDEX (as reader)',:ok, non_admin_opts)
+  end
+
+  get '/progress_events' do
+    let(:authentication_token) { no_access_token }
+    standard_request_options(
+        :get,
+        'INDEX (as reader)',
+        :ok,
+        {expected_json_path: 'data/0/dataset_item_id', data_item_count: 1}
+    )
+  end
+
+  get '/progress_events' do
+    let(:authentication_token) { invalid_token }
+    standard_request_options(
+        :get,
+        'INDEX (invalid token)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)}
+    )
+  end
+
+  get '/progress_events' do
+    standard_request_options(
+        :get,
+        'INDEX (as anonymous user)',
+        :ok,
+        {remove_auth: true, response_body_content: ['"order_by":"created_at","direction":"desc"'], data_item_count: 0}
+    )
+  end
+
+  get '/progress_events' do
+    let(:authentication_token) { harvester_token }
+    standard_request_options(
+        :get,
+        'INDEX (as harvester)',
+        :forbidden,
+        {response_body_content: ['"data":null'], expected_json_path: get_json_error_path(:permissions)}
+    )
+  end
+
+
+  ################################
+  # CREATE
+  ################################
+
+  # any user can create a dataset item if they have read-access on the project
+
+  create_success_opts = {expected_json_path: 'data/activity/', response_body_content: ['"activity":"viewed"'] }
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { admin_token }
+    standard_request_options(
+        :post,
+        'CREATE (as admin)',
+        :created,
+        create_success_opts
+    )
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { owner_token }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(:post,'CREATE (as owner)',:created, create_success_opts)
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { writer_token }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(:post,'CREATE (as writer)',:created, create_success_opts)
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { reader_token }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(:post,'CREATE (as reader)',:created, create_success_opts)
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { no_access_token }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(
+        :post,
+        'CREATE (no access user)',
+        :forbidden,
+        {expected_json_path: get_json_error_path(:permissions)}
+    )
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { invalid_token }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(
+        :post,
+        'CREATE (invalid token)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)}
+    )
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(
+        :post,
+        'CREATE (as anonymous user)',
+        :unauthorized,
+        {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)}
+    )
+  end
+
+  post '/progress_events' do
+    body_params
+    let(:raw_post) { {'progress_event' => post_attributes}.to_json }
+    let(:authentication_token) { harvester_token }
+    let(:dataset_item_id) { dataset_item.id }
+    standard_request_options(
+        :post,
+        'CREATE (as harvester)',
+        :forbidden,
+        {expected_json_path: get_json_error_path(:permissions)})
+  end
+
+  # ################################
+  # # NEW
+  # ################################
+
+  get '/progress_events/new' do
+    let(:authentication_token) { admin_token }
+    standard_request_options(
+        :get,
+        'NEW (as admin)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+  get '/progress_events/new' do
+    let(:authentication_token) { owner_token }
+    standard_request_options(
+        :get,
+        'NEW (as owner)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+  get '/progress_events/new' do
+    let(:authentication_token) { writer_token }
+    standard_request_options(
+        :get,
+        'NEW (as writer)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+  get '/progress_events/new' do
+    let(:authentication_token) { reader_token }
+    standard_request_options(
+        :get,
+        'NEW (as reader)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+  get '/progress_events/new' do
+    let(:authentication_token) { no_access_token }
+    standard_request_options(
+        :get,
+        'NEW (as reader)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+  get '/progress_events/new' do
+    let(:authentication_token) { invalid_token }
+    standard_request_options(
+        :get,
+        'NEW (with invalid token)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)}
+    )
+  end
+
+  get '/progress_events/new' do
+    standard_request_options(
+        :get,
+        'NEW (as anonymous user)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+
+  get '/progress_events/new' do
+    let(:authentication_token) { harvester_token }
+    standard_request_options(
+        :get,
+        'NEW (as harvester)',
+        :forbidden,
+        {expected_json_path: get_json_error_path(:permissions)}
+    )
+  end
+
+  # ################################
+  # # SHOW
+  # ################################
+
+  show_success_opts = {expected_json_path: ['data/activity'], response_body_content: ['"activity":"viewed"']}
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { admin_token }
+    standard_request_options(
+        :get,
+        'SHOW (as admin)',
+        :ok,
+        {expected_json_path: 'data/activity'}
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { owner_token }
+    standard_request_options(
+        :get,
+        'SHOW (as owner)',
+        :ok,
+        show_success_opts
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { writer_token }
+    standard_request_options(
+        :get,
+        'SHOW (as writer)',
+        :ok,
+        show_success_opts
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { reader_token }
+    standard_request_options(
+        :get,
+        'SHOW (as reader)',
+        :ok,
+        show_success_opts
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { no_access_token }
+    standard_request_options(
+        :get,
+        'SHOW (as no access user)',
+        :forbidden,
+        {expected_json_path: get_json_error_path(:permissions)}
+    )
+  end
+
+  # does not have access to the dataset item, but created the progress event
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event_for_no_access_user.id }
+    let(:authentication_token) { no_access_token }
+    standard_request_options(
+        :get,
+        'SHOW (as no access user on progress event created by this user)',
+        :ok,
+        {expected_json_path: ['data/activity'], response_body_content: ['"activity":"played"']}
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { no_access_progress_event.id }
+    let(:authentication_token) { owner_token }
+    standard_request_options(
+        :get,
+        'SHOW (as no access user) 2',
+        :forbidden,
+        {expected_json_path: get_json_error_path(:permissions)}
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { invalid_token }
+    standard_request_options(
+        :get,
+        'SHOW (with invalid token)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)}
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    standard_request_options(
+        :get,
+        'SHOW (an anonymous user)',
+        :unauthorized,
+        {expected_json_path: get_json_error_path(:sign_up)}
+    )
+  end
+
+  get '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { harvester_token }
+    standard_request_options(
+        :get,
+        'SHOW (an anonymous user)',
+        :forbidden,
+        {response_body_content: ['"data":null'], expected_json_path: get_json_error_path(:permissions)}
+    )
+  end
+
+  # ################################
+  # # UPDATE
+  # ################################
+
+  # only admin can update
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { admin_token }
+    standard_request_options(
+        :put,
+        'UPDATE (as admin)',
+        :ok,
+        {expected_json_path: 'data/activity/', response_body_content: '"activity":"played"'}
+    )
+  end
+
+  forbidden_opts = {expected_json_path: get_json_error_path(:permissions)}
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { owner_token }
+    standard_request_options(:put, 'UPDATE (as owner)', :forbidden, forbidden_opts)
+  end
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { writer_token }
+    standard_request_options(:put, 'UPDATE (as writer)', :forbidden, forbidden_opts)
+  end
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { reader_token }
+    standard_request_options(:put, 'UPDATE (as reader)', :forbidden, forbidden_opts)
+  end
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { no_access_token }
+    standard_request_options(:put, 'UPDATE (as no access user)', :forbidden, forbidden_opts)
+  end
+
+  # can not update the progress event, even through is the creator
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event_for_no_access_user.id }
+    let(:raw_post) {  {progress_event: {activity: "viewed"}}.to_json }
+    let(:authentication_token) { no_access_token }
+    standard_request_options(:put, 'UPDATE (as no access user)', :forbidden, forbidden_opts)
+  end
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { invalid_token }
+    standard_request_options(:put, 'UPDATE (as invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+  end
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    standard_request_options(:put, 'UPDATE (as not logged in)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+  end
+
+  put '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:raw_post) {  {progress_event: {activity: "played"}}.to_json }
+    let(:authentication_token) { harvester_token }
+    standard_request_options(:put, 'UPDATE (as harvester)', :forbidden, forbidden_opts)
+  end
+
+  # ################################
+  # # DESTROY
+  # ################################
+
+  # only admin can destroy
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    let(:id) { progress_event.id }
+    let(:authentication_token) { admin_token }
+    standard_request_options(
+        :delete,
+        'DELETE (as admin user)',
+        :no_content,
+        {expected_response_has_content: false, expected_response_content_type: nil}
+    )
+  end
+
+  forbidden_opts = {expected_json_path: get_json_error_path(:permissions)}
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:authentication_token) { owner_token }
+    standard_request_options(:delete, 'DELETE (as owner)', :forbidden, forbidden_opts)
+  end
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:authentication_token) { writer_token }
+    standard_request_options(:delete, 'DELETE (as writer)', :forbidden, forbidden_opts)
+  end
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:authentication_token) { reader_token }
+    standard_request_options(:delete, 'DELETE (as reader)', :forbidden, forbidden_opts)
+  end
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:authentication_token) { no_access_token }
+    standard_request_options(:delete, 'DELETE (as no access user)', :forbidden, forbidden_opts)
+  end
+
+  # can not delete the progress event, even through is the creator
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event_for_no_access_user.id }
+    let(:authentication_token) { no_access_token }
+    standard_request_options(:delete, 'DELETE (as no access user)', :forbidden, forbidden_opts)
+  end
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:authentication_token) { invalid_token }
+    standard_request_options(:delete, 'DELETE (as invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+  end
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    standard_request_options(:delete, 'DELETE (as not logged in)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+  end
+
+  delete '/progress_events/:id' do
+    progress_event_id_param
+    body_params
+    let(:id) { progress_event.id }
+    let(:authentication_token) { harvester_token }
+    standard_request_options(:delete, 'DELETE (as harvester)', :forbidden, forbidden_opts)
+  end
+
+  # ################################
+  # # FILTER
+  # ################################
+
+
+  context 'filter progress events' do
+
+    # creates 40 progress events in addition to the existing 3
+    # This includes 8 that use the no_access_dataset_item (4 of each activity)
+    # So, with the original 3, there are 9 out of 43 that only admin user should find
+    # leaving 34 that other users (owner, reader, writer) should find
+    # One progress event is created by the no access user with the main dataset item. This user should
+    # therefore find that progress event only
+    prepare_many_progress_events
+
+    # admin finds all items (1 full page)
+    post '/progress_events/filter' do
+      let(:authentication_token) { admin_token }
+      standard_request_options(
+          :post,
+          'FILTER (as admin)',
+          :ok,
+          {
+              response_body_content: ['"activity":"viewed"'],
+              expected_json_path: 'data/0/dataset_item_id',
+              data_item_count: 25
+          }
+      )
+
+    end
+
+    # admin finds all items
+    post '/progress_events/filter' do
+      let(:authentication_token) { admin_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as admin)',
+          :ok,
+          {
+              response_body_content: ['"activity":"viewed"'],
+              expected_json_path: 'data/0/dataset_item_id',
+              data_item_count: 43
+          }
+      )
+    end
+
+    # permissions will be the same for reader,writer,owner so they will have
+    # the same response for the same filter params. Should return 6 items
+    # from the two datasets, but not the dataset item from the no-access hierarchy
+    regular_user_opts = {
+        response_body_content: ['"activity":"viewed"'],
+        expected_json_path: 'data/0/dataset_item_id',
+        data_item_count: 34
+    }
+
+    post '/progress_events/filter' do
+      let(:authentication_token) { owner_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(:post,'FILTER (as owner)',:ok,regular_user_opts)
+    end
+
+    post '/progress_events/filter' do
+      let(:authentication_token) { writer_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(:post,'FILTER (as writer)',:ok,regular_user_opts)
+    end
+
+    post '/progress_events/filter' do
+      let(:authentication_token) { reader_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(:post,'FILTER (as reader)',:ok,regular_user_opts)
+    end
+
+    # no-access user has is the creator of 1 progress event for a dataset_item that
+    # this user does not have access to, to simulate access to a progress event if the
+    # user has had access to the project revoked.
+    post '/progress_events/filter' do
+      let(:authentication_token) { no_access_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as no access)',
+          :ok,
+          {response_body_content: ['"order_by":"created_at"'], expected_json_path: 'data', data_item_count: 1})
+    end
+
+    post '/progress_events/filter' do
+      let(:authentication_token) { invalid_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as invalid token)',
+          :unauthorized,
+          {expected_json_path: get_json_error_path(:sign_up)})
+    end
+
+    # not logged in users can filter dataset items, but they won't get any items that they don't have permission for
+    post '/progress_events/filter' do
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as not logged in)',
+          :ok,
+          {response_body_content: ['"order_by":"created_at"'], expected_json_path: 'data', data_item_count: 0})
+    end
+
+    post '/progress_events/filter' do
+      let(:authentication_token) { harvester_token }
+      let(:raw_post) { {'paging' => {'items' => 100}}.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as harvester)',
+          :forbidden,
+          {response_body_content: ['"data":null'], expected_json_path: get_json_error_path(:permissions)}
+      )
+    end
+
+    # find only the "viewed" progress events
+    # out of the 33 accessible progress events, half + 1 are "viewed" = 17
+    post '/progress_events/filter' do
+      let(:authentication_token) { reader_token }
+      let(:raw_post) { {
+        'filter' => {
+            'activity' => {
+                'eq' => 'viewed'
+            }
+        },
+        'projection' => {
+            'include' => ['id', 'dataset_item_id', 'creator_id', 'created_at']
+        }
+      }.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as reader) where activity is "viewed"',
+          :ok,
+          {
+              expected_json_path: 'data/0/creator_id',
+              data_item_count: 17,
+              response_body_content: '"created_at":',
+              # activity is included in the projection
+              # the leading comma ensures we are looking in the data not meta
+              invalid_content: ',"activity":'
+          }
+      )
+    end
+
+    # find only the progress events created by owner or writer
+    # out of the 32 new progress non-no_access progress events, an equal amount were
+    # created by each user = 16 expected items
+    post '/progress_events/filter' do
+      let(:authentication_token) { admin_token }
+      let(:raw_post) { {
+          'filter' => {
+              'creator_id' => {
+                  'in' => [owner_user.id, writer_user.id]
+              }
+          }
+      }.to_json }
+      standard_request_options(
+          :post,
+          'FILTER (as admin) where creator is owner or writer',
+          :ok,
+          {
+              expected_json_path: 'data/0/creator_id',
+              data_item_count: 16,
+              response_body_content: '"created_at":'
+          }
+      )
+    end
+
+    # users can view progress events they created, even if they don't have access to the dataset item
+    post '/progress_events/filter' do
+      let(:authentication_token) { no_access_token }
+      standard_request_options(
+          :post,
+          'FILTER (as no access user)',
+          :ok,
+          {
+              response_body_content: ['"activity":"played"'],
+              expected_json_path: 'data/0/dataset_item_id',
+              data_item_count: 1
+          }
+      )
+    end
+
+  end
+
+end

--- a/spec/acceptance/projects_spec.rb
+++ b/spec/acceptance/projects_spec.rb
@@ -501,34 +501,46 @@ resource 'Projects' do
     })
   end
 
-  get '/projects/filter?direction=desc&filter_name=a&filter_partial_match=partial_match_text&items=35&order_by=createdAt&page=1' do
-    let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'BASIC FILTER (as reader with filtering, sorting, paging)', :ok, {
-        expected_json_path: 'meta/paging/current',
-        data_item_count: 0,
-        response_body_content: '/projects/filter?direction=desc\u0026filter_name=a\u0026filter_partial_match=partial_match_text\u0026items=35\u0026order_by=createdAt\u0026page=1'
-    })
+  context 'filter partial match' do
+
+    get '/projects/filter?direction=desc&filter_name=a&filter_partial_match=partial_match_text&items=35&order_by=createdAt&page=1' do
+      let(:authentication_token) { reader_token }
+      standard_request_options(:get, 'BASIC FILTER (as reader with filtering, sorting, paging)', :ok, {
+          expected_json_path: 'meta/paging/current',
+          data_item_count: 0,
+          response_body_content: '/projects/filter?direction=desc\u0026filter_name=a\u0026filter_partial_match=partial_match_text\u0026items=35\u0026order_by=createdAt\u0026page=1'
+      })
+    end
+
   end
 
-  get '/projects/filter?disable_paging=true' do
-    let(:authentication_token) { writer_token }
-    let!(:more_projects) {
-      # default items per page is 25
-      29.times do
-        FactoryGirl.create(:project, creator: writer_permission.user)
-      end
-    }
+  context 'filter with paging via GET' do
 
-    standard_request_options(:get, 'BASIC FILTER (as reader with filtering, paging disabled)', :ok, {
-        expected_json_path: 'meta/paging/current',
-        data_item_count: 30,
-        response_body_content: [
-            '{"meta":{"status":200,"message":"OK","sorting":{"order_by":"name","direction":"asc"},',
-            '"paging":{"page":1,"items":30,"total":30,"max_page":1,',
-            '"current":"http://localhost:3000/projects/filter?direction=asc\u0026disable_paging=true\u0026items=30\u0026order_by=name\u0026page=1",',
-            '"previous":null,"next":null}}'
-        ]
-    })
+    get '/projects/filter?page=1&items=2' do
+      let(:authentication_token) { writer_token }
+      let!(:more_projects) {
+        # default items per page is 25
+        29.times do
+          FactoryGirl.create(:project, creator: writer_permission.user)
+        end
+      }
+
+      standard_request_options(:get, 'BASIC FILTER (as reader with paging)', :ok, {
+          expected_json_path: 'meta/paging/current',
+          data_item_count: 2,
+          response_body_content: [
+              '"paging":{"page":1,"items":2,"total":30,"max_page":15',
+              '"current":"http://localhost:3000/projects/filter?direction=asc\u0026items=2\u0026order_by=name\u0026page=1"',
+              '"previous":null,',
+              '"next":"http://localhost:3000/projects/filter?direction=asc\u0026items=2\u0026order_by=name\u0026page=2"'
+          ]
+      })
+    end
+
   end
+
+
+
+
 
 end

--- a/spec/factories/dataset_item_factory.rb
+++ b/spec/factories/dataset_item_factory.rb
@@ -1,13 +1,29 @@
 FactoryGirl.define do
+
   factory :dataset_item do
 
     start_time_seconds 11
     sequence(:end_time_seconds) { |n| n*20.2 }
     sequence(:order) { |n| (n+10.0)/2 }
 
+    audio_recording
+    creator
     dataset
+
+  end
+
+  # this one doesn't try to create a new dataset if dataset is not passed
+  # and instead just assigns the dataset id for the default dataset
+  factory :default_dataset_item, class: 'DatasetItem' do
+
+    start_time_seconds 1441
+    end_time_seconds 1442
+    sequence(:order) { |n| (n+10.0)/2 }
+
+    dataset_id 1
     audio_recording
     creator
 
   end
+
 end

--- a/spec/factories/dataset_item_factory.rb
+++ b/spec/factories/dataset_item_factory.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
     end_time_seconds 1442
     sequence(:order) { |n| (n+10.0)/2 }
 
-    dataset_id 1
+    dataset_id Dataset.default_dataset_id
     audio_recording
     creator
 

--- a/spec/lib/creation.rb
+++ b/spec/lib/creation.rb
@@ -51,7 +51,9 @@ module Creation
       let!(:no_access_project_creator) { FactoryGirl.create(:user, user_name: 'creator_2') }
       let!(:no_access_project) { Common.create_project(no_access_project_creator) }
       let!(:no_access_site) { Common.create_site(no_access_project_creator, no_access_project) }
-      let!(:no_access_audio_recording) { Common.create_audio_recording(no_access_project_creator, no_access_project_creator, no_access_site) }
+      let!(:no_access_audio_recording) {
+        Common.create_audio_recording(no_access_project_creator, no_access_project_creator, no_access_site)
+      }
       let!(:no_access_dataset_item) { Common.create_dataset_item(admin_user, dataset, no_access_audio_recording) }
       let!(:no_access_progress_event) {
         Common.create_progress_event(admin_user, no_access_dataset_item)
@@ -116,11 +118,15 @@ module Creation
     end
 
     def prepare_permission_writer
-      let!(:writer_permission) { FactoryGirl.create(:write_permission, creator: owner_user, user: writer_user, project: project) }
+      let!(:writer_permission) {
+        FactoryGirl.create(:write_permission, creator: owner_user, user: writer_user, project: project)
+      }
     end
 
     def prepare_permission_reader
-      let!(:reader_permission) { FactoryGirl.create(:read_permission, creator: owner_user, user: reader_user, project: project) }
+      let!(:reader_permission) {
+        FactoryGirl.create(:read_permission, creator: owner_user, user: reader_user, project: project)
+      }
     end
 
     def prepare_project_anon
@@ -262,7 +268,13 @@ module Creation
       end
 
       def create_audio_recording(creator, uploader, site)
-        FactoryGirl.create(:audio_recording, :status_ready, creator: creator, uploader: uploader, site: site, sample_rate_hertz: 44100)
+        FactoryGirl.create(
+            :audio_recording,
+            :status_ready,
+            creator: creator,
+            uploader: uploader,
+            site: site,
+            sample_rate_hertz: 44100)
       end
 
       def create_bookmark(creator, audio_recording)

--- a/spec/lib/creation.rb
+++ b/spec/lib/creation.rb
@@ -192,8 +192,6 @@ module Creation
       }
       let!(:progress_event_for_no_access_user) {
         # create a progress event where the creator does not have read permissions
-        # To test that a user always has access to their own progress events, even if
-        # project permission has been revoked
         Common.create_progress_event_full(no_access_user, dataset_item, "played")
       }
     end

--- a/spec/lib/creation.rb
+++ b/spec/lib/creation.rb
@@ -187,8 +187,10 @@ module Creation
     end
 
     def prepare_progress_event
+      let!(:default_dataset_item) {
+        FactoryGirl.create(:default_dataset_item, creator: writer_user, audio_recording: audio_recording)
+      }
       let!(:progress_event) {
-        default_dataset_item = FactoryGirl.create(:default_dataset_item, creator: writer_user, audio_recording: audio_recording)
         Common.create_progress_event(admin_user, default_dataset_item)
       }
       let!(:progress_event_for_no_access_user) {
@@ -224,7 +226,6 @@ module Creation
 
       }
     end
-
 
   end
 

--- a/spec/lib/creation.rb
+++ b/spec/lib/creation.rb
@@ -188,7 +188,8 @@ module Creation
 
     def prepare_progress_event
       let!(:progress_event) {
-        Common.create_progress_event(admin_user, dataset_item)
+        default_dataset_item = FactoryGirl.create(:default_dataset_item, creator: writer_user, audio_recording: audio_recording)
+        Common.create_progress_event(admin_user, default_dataset_item)
       }
       let!(:progress_event_for_no_access_user) {
         # create a progress event where the creator does not have read permissions

--- a/spec/lib/creation.rb
+++ b/spec/lib/creation.rb
@@ -62,6 +62,27 @@ module Creation
     end
 
 
+    # creates an project with public (allow anon) permissions
+    # as well as a site, audio recording and dataset item
+    def create_anon_hierarchy
+
+      prepare_project_anon
+
+      let!(:site_anon) {
+        Common.create_site(owner_user, project_anon)
+      }
+
+      let!(:audio_recording_anon) {
+        Common.create_audio_recording(writer_user, writer_user, site_anon)
+      }
+
+      let!(:dataset_item_anon) {
+        Common.create_dataset_item(admin_user, dataset, audio_recording_anon)
+      }
+
+    end
+
+
     # create audio recordings and all parent entities
     def create_audio_recordings_hierarchy
       prepare_users

--- a/spec/lib/creation.rb
+++ b/spec/lib/creation.rb
@@ -31,6 +31,8 @@ module Creation
 
       prepare_dataset_item
 
+      prepare_progress_event
+
     end
 
     # similar to create entire hierarchy
@@ -51,6 +53,9 @@ module Creation
       let!(:no_access_site) { Common.create_site(no_access_project_creator, no_access_project) }
       let!(:no_access_audio_recording) { Common.create_audio_recording(no_access_project_creator, no_access_project_creator, no_access_site) }
       let!(:no_access_dataset_item) { Common.create_dataset_item(admin_user, dataset, no_access_audio_recording) }
+      let!(:no_access_progress_event) {
+        Common.create_progress_event(admin_user, no_access_dataset_item)
+      }
 
     end
 
@@ -181,6 +186,46 @@ module Creation
       let!(:dataset_item) { Common.create_dataset_item(admin_user, dataset, audio_recording) }
     end
 
+    def prepare_progress_event
+      let!(:progress_event) {
+        Common.create_progress_event(admin_user, dataset_item)
+      }
+      let!(:progress_event_for_no_access_user) {
+        # create a progress event where the creator does not have read permissions
+        # To test that a user always has access to their own progress events, even if
+        # project permission has been revoked
+        Common.create_progress_event_full(no_access_user, dataset_item, "played")
+      }
+    end
+
+    # creates a whole lot of progress events for filter testing
+    def prepare_many_progress_events
+      let!(:progress_events_stats) {
+
+        creators = [admin_user, owner_user, reader_user, writer_user]
+        activities = ["viewed", "played"]
+        dataset_items = [dataset_item, no_access_dataset_item]
+        num = 4
+        result = []
+
+        for c in creators do
+          for a in activities do
+            for d in dataset_items do
+              for n in 1..num do
+                if c == admin_user || d != no_access_dataset_item
+                  Common.create_progress_event_full(c, d, a)
+                  result.push({creator_id: c.id, dataset_item_id: d.id, activity: a})
+                end
+              end
+            end
+          end
+        end
+
+        return result
+
+      }
+    end
+
 
   end
 
@@ -262,6 +307,14 @@ module Creation
 
       def create_dataset_item(creator, dataset, audio_recording)
         FactoryGirl.create(:dataset_item, creator: creator, dataset: dataset, audio_recording: audio_recording)
+      end
+
+      def create_progress_event(creator, dataset_item)
+        FactoryGirl.create(:progress_event, creator: creator, dataset_item: dataset_item)
+      end
+
+      def create_progress_event_full(creator, dataset_item, activity)
+        FactoryGirl.create(:progress_event, creator: creator, dataset_item: dataset_item, activity: activity)
       end
 
     end

--- a/spec/lib/creation_spec.rb
+++ b/spec/lib/creation_spec.rb
@@ -56,7 +56,7 @@ describe 'creation helper' do
     expect(AnalysisJobsItem.first.id).to eq(AudioRecording.first.analysis_jobs_items.first.id)
 
     expect(Dataset.count).to eq(2)
-    expect(DatasetItem.count).to eq(1)
+    expect(DatasetItem.count).to eq(2)
     expect(Dataset.all[1].id).to eq(DatasetItem.first.dataset_id)
 
   end

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -123,6 +123,163 @@ describe "Dataset Items" do
 
   end
 
+  describe "filter by unseen dataset items" do
+
+    def filter_and_sort_for_comparison (items, user)
+
+      # filter only dataset items with the right dataset id
+      filtered = items.select { |item| item[:dataset_item][:dataset_id] == dataset.id }
+
+      # sort by number of views, number of own views, id
+      sorted = filtered.sort_by { |item| [
+          # number of progress events of type "viewed"
+          (item[:progress_events].select { |progress_event| progress_event.activity == "viewed"}).size,
+          # number of progress events of type "viewed" created by the user
+          (item[:progress_events].select { |progress_event| progress_event.activity == "viewed" && progress_event.creator_id == user.id}).size,
+          # dataset item id
+          item[:dataset_item][:id]
+      ] }
+
+      # get the ids in the order we expect them back
+      sorted_ids = sorted.map { |item| item[:dataset_item][:id]}
+
+      sorted_ids
+
+    end
+
+
+
+    before(:each) do
+      @env['CONTENT_TYPE'] = "application/json"
+      @dataset_item_filter_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/filter"
+      @dataset_item_filter_todo_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/filter_todo"
+    end
+
+
+
+
+    # creates 12 dataset items. Every 3rd dataset item has a progress event created by the writer user
+    # and every 2nd has a progress event created by the reader user.
+    # Half the items are with one audio_recording and the other half with another (alternating between them)
+    # Resulting in dataset items 2,4,6,8,10,12 viewed by reader and
+    # 3,6,9,12 viewed by writer, and 6,12 viewed by both and 1,5,7,11 not viewed
+    # Adding these to the 1 dataset item already created in the create_entire_hierarchy, which
+    # has a progress event, there are 13 dataset items, 4 of which are not viewed
+    let(:many_dataset_items_some_with_events) {
+
+      # start with the 2 dataset items created in the entire hierarchy
+      results = [
+          {dataset_item: dataset_item, progress_events: [progress_event_for_no_access_user]},
+          {dataset_item: default_dataset_item, progress_events: [progress_event]}
+      ]
+
+      progress_event_creators = [
+          {creator: writer_user, view_every: 3},
+          {creator: reader_user, view_every: 2},
+      ]
+      num_dataset_items = 12
+
+      # create another audio recording so we can make sure the order is not affected by the audio recording id
+      another_audio_recording = FactoryGirl.create(:audio_recording, :status_ready, creator: writer_user, uploader: writer_user, site: site, sample_rate_hertz: 22050)
+
+      audio_recordings = [audio_recording, another_audio_recording]
+
+      for d in 1..num_dataset_items do
+
+        # create a dataset item with alternating audio recording id
+        dataset_item = FactoryGirl.create(:dataset_item,
+                                          creator: admin_user,
+                                          dataset: dataset,
+                                          audio_recording: audio_recordings[d % 2],
+                                          start_time_seconds: d,
+                                          end_time_seconds: d+10,
+                                          order: d)
+        dataset_item.save!
+
+        cur_data = {dataset_item: dataset_item, progress_events: [], progress_event_count: 0 }
+
+        for c in progress_event_creators do
+          progress_event = nil
+          if d % c[:view_every] == 0
+            progress_event = FactoryGirl.create(:progress_event, creator: c[:creator], dataset_item: dataset_item, activity: "viewed", created_at: "2017-01-01 12:34:56")
+            #has_saved = progress_event.save!
+            cur_data[:progress_events].push(progress_event)
+          end
+        end
+
+        results.push(cur_data)
+      end
+
+      results
+
+    }
+
+
+    let(:raw_post) {
+      {
+          sorting: {
+              order_by: :priority
+          }
+      }.to_json
+    }
+
+    it 'gets all dataset items' do
+
+      many_dataset_items_some_with_events
+      post @dataset_item_filter_url, raw_post, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(200)
+
+    end
+
+    it 'orders dataset items by least viewed first (admin user)' do
+
+      # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
+      all_dataset_items =  many_dataset_items_some_with_events
+      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, admin_user)
+      get @dataset_item_filter_todo_url, nil, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(200)
+      ids = parsed_response["data"].map { |item| item["id"] }
+      expect(ids).to eq(sorted_ids)
+
+    end
+
+
+    it 'orders dataset items by least viewed first (writer user)' do
+
+      @env['HTTP_AUTHORIZATION'] = writer_token
+
+      # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
+      all_dataset_items =  many_dataset_items_some_with_events
+      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, writer_user)
+      get @dataset_item_filter_todo_url, nil, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(200)
+      ids = parsed_response["data"].map { |item| item["id"] }
+      expect(ids).to eq(sorted_ids)
+
+    end
+
+    it 'orders dataset items by least viewed first (reader user)' do
+
+      @env['HTTP_AUTHORIZATION'] = reader_token
+
+      # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
+      all_dataset_items =  many_dataset_items_some_with_events
+      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, reader_user)
+      get @dataset_item_filter_todo_url, nil, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(200)
+      ids = parsed_response["data"].map { |item| item["id"] }
+      expect(ids).to eq(sorted_ids)
+
+    end
+
+
+  end
+
+
 end
 
 

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -122,9 +122,38 @@ describe "Dataset Items" do
 
   end
 
-  describe "filter by unseen dataset items" do
+  describe "filter" do
 
-    def filter_and_sort_for_comparison (items, user)
+    it 'does not allow arbitrary string in sort column' do
+
+      @env['CONTENT_TYPE'] = "application/json"
+      params = {
+          sorting: {
+              order_by: "; select * from projects",
+              direction: "desc"
+          }
+      }.to_json
+
+      post "/dataset_items/filter", params, @env
+      expect(response).to have_http_status(400)
+
+    end
+
+  end
+
+  describe "list next for me" do
+
+    # filters sorts and pages an array of dataset items
+    # to mirror what should be returned by the api, so that it can be compared
+    # @param items, array of created dataset items
+    # @user User object. The sort order is dependent on the user
+    # @page int which page to get
+    # @limit int how many items per page
+    def filter_and_sort_for_comparison (items, user, page = nil, limit = nil)
+
+      # if limit is not supplied, default is 25
+      limit = limit || 25
+      page = page || 1
 
       # filter only dataset items with the right dataset id
       filtered = items.select { |item| item[:dataset_item][:dataset_id] == dataset.id }
@@ -146,6 +175,13 @@ describe "Dataset Items" do
       # get the ids in the order we expect them back
       sorted_ids = sorted.map { |item| item[:dataset_item][:id]}
 
+      from_index = (page - 1) * limit
+      to_index = from_index + limit - 1
+
+      from_index = [from_index, sorted_ids.count].min
+      to_index = [to_index, sorted_ids.count].min
+      sorted_ids = sorted_ids[from_index..to_index]
+
       sorted_ids
 
     end
@@ -153,7 +189,7 @@ describe "Dataset Items" do
     before(:each) do
       @env['CONTENT_TYPE'] = "application/json"
       @dataset_item_filter_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/filter"
-      @dataset_item_filter_todo_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/filter_todo"
+      @dataset_item_next_for_me_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/next_for_me"
     end
 
     # creates 12 dataset items. Every 3rd dataset item has a progress event created by the writer user
@@ -171,11 +207,17 @@ describe "Dataset Items" do
           {dataset_item: default_dataset_item, progress_events: [progress_event]}
       ]
 
+      # create a progress event for the writer user on every 3rd dataset item
+      # and a progress event for the reader user on every 2nd dataset item.
+      # some dataset items will have no progress events, some by writer only, some by
+      # reader only and some by both
       progress_event_creators = [
           {creator: writer_user, view_every: 3},
           {creator: reader_user, view_every: 2},
       ]
-      num_dataset_items = 12
+
+      # make more than 25 to test paging
+      num_dataset_items = 32
 
       # create another audio recording so we can make sure the order is not affected by the audio recording id
       another_audio_recording = FactoryGirl.create(
@@ -191,9 +233,11 @@ describe "Dataset Items" do
       # random number generator with seed
       my_rand = Random.new(99)
 
+      # create the dataset items one at a time
       for d in 1..num_dataset_items do
 
         # create a dataset item with alternating audio recording id
+        # So that we can test the audio recording does not affect the order
         dataset_item = FactoryGirl.create(:dataset_item,
                                           creator: admin_user,
                                           dataset: dataset,
@@ -203,8 +247,11 @@ describe "Dataset Items" do
                                           order: my_rand.rand * 10)
         dataset_item.save!
 
-        cur_data = {dataset_item: dataset_item, progress_events: [], progress_event_count: 0 }
+        current_data = {dataset_item: dataset_item, progress_events: [], progress_event_count: 0 }
 
+        # for this dataset item, add a progress even for zero or more of the users
+        # If this dataset item is the nth created, add progress events for those users
+        # who's view_every value is a factor of n.
         for c in progress_event_creators do
           progress_event = nil
           if d % c[:view_every] == 0
@@ -214,12 +261,12 @@ describe "Dataset Items" do
                 dataset_item: dataset_item,
                 activity: "viewed",
                 created_at: "2017-01-01 12:34:56")
-            #has_saved = progress_event.save!
-            cur_data[:progress_events].push(progress_event)
+
+            current_data[:progress_events].push(progress_event)
           end
         end
 
-        results.push(cur_data)
+        results.push(current_data)
       end
 
       results
@@ -247,8 +294,8 @@ describe "Dataset Items" do
 
       # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
       all_dataset_items =  many_dataset_items_some_with_events
-      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, admin_user)
-      get @dataset_item_filter_todo_url, nil, @env
+      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, admin_user, 1, 25)
+      get @dataset_item_next_for_me_url, nil, @env
       parsed_response = JSON.parse(response.body)
       expect(response).to have_http_status(200)
       ids = parsed_response["data"].map { |item| item["id"] }
@@ -262,8 +309,8 @@ describe "Dataset Items" do
 
       # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
       all_dataset_items =  many_dataset_items_some_with_events
-      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, writer_user)
-      get @dataset_item_filter_todo_url, nil, @env
+      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, writer_user, 1, 25)
+      get @dataset_item_next_for_me_url, nil, @env
       parsed_response = JSON.parse(response.body)
       expect(response).to have_http_status(200)
       ids = parsed_response["data"].map { |item| item["id"] }
@@ -277,8 +324,8 @@ describe "Dataset Items" do
 
       # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
       all_dataset_items =  many_dataset_items_some_with_events
-      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, reader_user)
-      get @dataset_item_filter_todo_url, nil, @env
+      sorted_ids = filter_and_sort_for_comparison(all_dataset_items, reader_user, 1, 25)
+      get @dataset_item_next_for_me_url, nil, @env
       parsed_response = JSON.parse(response.body)
       expect(response).to have_http_status(200)
       ids = parsed_response["data"].map { |item| item["id"] }
@@ -286,8 +333,82 @@ describe "Dataset Items" do
 
     end
 
-  end
+    describe "batch check paging" do
 
+      # for each user, check different combinations of page number and limit/items
+      # to make sure that the correct items are returned for that user, and that the paging
+      # metadata is also correct
+
+      let (:user_tokens) { [admin_token, writer_token, reader_token] }
+      let (:users) { [admin_user, writer_user, reader_user] }
+      users_description = ['admin', 'writer', 'reader']
+      pages = [1, 20, nil]
+      limits = [1, 7, 40, nil]
+
+      combos = (0..(users_description.length-1)).to_a
+                   .product(pages, limits).map { |c| { u: c[0], page: c[1], limit: c[2] } }
+
+      combos.each do | combo |
+
+        u = combo[:u]
+        page = combo[:page]
+        limit = combo[:limit]
+
+        it "orders items correctly for #{users_description[u]} page #{page} limit #{limit} " do
+
+          @env['HTTP_AUTHORIZATION'] = user_tokens[u]
+
+          # create an array that has the stuff from create_entire_hierarchy as well as the stuff created above
+          # this runs on every iteration ... so it's slow!
+          all_dataset_items =  many_dataset_items_some_with_events
+          sorted_ids = filter_and_sort_for_comparison(all_dataset_items, users[u], page, limit)
+          qsp = {}
+          qsp[:page] = page if page
+          qsp[:items] = limit if limit
+          get @dataset_item_next_for_me_url, qsp, @env
+          parsed_response = JSON.parse(response.body)
+
+          expect(response).to have_http_status(200)
+          ids = parsed_response["data"].map { |item| item["id"] }
+          expect(ids).to eq(sorted_ids)
+
+          expected_page = page ? page : 1
+          expected_items = limit ? limit : 25
+          # all items this user should see, but with no limit
+          expected_total = filter_and_sort_for_comparison(all_dataset_items, users[u], 1, 10000).count
+          expected_max_page = (expected_total.to_f / expected_items).ceil
+
+          paging_response = parsed_response.dig('meta', 'paging')
+
+          expect(paging_response).to be_a(Hash)
+
+          if paging_response
+            paging_numbers = paging_response.slice('page', 'items', 'total', 'max_page').symbolize_keys
+            expected_paging_numbers = { page: expected_page, items: expected_items, total: expected_total, max_page: expected_max_page }
+            paging_numbers.should == expected_paging_numbers
+
+            # next, previous and current pages are limited to between 1 and max_page (inclusive)
+            # if next or previous ends up being the same as current after this limiting, it is not included
+            if expected_page < expected_max_page
+              expect(paging_response['next']).to be_a(String)
+            else
+              expect(paging_response['next']).to be(nil)
+            end
+
+            # if expected_page were > expected_max_page, the link to current and previous
+            # would both be a link to the max page, so prev would not be included
+            if expected_page > 1 && expected_page <= expected_max_page
+              expect(paging_response['previous']).to be_a(String)
+            else
+              expect(paging_response['previous']).to be(nil)
+            end
+
+          end
+
+        end
+      end
+    end
+  end
 end
 
 

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -75,7 +75,6 @@ describe "Dataset Items" do
 
   end
 
-
   describe 'Updating a dataset item' do
 
     it 'does not allow text/plain content-type' do
@@ -147,16 +146,11 @@ describe "Dataset Items" do
 
     end
 
-
-
     before(:each) do
       @env['CONTENT_TYPE'] = "application/json"
       @dataset_item_filter_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/filter"
       @dataset_item_filter_todo_url = "/datasets/#{dataset_item.dataset_id}/dataset_items/filter_todo"
     end
-
-
-
 
     # creates 12 dataset items. Every 3rd dataset item has a progress event created by the writer user
     # and every 2nd has a progress event created by the reader user.
@@ -214,7 +208,6 @@ describe "Dataset Items" do
 
     }
 
-
     let(:raw_post) {
       {
           sorting: {
@@ -244,7 +237,6 @@ describe "Dataset Items" do
       expect(ids).to eq(sorted_ids)
 
     end
-
 
     it 'orders dataset items by least viewed first (writer user)' do
 
@@ -276,9 +268,7 @@ describe "Dataset Items" do
 
     end
 
-
   end
-
 
 end
 

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -134,7 +134,9 @@ describe "Dataset Items" do
           # number of progress events of type "viewed"
           (item[:progress_events].select { |progress_event| progress_event.activity == "viewed"}).size,
           # number of progress events of type "viewed" created by the user
-          (item[:progress_events].select { |progress_event| progress_event.activity == "viewed" && progress_event.creator_id == user.id}).size,
+          (item[:progress_events].select { |progress_event|
+            progress_event.activity == "viewed" && progress_event.creator_id == user.id
+          }).size,
           # order
           item[:dataset_item][:order],
           # dataset item id
@@ -176,7 +178,13 @@ describe "Dataset Items" do
       num_dataset_items = 12
 
       # create another audio recording so we can make sure the order is not affected by the audio recording id
-      another_audio_recording = FactoryGirl.create(:audio_recording, :status_ready, creator: writer_user, uploader: writer_user, site: site, sample_rate_hertz: 22050)
+      another_audio_recording = FactoryGirl.create(
+          :audio_recording,
+          :status_ready,
+          creator: writer_user,
+          uploader: writer_user,
+          site: site,
+          sample_rate_hertz: 22050)
 
       audio_recordings = [audio_recording, another_audio_recording]
 
@@ -200,7 +208,12 @@ describe "Dataset Items" do
         for c in progress_event_creators do
           progress_event = nil
           if d % c[:view_every] == 0
-            progress_event = FactoryGirl.create(:progress_event, creator: c[:creator], dataset_item: dataset_item, activity: "viewed", created_at: "2017-01-01 12:34:56")
+            progress_event = FactoryGirl.create(
+                :progress_event,
+                creator: c[:creator],
+                dataset_item: dataset_item,
+                activity: "viewed",
+                created_at: "2017-01-01 12:34:56")
             #has_saved = progress_event.save!
             cur_data[:progress_events].push(progress_event)
           end

--- a/spec/requests/dataset_items_spec.rb
+++ b/spec/requests/dataset_items_spec.rb
@@ -135,6 +135,8 @@ describe "Dataset Items" do
           (item[:progress_events].select { |progress_event| progress_event.activity == "viewed"}).size,
           # number of progress events of type "viewed" created by the user
           (item[:progress_events].select { |progress_event| progress_event.activity == "viewed" && progress_event.creator_id == user.id}).size,
+          # order
+          item[:dataset_item][:order],
           # dataset item id
           item[:dataset_item][:id]
       ] }
@@ -178,6 +180,9 @@ describe "Dataset Items" do
 
       audio_recordings = [audio_recording, another_audio_recording]
 
+      # random number generator with seed
+      my_rand = Random.new(99)
+
       for d in 1..num_dataset_items do
 
         # create a dataset item with alternating audio recording id
@@ -187,7 +192,7 @@ describe "Dataset Items" do
                                           audio_recording: audio_recordings[d % 2],
                                           start_time_seconds: d,
                                           end_time_seconds: d+10,
-                                          order: d)
+                                          order: my_rand.rand * 10)
         dataset_item.save!
 
         cur_data = {dataset_item: dataset_item, progress_events: [], progress_event_count: 0 }

--- a/spec/requests/datasets_spec.rb
+++ b/spec/requests/datasets_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+require 'rspec/mocks'
+
+describe "Datasets" do
+
+  create_entire_hierarchy
+
+  let(:dataset_attributes) {
+    FactoryGirl.attributes_for(:dataset)
+  }
+
+  before(:each) do
+    @env ||= {}
+    @env['HTTP_AUTHORIZATION'] = admin_token
+    @env['CONTENT_TYPE'] = "application/json"
+  end
+
+  describe 'Creating a dataset' do
+
+    it 'does not allow a new dataset to be named default' do
+      params = {dataset: dataset_attributes.merge({ name: 'default'})}.to_json
+      post '/datasets', params, @env
+      expect(response).to have_http_status(422)
+      expect(Dataset.where(name: 'default').count).to eq(1)
+    end
+
+  end
+
+  describe 'Updating a dataset' do
+
+    it 'does not allow a dataset to be renamed to default' do
+      params = {dataset: { name: 'default'}}.to_json
+      put "/datasets/#{dataset.id}", params, @env
+      expect(response).to have_http_status(422)
+      expect(Dataset.where(name: 'default').count).to eq(1)
+    end
+
+  end
+
+end
+
+
+

--- a/spec/requests/progress_events_spec.rb
+++ b/spec/requests/progress_events_spec.rb
@@ -40,6 +40,7 @@ describe "Progress Events" do
 
   let(:progress_event_attributes_invalid_dataset_item_id) {
     attributes = progress_event_attributes
+    # set the dataset_item_id attribute for the progress events that definitely does not exist
     attributes[:dataset_item_id] = 38921111
     attributes
   }
@@ -209,7 +210,7 @@ describe "Progress Events" do
     end
 
     # specifying the dataset by name rather than id is available only for the default dataset
-    # As it is the only one where name is guaranteed to be unique. 
+    # 
     it 'Responds with 404 if dataset_id is the name of a dataset other than default' do
       url = create_by_dataset_item_params_path(
           another_dataset_item,

--- a/spec/requests/progress_events_spec.rb
+++ b/spec/requests/progress_events_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 require 'rspec/mocks'
 
+# create the url for create_by_dataset_item_params based on the dataset item
+# @param dataset_item Object to use for the dataset item params
+# @param params Hash any values to use instead of the dataset_item's values
+def create_by_dataset_item_params_path (dataset_item, params = {})
+  valid_params = [:dataset_id, :audio_recording_id, :start_time_seconds, :end_time_seconds]
+  params = values_to_string(dataset_item.attributes.symbolize_keys.slice(*valid_params).merge(params.symbolize_keys.slice(*valid_params)))
+  url = "/datasets/#{params[:dataset_id]}/progress_events/audio_recordings/#{params[:audio_recording_id]}/start/#{params[:start_time_seconds]}/end/#{params[:end_time_seconds]}"
+  { path: url, params: params }
+end
+
 describe "Progress Events" do
 
   create_entire_hierarchy
@@ -9,19 +19,43 @@ describe "Progress Events" do
     FactoryGirl.attributes_for(:progress_event, {dataset_item_id: dataset_item.id})
   }
 
+  let!(:another_dataset_item) {
+    another_dataset_item = FactoryGirl.create(:dataset_item,
+                                      creator: writer_user,
+                                      dataset: dataset,
+                                      audio_recording: audio_recording,
+                                      start_time_seconds: 23,
+                                      end_time_seconds: 33,
+                                      order: 55.5)
+    another_dataset_item
+  }
+
   let(:progress_event_attributes_invalid_dataset_item_id) {
     attributes = progress_event_attributes
     attributes[:dataset_item_id] = 38921111
     attributes
   }
 
+  let(:progress_event_attributes_2) {
+    attributes = progress_event_attributes.dup
+    attributes.delete(:dataset_item_id)
+    attributes
+  }
+
   before(:each) do
     @env ||= {}
-    @env['HTTP_AUTHORIZATION'] = admin_token
+    @env['HTTP_AUTHORIZATION'] = reader_token
     @env['CONTENT_TYPE'] = "application/json"
 
     @create_progress_event_url = "/progress_events"
     @update_progress_event_url = "/progress_events/#{progress_event.id}"
+  end
+
+  # converts values of a hash to string
+  # not recursive: does not work on nested hashes
+  def values_to_string hash
+    hash.each { |key,val| hash[key] = val.to_s }
+    hash
   end
 
   describe 'Creating a progress event' do
@@ -36,15 +70,123 @@ describe "Progress Events" do
 
   describe 'Updating a progress event' do
 
-    it 'does not allow a non-existent dataset item id' do
+    it 'does not allow a non-existent dataset item id (admin user)' do
+      @env['HTTP_AUTHORIZATION'] = admin_token
       params = {progress_event: progress_event_attributes_invalid_dataset_item_id}.to_json
       put @update_progress_event_url, params, @env
       expect(response).to have_http_status(422)
     end
 
+    it 'does not allow a non-existent dataset item id (owner user)' do
+      @env['HTTP_AUTHORIZATION'] = owner_token
+      params = {progress_event: progress_event_attributes_invalid_dataset_item_id}.to_json
+      put @update_progress_event_url, params, @env
+      expect(response).to have_http_status(403)
+    end
+
+  end
+
+  describe 'Creating a progress event by dataset item parameters' do
+
+    let! (:num_progress_events_before) { ProgressEvent.count }
+    let! (:num_dataset_items_before) { DatasetItem.count }
+
+    # checks if the number of progress events and dataset items after the request is what is expected
+    # @param expect_new_progress_event Boolean should 1 new progress event have been added?
+    # @param expect_new_dataset_item Boolean should 1 new dataset_item have been added?
+    def check_counts (expect_new_progress_event = false, expect_new_dataset_item = false)
+
+      num_expected_progress_events = num_progress_events_before
+      if expect_new_progress_event
+        num_expected_progress_events += 1
+      end
+      num_expected_dataset_items = num_dataset_items_before
+      if expect_new_dataset_item
+        num_expected_dataset_items += 1
+      end
+
+      expect(ProgressEvent.count).to eq(num_expected_progress_events)
+      expect(DatasetItem.count).to eq(num_expected_dataset_items)
+
+    end
+
+    describe 'using parameters of existing dataset item' do
+
+      let (:valid_url) {
+        create_by_dataset_item_params_path(another_dataset_item)
+      }
+
+      it 'Creates a progress event when user has access to audio recording' do
+        params = {progress_event: progress_event_attributes_2}.to_json
+        post valid_url[:path], params, @env
+        parsed_response = JSON.parse(response.body)
+        expect(response).to have_http_status(201)
+        expect(parsed_response['data']['dataset_item_id']).to eq(another_dataset_item.id)
+        check_counts true, false
+      end
+
+      it 'responds with :forbidden if user does not have access to audio recording' do
+        @env['HTTP_AUTHORIZATION'] = no_access_token
+        params = {progress_event: progress_event_attributes_2}.to_json
+        post valid_url[:path], params, @env
+        expect(response).to have_http_status(:forbidden)
+        check_counts
+      end
+
+    end
+
+    it 'Returns 422 when parameters do not match existing dataset item for non-default dataset' do
+      url = create_by_dataset_item_params_path(another_dataset_item, {'end_time_seconds' => another_dataset_item.end_time_seconds + 1})
+      params = {progress_event: progress_event_attributes_2}.to_json
+      post url[:path], params, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(422)
+      expect(values_to_string(parsed_response['meta']['error']['info']).symbolize_keys).to eq(url[:params])
+      check_counts
+    end
+
+    describe 'using parameters of non-existing dataset item in default dataset' do
+
+      let (:url) {
+        create_by_dataset_item_params_path(default_dataset_item, {'start_time_seconds' => default_dataset_item.start_time_seconds + 100, 'end_time_seconds' => default_dataset_item.end_time_seconds + 100})
+      }
+
+      it 'Creates a dataset item and progress event for the default dataset' do
+        params = {progress_event: progress_event_attributes_2}.to_json
+        post url[:path], params, @env
+        expect(response).to have_http_status(201)
+        parsed_response = JSON.parse(response.body)
+        created_dataset_item = DatasetItem.find(parsed_response['data']['dataset_item_id'])
+        # check that the associated dataset item has the same attributes as what we specified in the request
+        created_dataset_item_attributes = values_to_string(created_dataset_item.attributes.symbolize_keys.slice(*url[:params].keys))
+        expect(created_dataset_item_attributes).to eq(url[:params])
+        expect(created_dataset_item.dataset_id).to eq(1)
+        check_counts true, true
+      end
+
+      it 'responds with :forbidden if user does not have access to audio recording' do
+        @env['HTTP_AUTHORIZATION'] = no_access_token
+        params = {progress_event: progress_event_attributes_2}.to_json
+        post url[:path], params, @env
+        expect(response).to have_http_status(:forbidden)
+        parsed_response = JSON.parse(response.body)
+        check_counts
+      end
+
+    end
+
+    it 'Responds with 422 if dataset item params for default dataset are invalid: same start and end time' do
+      url = create_by_dataset_item_params_path(default_dataset_item, {'start_time_seconds' => '123', 'end_time_seconds' => '123'})
+      params = {progress_event: progress_event_attributes_2}.to_json
+      post url[:path], params, @env
+      num_progress_events_after = ProgressEvent.count
+      num_dataset_items_after = DatasetItem.count
+      expect(response).to have_http_status(422)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['meta']['error']['info']['end_time_seconds']).to eq(['must be greater than 123.0'])
+      check_counts
+    end
+
   end
 
 end
-
-
-

--- a/spec/requests/progress_events_spec.rb
+++ b/spec/requests/progress_events_spec.rb
@@ -60,6 +60,13 @@ describe "Progress Events" do
 
   describe 'Creating a progress event' do
 
+    it 'creates a progress event' do
+      params = {progress_event: progress_event_attributes}.to_json
+      post @create_progress_event_url, params, @env
+      expect(response).to have_http_status(201)
+    end
+
+
     it 'does not allow a non-existent dataset item id' do
       params = {progress_event: progress_event_attributes_invalid_dataset_item_id}.to_json
       post @create_progress_event_url, params, @env

--- a/spec/requests/progress_events_spec.rb
+++ b/spec/requests/progress_events_spec.rb
@@ -210,7 +210,6 @@ describe "Progress Events" do
     end
 
     # specifying the dataset by name rather than id is available only for the default dataset
-    # 
     it 'Responds with 404 if dataset_id is the name of a dataset other than default' do
       url = create_by_dataset_item_params_path(
           another_dataset_item,

--- a/spec/requests/progress_events_spec.rb
+++ b/spec/requests/progress_events_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'rspec/mocks'
+
+describe "Progress Events" do
+
+  create_entire_hierarchy
+
+  let(:progress_event_attributes) {
+    FactoryGirl.attributes_for(:progress_event, {dataset_item_id: dataset_item.id})
+  }
+
+  let(:progress_event_attributes_invalid_dataset_item_id) {
+    attributes = progress_event_attributes
+    attributes[:dataset_item_id] = 38921111
+    attributes
+  }
+
+  before(:each) do
+    @env ||= {}
+    @env['HTTP_AUTHORIZATION'] = admin_token
+    @env['CONTENT_TYPE'] = "application/json"
+
+    @create_progress_event_url = "/progress_events"
+    @update_progress_event_url = "/progress_events/#{progress_event.id}"
+  end
+
+  describe 'Creating a progress event' do
+
+    it 'does not allow a non-existent dataset item id' do
+      params = {progress_event: progress_event_attributes_invalid_dataset_item_id}.to_json
+      post @create_progress_event_url, params, @env
+      expect(response).to have_http_status(422)
+    end
+
+  end
+
+  describe 'Updating a progress event' do
+
+    it 'does not allow a non-existent dataset item id' do
+      params = {progress_event: progress_event_attributes_invalid_dataset_item_id}.to_json
+      put @update_progress_event_url, params, @env
+      expect(response).to have_http_status(422)
+    end
+
+  end
+
+end
+
+
+

--- a/spec/routing/progress_events_routing_spec.rb
+++ b/spec/routing/progress_events_routing_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe ProgressEventsController, :type => :routing do
+  describe :routing do
+
+    describe 'create with valid params' do
+      it { expect(post('/progress_events')).to route_to('progress_events#create', format: 'json') }
+    end
+
+    describe 'create_by_dataset_item_params with valid params (integer offsets)' do
+      it { expect(post('/datasets/1/progress_events/audio_recordings/2/start/3/end/4')).to route_to('progress_events#create_by_dataset_item_params', dataset_id: '1', audio_recording_id: '2', start_time_seconds: '3', end_time_seconds: '4', format: 'json') }
+    end
+
+    describe 'create_by_dataset_item_params with valid params (offsets 1 decimal place)' do
+      it { expect(post('/datasets/1/progress_events/audio_recordings/2/start/3.0/end/4.0')).to route_to('progress_events#create_by_dataset_item_params', dataset_id: '1', audio_recording_id: '2', start_time_seconds: '3.0', end_time_seconds: '4.0', format: 'json') }
+    end
+
+    describe 'create_by_dataset_item_params with valid params (offsets 5 decimal places)' do
+      it { expect(post('/datasets/1/progress_events/audio_recordings/2/start/3.12345/end/4.12345')).to route_to('progress_events#create_by_dataset_item_params', dataset_id: '1', audio_recording_id: '2', start_time_seconds: '3.12345', end_time_seconds: '4.12345', format: 'json') }
+    end
+
+  end
+end

--- a/spec/routing/progress_events_routing_spec.rb
+++ b/spec/routing/progress_events_routing_spec.rb
@@ -8,15 +8,42 @@ describe ProgressEventsController, :type => :routing do
     end
 
     describe 'create_by_dataset_item_params with valid params (integer offsets)' do
-      it { expect(post('/datasets/1/progress_events/audio_recordings/2/start/3/end/4')).to route_to('progress_events#create_by_dataset_item_params', dataset_id: '1', audio_recording_id: '2', start_time_seconds: '3', end_time_seconds: '4', format: 'json') }
+      it {
+        expect(post('/datasets/1/progress_events/audio_recordings/2/start/3/end/4'))
+            .to route_to(
+                    'progress_events#create_by_dataset_item_params',
+                    dataset_id: '1',
+                    audio_recording_id: '2',
+                    start_time_seconds: '3',
+                    end_time_seconds: '4',
+                    format: 'json')
+      }
     end
 
     describe 'create_by_dataset_item_params with valid params (offsets 1 decimal place)' do
-      it { expect(post('/datasets/1/progress_events/audio_recordings/2/start/3.0/end/4.0')).to route_to('progress_events#create_by_dataset_item_params', dataset_id: '1', audio_recording_id: '2', start_time_seconds: '3.0', end_time_seconds: '4.0', format: 'json') }
+      it {
+        expect(post('/datasets/1/progress_events/audio_recordings/2/start/3.0/end/4.0'))
+            .to route_to(
+                    'progress_events#create_by_dataset_item_params',
+                    dataset_id: '1',
+                    audio_recording_id: '2',
+                    start_time_seconds: '3.0',
+                    end_time_seconds: '4.0',
+                    format: 'json')
+      }
     end
 
     describe 'create_by_dataset_item_params with valid params (offsets 5 decimal places)' do
-      it { expect(post('/datasets/1/progress_events/audio_recordings/2/start/3.12345/end/4.12345')).to route_to('progress_events#create_by_dataset_item_params', dataset_id: '1', audio_recording_id: '2', start_time_seconds: '3.12345', end_time_seconds: '4.12345', format: 'json') }
+      it {
+        expect(post('/datasets/1/progress_events/audio_recordings/2/start/3.12345/end/4.12345'))
+            .to route_to(
+                    'progress_events#create_by_dataset_item_params',
+                    dataset_id: '1',
+                    audio_recording_id: '2',
+                    start_time_seconds: '3.12345',
+                    end_time_seconds: '4.12345',
+                    format: 'json')
+      }
     end
 
   end


### PR DESCRIPTION
Closes #371 
Fixes #368
(Included filter specs that return datasets that have different audio_recording_ids in the correct order)
Closes #348

Progress events api endpoints. The standard endpoints plus:
- a specific endpoint in dataset items controller #filter_todo that performs the filter with a priority algorithm that returns dataset items in order of their count of 'viewed' progress events.  It was named 'filter_todo' because it returns items in a dataset that are still "to do", i.e. they have not yet been viewed. I am happy for this to be replaced with a better name. 
- a specific endpoint for adding progress events with route parameters that define the parent dataset_item by its dataset_id, audio_recording_id, start_time_seconds, and end_time_seconds. This endpoint allows adding of progress events to segments of audio without knowing the dataset_item_id, or, in the case of the default dataset, if the dataset item has not yet been created. 
