### PR TITLE
Missing site model details

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,8 @@ Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
   Max: 30
+  ExcludedMethods:
+    - filter_settings
 Metrics/AbcSize:
   Max: 60
 Style/BlockDelimiters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,8 +38,6 @@ Metrics/MethodLength:
     - filter_settings
 Metrics/AbcSize:
   Max: 60
-Naming/AccessorMethodName:
-  Enabled: false
 Style/BlockDelimiters:
   EnforcedStyle: semantic
   AllowBracesOnProceduralOneLiners: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,8 @@ Metrics/MethodLength:
     - filter_settings
 Metrics/AbcSize:
   Max: 60
+Naming/AccessorMethodName:
+  Enabled: false
 Style/BlockDelimiters:
   EnforcedStyle: semantic
 Style/BracesAroundHashParameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,7 @@ Naming/AccessorMethodName:
   Enabled: false
 Style/BlockDelimiters:
   EnforcedStyle: semantic
+  AllowBracesOnProceduralOneLiners: true
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 Layout/LeadingCommentSpace:

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SitesController < ApplicationController
   include Api::ControllerHelper
 
@@ -11,10 +13,10 @@ class SitesController < ApplicationController
       #format.html # index.html.erb
       format.json {
         @sites, opts = Settings.api_response.response_advanced(
-            api_filter_params,
-            Access::ByPermission.sites(current_user, Access::Core.levels, [@project.id]),
-            Site,
-            Site.filter_settings
+          api_filter_params,
+          Access::ByPermission.sites(current_user, Access::Core.levels, [@project.id]),
+          Site,
+          Site.filter_settings
         )
         respond_index(opts)
       }
@@ -38,7 +40,7 @@ class SitesController < ApplicationController
     do_authorize_instance
 
     respond_to do |format|
-      format.html { @site.update_location_obfuscated(current_user) }
+      format.html do @site.update_location_obfuscated(current_user) end
       format.json { respond_show }
     end
   end
@@ -75,10 +77,10 @@ class SitesController < ApplicationController
 
     respond_to do |format|
       if @site.save
-        format.html { redirect_to [@project, @site], notice: 'Site was successfully created.' }
+        format.html do redirect_to [@project, @site], notice: 'Site was successfully created.' end
         format.json { respond_create_success(project_site_path(@project, @site)) }
       else
-        format.html { render action: 'new' }
+        format.html do render action: 'new' end
         format.json { respond_change_fail }
       end
     end
@@ -94,13 +96,13 @@ class SitesController < ApplicationController
 
     respond_to do |format|
       if @site.update_attributes(site_params)
-        format.html { redirect_to [@project, @site], notice: 'Site was successfully updated.' }
+        format.html do redirect_to [@project, @site], notice: 'Site was successfully updated.' end
         format.json { respond_show }
       else
-        format.html {
+        format.html do
 
           render action: 'edit'
-        }
+        end
         format.json { respond_change_fail }
       end
     end
@@ -116,7 +118,7 @@ class SitesController < ApplicationController
     add_archived_at_header(@site)
 
     respond_to do |format|
-      format.html { redirect_to project_sites_url(@project) }
+      format.html do redirect_to project_sites_url(@project) end
       format.json { respond_destroy }
     end
   end
@@ -149,14 +151,11 @@ class SitesController < ApplicationController
   def orphans
     do_authorize_class
 
-    @sites = Site.find_by_sql("SELECT * FROM sites s
-WHERE s.id NOT IN (SELECT site_id FROM projects_sites)
-ORDER BY s.name")
+    @sites = Site.find_by_sql('SELECT * FROM sites s WHERE s.id NOT IN (SELECT site_id FROM projects_sites) ORDER BY s.name')
 
     respond_to do |format|
       format.html
     end
-
   end
 
   # GET|POST /sites/filter
@@ -164,43 +163,43 @@ ORDER BY s.name")
     do_authorize_class
 
     filter_response, opts = Settings.api_response.response_advanced(
-        api_filter_params,
-        Access::ByPermission.sites(current_user),
-        Site,
-        Site.filter_settings
+      api_filter_params,
+      Access::ByPermission.sites(current_user),
+      Site,
+      Site.filter_settings
     )
     respond_filter(filter_response, opts)
   end
 
   def nav_menu
     {
-        anchor_after: 'baw.shared.links.projects.title',
-        menu_items: [
-            {
-                title: 'baw.shared.links.projects.title',
-                href: project_path(@project),
-                tooltip: 'baw.shared.links.projects.description',
-                icon: nil,
-                indentation: 1,
-                #predicate:
-            },
-            {
-                title: 'baw.shared.links.site.title',
-                href: project_site_path(@project, @site),
-                tooltip: 'baw.shared.links.site.description',
-                icon: nil,
-                indentation: 2,
-                #predicate:
-            },
-            # {
-            #     title: 'baw.shared.links.ethics_statement.title',
-            #     href: ethics_statement_path,
-            #     tooltip: 'baw.shared.links.ethics_statement.description',
-            #     icon: nil,
-            #     indentation: 0,
-            #     predicate: lambda { |user| action_name == 'ethics_statement' }
-            # }
-        ]
+      anchor_after: 'baw.shared.links.projects.title',
+      menu_items: [
+        {
+          title: 'baw.shared.links.projects.title',
+          href: project_path(@project),
+          tooltip: 'baw.shared.links.projects.description',
+          icon: nil,
+          indentation: 1
+          #predicate:
+        },
+        {
+          title: 'baw.shared.links.site.title',
+          href: project_site_path(@project, @site),
+          tooltip: 'baw.shared.links.site.description',
+          icon: nil,
+          indentation: 2
+          #predicate:
+        }
+        # {
+        #     title: 'baw.shared.links.ethics_statement.title',
+        #     href: ethics_statement_path,
+        #     tooltip: 'baw.shared.links.ethics_statement.description',
+        #     icon: nil,
+        #     indentation: 0,
+        #     predicate: lambda { |user| action_name == 'ethics_statement' }
+        # }
+      ]
     }
   end
 
@@ -210,9 +209,7 @@ ORDER BY s.name")
     @project = Project.find(params[:project_id])
 
     # avoid the same project assigned more than once to a site
-    if defined?(@site) && !@site.projects.include?(@project)
-      @site.projects << @project
-    end
+    @site.projects << @project if defined?(@site) && !@site.projects.include?(@project)
   end
 
   def site_params
@@ -222,5 +219,4 @@ ORDER BY s.name")
   def site_show_params
     params.permit(:id, :project_id, site: {})
   end
-
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -11,7 +11,7 @@ class SitesController < ApplicationController
 
     respond_to do |format|
       #format.html # index.html.erb
-      format.json {
+      format.json do
         @sites, opts = Settings.api_response.response_advanced(
           api_filter_params,
           Access::ByPermission.sites(current_user, Access::Core.levels, [@project.id]),
@@ -19,7 +19,7 @@ class SitesController < ApplicationController
           Site.filter_settings
         )
         respond_index(opts)
-      }
+      end
     end
   end
 
@@ -28,9 +28,7 @@ class SitesController < ApplicationController
     do_load_resource
     do_authorize_instance
 
-    respond_to do |format|
-      format.json { respond_show }
-    end
+    respond_to { |format| format.json { respond_show } }
   end
 
   # GET /projects/:project_id/sites/:id
@@ -40,7 +38,7 @@ class SitesController < ApplicationController
     do_authorize_instance
 
     respond_to do |format|
-      format.html do @site.update_location_obfuscated(current_user) end
+      format.html { @site.update_location_obfuscated(current_user) }
       format.json { respond_show }
     end
   end
@@ -77,10 +75,10 @@ class SitesController < ApplicationController
 
     respond_to do |format|
       if @site.save
-        format.html do redirect_to [@project, @site], notice: 'Site was successfully created.' end
+        format.html { redirect_to [@project, @site], notice: 'Site was successfully created.' }
         format.json { respond_create_success(project_site_path(@project, @site)) }
       else
-        format.html do render action: 'new' end
+        format.html { render action: 'new' }
         format.json { respond_change_fail }
       end
     end
@@ -96,7 +94,7 @@ class SitesController < ApplicationController
 
     respond_to do |format|
       if @site.update_attributes(site_params)
-        format.html do redirect_to [@project, @site], notice: 'Site was successfully updated.' end
+        format.html { redirect_to [@project, @site], notice: 'Site was successfully updated.' }
         format.json { respond_show }
       else
         format.html do
@@ -118,7 +116,7 @@ class SitesController < ApplicationController
     add_archived_at_header(@site)
 
     respond_to do |format|
-      format.html do redirect_to project_sites_url(@project) end
+      format.html { redirect_to project_sites_url(@project) }
       format.json { respond_destroy }
     end
   end
@@ -129,9 +127,7 @@ class SitesController < ApplicationController
     get_project
     do_authorize_instance
 
-    respond_to do |format|
-      format.html
-    end
+    respond_to { |format| format.html }
   end
 
   # GET /projects/:project_id/sites/:id/harvest
@@ -153,9 +149,7 @@ class SitesController < ApplicationController
 
     @sites = Site.find_by_sql('SELECT * FROM sites s WHERE s.id NOT IN (SELECT site_id FROM projects_sites) ORDER BY s.name')
 
-    respond_to do |format|
-      format.html
-    end
+    respond_to { |format| format.html }
   end
 
   # GET|POST /sites/filter

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -52,7 +52,7 @@ class SitesController < ApplicationController
     do_set_attributes
     do_authorize_instance
 
-    # initialise lat/lng to Brisbane-ish
+    # initialize lat/lng to Brisbane-ish
     @site.longitude = 152
     @site.latitude = -27
     respond_to do |format|

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Site < ActiveRecord::Base
   # ensures that creator_id, updater_id, deleter_id are set
   include UserChange
@@ -13,7 +15,13 @@ class Site < ActiveRecord::Base
   belongs_to :deleter, class_name: 'User', foreign_key: :deleter_id, inverse_of: :deleted_sites
 
   has_attached_file :image,
-                    styles: {span4: '300x300#', span3: '220x220#', span2: '140x140#', span1: '60x60#', spanhalf: '30x30#'},
+                    styles: {
+                      span4: '300x300#',
+                      span3: '220x220#',
+                      span2: '140x140#',
+                      span1: '60x60#',
+                      spanhalf: '30x30#'
+                    },
                     default_url: '/images/site/site_:style.png'
 
   LATITUDE_MIN = -90
@@ -33,20 +41,30 @@ class Site < ActiveRecord::Base
   validates :creator, existence: true
 
   # attribute validations
-  validates :name, presence: true, length: {minimum: 2}
+  validates :name, presence: true, length: { minimum: 2 }
 
   # between -90 and 90 degrees
-  validates :latitude, numericality: {only_integer: false, greater_than_or_equal_to: Site::LATITUDE_MIN, less_than_or_equal_to: Site::LATITUDE_MAX,
-                                      message: "%{value} must be greater than or equal to #{Site::LATITUDE_MIN} and less than or equal to #{Site::LATITUDE_MAX}"}, allow_nil: true
+  validates :latitude, numericality: {
+    only_integer: false,
+    greater_than_or_equal_to: Site::LATITUDE_MIN,
+    less_than_or_equal_to: Site::LATITUDE_MAX,
+    message: "%{value} must be greater than or equal to #{Site::LATITUDE_MIN} and less than or equal to #{Site::LATITUDE_MAX}"
+  }, allow_nil: true
 
   # -180 and 180 degrees
-  validates :longitude, numericality: {only_integer: false, greater_than_or_equal_to: Site::LONGITUDE_MIN, less_than_or_equal_to: Site::LONGITUDE_MAX,
-                                       message: "%{value} must be greater than or equal to #{Site::LONGITUDE_MIN} and less than or equal to #{Site::LONGITUDE_MAX}"}, allow_nil: true
+  validates :longitude, numericality: {
+    only_integer: false,
+    greater_than_or_equal_to: Site::LONGITUDE_MIN,
+    less_than_or_equal_to: Site::LONGITUDE_MAX,
+    message: "%{value} must be greater than or equal to #{Site::LONGITUDE_MIN} and less than or equal to #{Site::LONGITUDE_MAX}"
+  }, allow_nil: true
 
-  validates_attachment_content_type :image, content_type: /^image\/(jpg|jpeg|pjpeg|png|x-png|gif)$/, message: 'file type %{value} is not allowed (only jpeg/png/gif images)'
+  validates_attachment_content_type :image,
+                                    content_type: %r{^image/(jpg|jpeg|pjpeg|png|x-png|gif)$},
+                                    message: 'file type %{value} is not allowed (only jpeg/png/gif images)'
 
   validate :check_tz
-  before_save :set_rails_tz, if: Proc.new { |site| site.tzinfo_tz_changed? }
+  before_save :set_rails_tz, if: proc { |site| site.tzinfo_tz_changed? }
 
   # commonly used queries
   #scope :specified_sites, lambda { |site_ids| where('id in (:ids)', { :ids => site_ids } ) }
@@ -54,11 +72,11 @@ class Site < ActiveRecord::Base
   #scope :site_projects, lambda{ |project_ids| includes(:projects).where(:projects => {:id => project_ids} ) }
 
   def get_bookmark
-    Bookmark.where(audio_recording: self.audio_recordings).order(:updated_at).first
+    Bookmark.where(audio_recording: audio_recordings).order(:updated_at).first
   end
 
   def most_recent_recording
-    self.audio_recordings.order(recorded_date: :desc).first
+    audio_recordings.order(recorded_date: :desc).first
   end
 
   def get_bookmark_or_recording
@@ -66,25 +84,23 @@ class Site < ActiveRecord::Base
     recording = most_recent_recording
     if !bookmark.blank?
       {
-          audio_recording: bookmark.audio_recording,
-          start_offset_seconds: bookmark.offset_seconds,
-          source: :bookmark
+        audio_recording: bookmark.audio_recording,
+        start_offset_seconds: bookmark.offset_seconds,
+        source: :bookmark
       }
     elsif !recording.blank?
       {
-          audio_recording: recording,
-          start_offset_seconds: nil,
-          source: :audio_recording
+        audio_recording: recording,
+        start_offset_seconds: nil,
+        source: :audio_recording
       }
-    else
-      nil
     end
   end
 
   # overrides getting, does not change setting
   def latitude
     value = read_attribute(:latitude)
-    if self.location_obfuscated && !value.blank?
+    if location_obfuscated && !value.blank?
       Site.add_location_jitter(value, Site::LATITUDE_MIN, Site::LATITUDE_MAX)
     else
       value
@@ -94,7 +110,7 @@ class Site < ActiveRecord::Base
   # overrides getting, does not change setting
   def longitude
     value = read_attribute(:longitude)
-    if self.location_obfuscated && !value.blank?
+    if location_obfuscated && !value.blank?
       Site.add_location_jitter(value, Site::LONGITUDE_MIN, Site::LONGITUDE_MAX)
     else
       value
@@ -103,7 +119,7 @@ class Site < ActiveRecord::Base
 
   def update_location_obfuscated(current_user)
     Access::Core.check_orphan_site!(self)
-    is_owner = Access::Core.can_any?(current_user, :owner, self.projects)
+    is_owner = Access::Core.can_any?(current_user, :owner, projects)
 
     # obfuscate if level is less than owner
     @location_obfuscated = !is_owner
@@ -114,14 +130,13 @@ class Site < ActiveRecord::Base
   end
 
   def self.add_location_jitter(value, min, max)
-
     # multiply by 10,000 to get to ~10m accuracy
-    accuracy = 10000
+    accuracy = 10_000
     multiplied = (value * accuracy).floor.to_i
 
     # get a range for potential jitter
 
-    max_diff =(Site::JITTER_RANGE * accuracy).floor.to_i
+    max_diff = (Site::JITTER_RANGE * accuracy).floor.to_i
     range_min = multiplied - max_diff
     range_max = multiplied + max_diff
 
@@ -142,31 +157,19 @@ class Site < ActiveRecord::Base
     selected = available.sample
 
     # ensure the last digit is not zero (0), as this will be removed when converted
-    if selected.to_s.last == '0'
-      selected += 1
-    end
+    selected += 1 if selected.to_s.last == '0'
 
     # round to ensure precision is maintained (damn floating point in-exactness)
     # 3 decimal places is at the scale of an 'individual street, land parcel'
-    modified_value = (selected.to_f / accuracy.to_f).round(4)
+    modified_value = selected.fdiv(accuracy).round(4)
 
     # ensure range is maintained (damn floating point in-exactness)
-    if modified_value > (value + Site::JITTER_RANGE)
-      modified_value = value + Site::JITTER_RANGE
-    end
-
-    if modified_value < (value - Site::JITTER_RANGE)
-      modified_value = value - Site::JITTER_RANGE
-    end
+    modified_value = value + Site::JITTER_RANGE if modified_value > (value + Site::JITTER_RANGE)
+    modified_value = value - Site::JITTER_RANGE if modified_value < (value - Site::JITTER_RANGE)
 
     # ensure modified value stays within lat/long valid ranges
-    if modified_value > max
-      modified_value = max
-    end
-
-    if modified_value < min
-      modified_value = min
-    end
+    modified_value = max if modified_value > max
+    modified_value = min if modified_value < min
 
     modified_value
   end
@@ -174,66 +177,68 @@ class Site < ActiveRecord::Base
   # Define filter api settings
   def self.filter_settings
     {
-        valid_fields: [:id, :name, :description, :created_at, :updated_at, :project_ids, :timezone_information],
-        render_fields: [:id, :name, :description],
-        text_fields: [:description, :name],
-        custom_fields: lambda { |item, user|
+      valid_fields: [:id, :name, :description, :created_at, :updated_at, :project_ids, :timezone_information],
+      render_fields: [:id, :name, :description, :creator_id, :updater_id, :created_at, :updated_at],
+      text_fields: [:description, :name],
+      custom_fields: lambda { |item, user|
 
-          # item can be nil or a new record
-          is_new_record = item.nil? || item.new_record?
-          fresh_site = is_new_record ? nil : Site.find(item.id)
-          site_hash = {}
+                       # item can be nil or a new record
+                       is_new_record = item.nil? || item.new_record?
+                       fresh_site = is_new_record ? nil : Site.find(item.id)
+                       site_hash = {}
 
-          unless fresh_site.nil?
-            fresh_site.update_location_obfuscated(user)
-            site_hash = {
-                project_ids: fresh_site.projects.pluck(:id).flatten,
-                location_obfuscated: fresh_site.location_obfuscated,
-                custom_latitude: fresh_site.latitude,
-                custom_longitude: fresh_site.longitude,
-                timezone_information: TimeZoneHelper.info_hash(fresh_site),
-                description_html: fresh_site.description_html
+                       unless fresh_site.nil?
+                         fresh_site.update_location_obfuscated(user)
+                         site_hash = {
+                           project_ids: fresh_site.projects.pluck(:id).flatten,
+                           location_obfuscated: fresh_site.location_obfuscated,
+                           custom_latitude: fresh_site.latitude,
+                           custom_longitude: fresh_site.longitude,
+                           timezone_information: TimeZoneHelper.info_hash(fresh_site),
+                           description_html: fresh_site.description_html,
+                           image_urls: Api::Image.image_urls(fresh_site.image)
+                         }
+                       end
+
+                       [item, site_hash]
+                     },
+
+      new_spec_fields: lambda { |user| # rubocop:disable Lint/UnusedBlockArgument
+                         {
+                           longitude: nil,
+                           latitude: nil,
+                           notes: nil,
+                           image: nil,
+                           tzinfo_tz: nil,
+                           rails_tz: nil
+                         }
+                       },
+      controller: :sites,
+      action: :filter,
+      defaults: {
+        order_by: :name,
+        direction: :asc
+      },
+      valid_associations: [
+        {
+          join: Arel::Table.new(:projects_sites),
+          on: Site.arel_table[:id].eq(Arel::Table.new(:projects_sites)[:site_id]),
+          available: false,
+          associations: [
+            {
+              join: Project,
+              on: Arel::Table.new(:projects_sites)[:project_id].eq(Project.arel_table[:id]),
+              available: true
             }
-          end
+          ]
 
-          [item, site_hash]
         },
-        new_spec_fields: lambda { |user|
-          {
-              longitude: nil,
-              latitude: nil,
-              notes: nil,
-              image: nil,
-              tzinfo_tz: nil,
-              rails_tz: nil,
-          }
-        },
-        controller: :sites,
-        action: :filter,
-        defaults: {
-            order_by: :name,
-            direction: :asc
-        },
-        valid_associations: [
-            {
-                join: Arel::Table.new(:projects_sites),
-                on: Site.arel_table[:id].eq(Arel::Table.new(:projects_sites)[:site_id]),
-                available: false,
-                associations: [
-                    {
-                        join: Project,
-                        on: Arel::Table.new(:projects_sites)[:project_id].eq(Project.arel_table[:id]),
-                        available: true
-                    }
-                ]
-
-            },
-            {
-                join: AudioRecording,
-                on: AudioRecording.arel_table[:site_id].eq(Site.arel_table[:id]),
-                available: true
-            },
-        ]
+        {
+          join: AudioRecording,
+          on: AudioRecording.arel_table[:site_id].eq(Site.arel_table[:id]),
+          available: true
+        }
+      ]
     }
   end
 
@@ -244,5 +249,4 @@ class Site < ActiveRecord::Base
   def check_tz
     TimeZoneHelper.validate_tzinfo_tz(self)
   end
-
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -181,7 +181,6 @@ class Site < ActiveRecord::Base
       render_fields: [:id, :name, :description, :creator_id, :updater_id, :created_at, :updated_at],
       text_fields: [:description, :name],
       custom_fields: lambda { |item, user|
-
                        # item can be nil or a new record
                        is_new_record = item.nil? || item.new_record?
                        fresh_site = is_new_record ? nil : Site.find(item.id)
@@ -202,7 +201,6 @@ class Site < ActiveRecord::Base
 
                        [item, site_hash]
                      },
-
       new_spec_fields: lambda { |user| # rubocop:disable Lint/UnusedBlockArgument
                          {
                            longitude: nil,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,14 +241,7 @@ class User < ActiveRecord::Base
                          {
                            timezone_information: TimeZoneHelper.info_hash(fresh_user),
                            roles_mask_names: fresh_user.roles,
-                           image_urls:
-                                 [
-                                   { size: :extralarge, url: fresh_user.image.url(:span4), width: 300, height: 300 },
-                                   { size: :large, url: fresh_user.image.url(:span3), width: 220, height: 220 },
-                                   { size: :medium, url: fresh_user.image.url(:span2), width: 140, height: 140 },
-                                   { size: :small, url: fresh_user.image.url(:span1), width: 60, height: 60 },
-                                   { size: :tiny, url: fresh_user.image.url(:spanhalf), width: 30, height: 30 }
-                                 ]
+                           image_urls: Api::Image.image_urls(fresh_user.image)
                          }
 
                        if is_admin || is_same_user

--- a/lib/modules/api/image.rb
+++ b/lib/modules/api/image.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 module Api
-  # Handles extracting image urls
+  # Handle model images
   class Image
     class << self
+      # Extract image urls from an image
+      # @param [Object] image Fresh model image parameter (ie. fresh_site.image)
+      # @return [Array] Array of image urls and sizes
       def image_urls(image)
         [
           { size: :extralarge, url: image.url(:span4), width: 300, height: 300 },

--- a/lib/modules/api/image.rb
+++ b/lib/modules/api/image.rb
@@ -5,6 +5,7 @@ module Api
   class Image
     class << self
       # Extract image urls from an image
+      # TODO Implement original size, and extract magic width and height values
       # @param [Object] image Fresh model image parameter (ie. fresh_site.image)
       # @return [Array] Array of image urls and sizes
       def image_urls(image)

--- a/lib/modules/api/image.rb
+++ b/lib/modules/api/image.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  # Handles extracting image urls
+  class Image
+    class << self
+      def image_urls(image)
+        [
+          { size: :extralarge, url: image.url(:span4), width: 300, height: 300 },
+          { size: :large, url: image.url(:span3), width: 220, height: 220 },
+          { size: :medium, url: image.url(:span2), width: 140, height: 140 },
+          { size: :small, url: image.url(:span1), width: 60, height: 60 },
+          { size: :tiny, url: image.url(:spanhalf), width: 30, height: 30 }
+        ]
+      end
+    end
+  end
+end

--- a/spec/acceptance/sites_spec.rb
+++ b/spec/acceptance/sites_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 require 'helpers/acceptance_spec_helper'
@@ -44,48 +46,72 @@ resource 'Sites' do
     sites_project_id_param
     let(:project_id) { project.id }
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'INDEX (as admin)', :ok, {expected_json_path: 'data/0/custom_latitude', data_item_count: 1})
+    standard_request_options(:get, 'INDEX (as admin)', :ok, expected_json_path: 'data/0/custom_latitude', data_item_count: 1)
   end
 
   get '/projects/:project_id/sites' do
     sites_project_id_param
     let(:project_id) { project.id }
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'INDEX (as owner)', :ok, {expected_json_path: 'data/0/custom_latitude', data_item_count: 1})
+    standard_request_options(:get, 'INDEX (as owner)', :ok, expected_json_path: 'data/0/custom_latitude', data_item_count: 1)
   end
 
   get '/projects/:project_id/sites' do
     sites_project_id_param
     let(:project_id) { project.id }
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'INDEX (as writer)', :ok, {expected_json_path: 'data/0/custom_latitude', data_item_count: 1})
+    standard_request_options(:get, 'INDEX (as writer)', :ok, expected_json_path: 'data/0/custom_latitude', data_item_count: 1)
   end
 
   get '/projects/:project_id/sites' do
     sites_project_id_param
     let(:project_id) { project.id }
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'INDEX (as reader)', :ok, {expected_json_path: 'data/0/custom_latitude', data_item_count: 1})
+    standard_request_options(:get, 'INDEX (as reader)', :ok, expected_json_path: 'data/0/custom_latitude', data_item_count: 1)
+  end
+
+  Array[
+    'id',
+    'name',
+    'description',
+    'creator_id',
+    'updater_id',
+    'created_at',
+    'updated_at',
+    'project_ids',
+    'location_obfuscated',
+    'custom_latitude',
+    'custom_longitude',
+    'timezone_information',
+    'description_html',
+    'image_urls'
+  ].each do |x|
+    get '/projects/:project_id/sites' do
+      sites_project_id_param
+      let(:project_id) { project.id }
+      let(:authentication_token) { reader_token }
+      standard_request_options(:get, "INDEX (has #{x}, as reader)", :ok, expected_json_path: "data/0/#{x}", data_item_count: 1)
+    end
   end
 
   get '/projects/:project_id/sites' do
     sites_project_id_param
     let(:project_id) { project.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'INDEX (as other)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:get, 'INDEX (as other)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   get '/projects/:project_id/sites' do
     sites_project_id_param
     let(:project_id) { project.id }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'INDEX (invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_in)})
+    standard_request_options(:get, 'INDEX (invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_in))
   end
 
   get '/projects/:project_id/sites' do
     sites_project_id_param
     let(:project_id) { project.id }
-    standard_request_options(:get, 'INDEX (as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_in)})
+    standard_request_options(:get, 'INDEX (as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_in))
   end
 
   ################################
@@ -95,42 +121,42 @@ resource 'Sites' do
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'NEW (as admin)', :ok, {expected_json_path: 'data/longitude'})
+    standard_request_options(:get, 'NEW (as admin)', :ok, expected_json_path: 'data/longitude')
   end
 
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'NEW (as owner)', :ok, {expected_json_path: 'data/longitude'})
+    standard_request_options(:get, 'NEW (as owner)', :ok, expected_json_path: 'data/longitude')
   end
 
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'NEW (as writer)', :ok, {expected_json_path: 'data/longitude'})
+    standard_request_options(:get, 'NEW (as writer)', :ok, expected_json_path: 'data/longitude')
   end
 
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'NEW (as reader)',  :ok, {expected_json_path: 'data/longitude'})
+    standard_request_options(:get, 'NEW (as reader)', :ok, expected_json_path: 'data/longitude')
   end
 
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'NEW (as no access user)',  :ok, {expected_json_path: 'data/longitude'})
+    standard_request_options(:get, 'NEW (as no access user)', :ok, expected_json_path: 'data/longitude')
   end
 
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'NEW (invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'NEW (invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/projects/:project_id/sites/new' do
     let(:project_id) { project.id }
-    standard_request_options(:get, 'NEW (as anonymous user)',  :ok, {expected_json_path: 'data/longitude'})
+    standard_request_options(:get, 'NEW (as anonymous user)', :ok, expected_json_path: 'data/longitude')
   end
 
   ################################
@@ -141,8 +167,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { admin_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as admin)', :created, {expected_json_path: 'data/project_ids'})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as admin)', :created, expected_json_path: 'data/project_ids')
   end
 
   post '/projects/:project_id/sites' do
@@ -150,8 +176,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { owner_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as owner)', :created, {expected_json_path: 'data/project_ids'})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as owner)', :created, expected_json_path: 'data/project_ids')
   end
 
   post '/projects/:project_id/sites' do
@@ -159,8 +185,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as writer)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as writer)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   post '/projects/:project_id/sites' do
@@ -168,8 +194,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { reader_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as reader)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as reader)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   post '/projects/:project_id/sites' do
@@ -177,8 +203,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { no_access_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as other)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as other)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   post '/projects/:project_id/sites' do
@@ -186,8 +212,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { invalid_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   post '/projects/:project_id/sites' do
@@ -195,8 +221,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:authentication_token) { invalid_token }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as anonymous user', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as anonymous user', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_up))
   end
 
   ################################
@@ -208,7 +234,7 @@ resource 'Sites' do
     let(:project_id) { project.id }
     let(:id) { site.id }
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'SHOW (nested route, as admin)', :ok, {expected_json_path: 'data/location_obfuscated'})
+    standard_request_options(:get, 'SHOW (nested route, as admin)', :ok, expected_json_path: 'data/location_obfuscated')
   end
 
   get '/projects/:project_id/sites/:id' do
@@ -217,7 +243,7 @@ resource 'Sites' do
     let(:project_id) { project.id }
     let(:id) { site.id }
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'SHOW (nested route, as owner)', :ok, {expected_json_path: 'data/location_obfuscated'})
+    standard_request_options(:get, 'SHOW (nested route, as owner)', :ok, expected_json_path: 'data/location_obfuscated')
   end
 
   get '/projects/:project_id/sites/:id' do
@@ -226,7 +252,7 @@ resource 'Sites' do
     let(:project_id) { project.id }
     let(:id) { site.id }
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'SHOW (nested route, as writer)', :ok, {expected_json_path: 'data/location_obfuscated'})
+    standard_request_options(:get, 'SHOW (nested route, as writer)', :ok, expected_json_path: 'data/location_obfuscated')
   end
 
   get '/projects/:project_id/sites/:id' do
@@ -235,7 +261,7 @@ resource 'Sites' do
     let(:project_id) { project.id }
     let(:id) { site.id }
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'SHOW (nested route, as reader)', :ok, {expected_json_path: 'data/location_obfuscated'})
+    standard_request_options(:get, 'SHOW (nested route, as reader)', :ok, expected_json_path: 'data/location_obfuscated')
   end
 
   get '/projects/:project_id/sites/:id' do
@@ -244,7 +270,7 @@ resource 'Sites' do
     let(:project_id) { project.id }
     let(:id) { site.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'SHOW (nested route, as other)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:get, 'SHOW (nested route, as other)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   get '/projects/:project_id/sites/:id' do
@@ -253,7 +279,7 @@ resource 'Sites' do
     let(:project_id) { project.id }
     let(:id) { site.id }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'SHOW (nested route, with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'SHOW (nested route, with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/projects/:project_id/sites/:id' do
@@ -261,7 +287,7 @@ resource 'Sites' do
     sites_id_param
     let(:project_id) { project.id }
     let(:id) { site.id }
-    standard_request_options(:get, 'SHOW (nested route, as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'SHOW (nested route, as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_up))
   end
 
   ################################
@@ -271,48 +297,48 @@ resource 'Sites' do
     sites_id_param
     let(:id) { site.id }
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'SHOW (shallow route, as admin)', :ok, {expected_json_path: 'data/project_ids'})
+    standard_request_options(:get, 'SHOW (shallow route, as admin)', :ok, expected_json_path: 'data/project_ids')
   end
 
   get '/sites/:id' do
     sites_id_param
     let(:id) { site.id }
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'SHOW (shallow route, as owner)', :ok, {expected_json_path: 'data/project_ids'})
+    standard_request_options(:get, 'SHOW (shallow route, as owner)', :ok, expected_json_path: 'data/project_ids')
   end
 
   get '/sites/:id' do
     sites_id_param
     let(:id) { site.id }
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'SHOW (shallow route, as writer)', :ok, {expected_json_path: 'data/project_ids'})
+    standard_request_options(:get, 'SHOW (shallow route, as writer)', :ok, expected_json_path: 'data/project_ids')
   end
 
   get '/sites/:id' do
     sites_id_param
     let(:id) { site.id }
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'SHOW (shallow route, as reader)', :ok, {expected_json_path: 'data/custom_longitude'})
+    standard_request_options(:get, 'SHOW (shallow route, as reader)', :ok, expected_json_path: 'data/custom_longitude')
   end
 
   get '/sites/:id' do
     sites_id_param
     let(:id) { site.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'SHOW (shallow route, as reader)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:get, 'SHOW (shallow route, as reader)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   get '/sites/:id' do
     sites_id_param
     let(:id) { site.id }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'SHOW (shallow route, with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'SHOW (shallow route, with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/sites/:id' do
     sites_id_param
     let(:id) { site.id }
-    standard_request_options(:get, 'SHOW (shallow route, as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'SHOW (shallow route, as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_up))
   end
 
   ################################
@@ -350,9 +376,9 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
+    let(:raw_post) { { site: post_attributes }.to_json }
     let(:authentication_token) { admin_token }
-    standard_request_options(:put, 'UPDATE (as admin)', :ok, {expected_json_path: 'data/custom_longitude'})
+    standard_request_options(:put, 'UPDATE (as admin)', :ok, expected_json_path: 'data/custom_longitude')
   end
 
   put '/projects/:project_id/sites/:id' do
@@ -361,9 +387,9 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
+    let(:raw_post) { { site: post_attributes }.to_json }
     let(:authentication_token) { owner_token }
-    standard_request_options(:put, 'UPDATE (as owner)', :ok, {expected_json_path: 'data/custom_longitude'})
+    standard_request_options(:put, 'UPDATE (as owner)', :ok, expected_json_path: 'data/custom_longitude')
   end
 
   put '/projects/:project_id/sites/:id' do
@@ -372,9 +398,9 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
+    let(:raw_post) { { site: post_attributes }.to_json }
     let(:authentication_token) { writer_token }
-    standard_request_options(:put, 'UPDATE (as writer)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:put, 'UPDATE (as writer)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   put '/projects/:project_id/sites/:id' do
@@ -383,9 +409,9 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
+    let(:raw_post) { { site: post_attributes }.to_json }
     let(:authentication_token) { reader_token }
-    standard_request_options(:put, 'UPDATE (as reader)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:put, 'UPDATE (as reader)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   put '/projects/:project_id/sites/:id' do
@@ -394,9 +420,9 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
+    let(:raw_post) { { site: post_attributes }.to_json }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:put, 'UPDATE (as other user)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:put, 'UPDATE (as other user)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   put '/projects/:project_id/sites/:id' do
@@ -405,9 +431,9 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
+    let(:raw_post) { { site: post_attributes }.to_json }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:put, 'UPDATE (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:put, 'UPDATE (with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   put '/projects/:project_id/sites/:id' do
@@ -416,8 +442,8 @@ resource 'Sites' do
     sites_body_params
     let(:project_id) { project.id }
     let(:id) { site.id }
-    let(:raw_post) { {site: post_attributes}.to_json }
-    standard_request_options(:put, 'UPDATE (as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)})
+    let(:raw_post) { { site: post_attributes }.to_json }
+    standard_request_options(:put, 'UPDATE (as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_up))
   end
 
   ################################
@@ -430,7 +456,7 @@ resource 'Sites' do
     let(:id) { site.id }
     let(:project_id) { project.id }
     let(:authentication_token) { admin_token }
-    standard_request_options(:delete, 'DESTROY (as admin)', :no_content, {expected_response_has_content: false, expected_response_content_type: nil})
+    standard_request_options(:delete, 'DESTROY (as admin)', :no_content, expected_response_has_content: false, expected_response_content_type: nil)
   end
 
   delete '/projects/:project_id/sites/:id' do
@@ -439,7 +465,7 @@ resource 'Sites' do
     let(:id) { site.id }
     let(:project_id) { project.id }
     let(:authentication_token) { owner_token }
-    standard_request_options(:delete, 'DESTROY (as owner)', :no_content, {expected_response_has_content: false, expected_response_content_type: nil})
+    standard_request_options(:delete, 'DESTROY (as owner)', :no_content, expected_response_has_content: false, expected_response_content_type: nil)
   end
 
   delete '/projects/:project_id/sites/:id' do
@@ -448,7 +474,7 @@ resource 'Sites' do
     let(:id) { site.id }
     let(:project_id) { project.id }
     let(:authentication_token) { writer_token }
-    standard_request_options(:delete, 'DESTROY (as writer)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:delete, 'DESTROY (as writer)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   delete '/projects/:project_id/sites/:id' do
@@ -457,7 +483,7 @@ resource 'Sites' do
     let(:id) { site.id }
     let(:project_id) { project.id }
     let(:authentication_token) { reader_token }
-    standard_request_options(:delete, 'DESTROY (as reader)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:delete, 'DESTROY (as reader)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   delete '/projects/:project_id/sites/:id' do
@@ -466,7 +492,7 @@ resource 'Sites' do
     let(:id) { site.id }
     let(:project_id) { project.id }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:delete, 'DESTROY (as other)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:delete, 'DESTROY (as other)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   delete '/projects/:project_id/sites/:id' do
@@ -475,7 +501,7 @@ resource 'Sites' do
     let(:id) { site.id }
     let(:project_id) { project.id }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:delete, 'DESTROY (invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:delete, 'DESTROY (invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   delete '/projects/:project_id/sites/:id' do
@@ -483,7 +509,7 @@ resource 'Sites' do
     sites_project_id_param
     let(:id) { site.id }
     let(:project_id) { project.id }
-    standard_request_options(:delete, 'DESTROY (as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:delete, 'DESTROY (as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_up))
   end
 
   #####################
@@ -492,86 +518,87 @@ resource 'Sites' do
 
   post '/sites/filter' do
     let(:authentication_token) { reader_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'id' => {
-                'in' => ['1', '2', '3', '4', site.id.to_s]
-            }
+          'id' => {
+            'in' => ['1', '2', '3', '4', site.id.to_s]
+          }
         },
         'projection' => {
-            'include' => ['id', 'name']}
-    }.to_json }
+          'include' => ['id', 'name']
+        }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as reader)', :ok,
-                             {
-                                 expected_json_path: 'data/0/project_ids/0',
-                                 data_item_count: 1,
-                                 regex_match: /"project_ids"\:\[[0-9]+\]/,
-                                 response_body_content: "\"project_ids\":[",
-                                 invalid_content: ["\"project_ids\":[{\"id\":", '"description":']
-                             })
+                             expected_json_path: 'data/0/project_ids/0',
+                             data_item_count: 1,
+                             regex_match: /"project_ids"\:\[[0-9]+\]/,
+                             response_body_content: '"project_ids":[',
+                             invalid_content: ['"project_ids":[{"id":', '"description":'])
   end
 
   post '/sites/filter' do
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'id' => {
-                'in' => ['1', '2', '3', '4', site.id.to_s]
-            }
+          'id' => {
+            'in' => ['1', '2', '3', '4', site.id.to_s]
+          }
         },
         'projection' => {
-            'include' => ['id', 'name']
+          'include' => ['id', 'name']
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as writer)', :ok,
-                             {
-                                 expected_json_path: 'data/0/project_ids/0',
-                                 data_item_count: 1,
-                                 regex_match: /"project_ids"\:\[[0-9]+\]/,
-                                 response_body_content: "\"project_ids\":[",
-                                 invalid_content: ["\"project_ids\":[{\"id\":", '"description":']
-                             })
+                             expected_json_path: 'data/0/project_ids/0',
+                             data_item_count: 1,
+                             regex_match: /"project_ids"\:\[[0-9]+\]/,
+                             response_body_content: '"project_ids":[',
+                             invalid_content: ['"project_ids":[{"id":', '"description":'])
   end
 
   post '/sites/filter' do
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'projects.id' => {
-                'in' => [writer_permission.project.id.to_s]
-            }
+          'projects.id' => {
+            'in' => [writer_permission.project.id.to_s]
+          }
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (project ids, as writer)', :ok,
-                             {
-                                 expected_json_path: 'data/0/project_ids/0',
-                                 data_item_count: 1,
-                                 regex_match: /"project_ids"\:\[[0-9]+\]/,
-                                 response_body_content: "\"project_ids\":[",
-                                 invalid_content: "\"project_ids\":[{\"id\":"
-                             })
+                             expected_json_path: 'data/0/project_ids/0',
+                             data_item_count: 1,
+                             regex_match: /"project_ids"\:\[[0-9]+\]/,
+                             response_body_content: '"project_ids":[',
+                             invalid_content: '"project_ids":[{"id":')
   end
 
   post '/sites/filter' do
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'audio_recordings.id' => {
-                'eq' => site.audio_recordings.first.id.to_s
-            }
+          'audio_recordings.id' => {
+            'eq' => site.audio_recordings.first.id.to_s
+          }
         },
         'projection' => {
-            'include' => ['id', 'name']
+          'include' => ['id', 'name']
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (audio recordings id, as writer)', :ok,
-                             {
-                                 expected_json_path: 'data/0/project_ids/0',
-                                 data_item_count: 1,
-                                 regex_match: /"data":\[\{"id":[0-9]+,"name":"site name [0-9]+","project_ids":\[[0-9]+\]/,
-                                 response_body_content: "\"projection\":{\"include\":[\"id\",\"name\"]}",
-                                 invalid_content: "\"project_ids\":[{\"id\":"
-                             })
+                             expected_json_path: 'data/0/project_ids/0',
+                             data_item_count: 1,
+                             regex_match: /"data":\[\{"id":[0-9]+,"name":"site name [0-9]+","project_ids":\[[0-9]+\]/,
+                             response_body_content: '"projection":{"include":["id","name"]}',
+                             invalid_content: '"project_ids":[{"id":')
   end
 
   post '/sites/filter' do
@@ -581,17 +608,17 @@ resource 'Sites' do
       site2.rails_tz = 'Sydney'
       site2.save!
     }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'projection' => {
-            'include' => ['id', 'name']
+          'include' => ['id', 'name']
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as writer checking for timezone info)', :ok,
-                             {
-                                 expected_json_path: ['data/0/project_ids/0', 'data/0/timezone_information'],
-                                 data_item_count: 2,
-                                 response_body_content: '"timezone_information":{"identifier_alt":"Sydney","identifier":"Australia/Sydney","friendly_identifier":"Australia - Sydney","utc_offset":'
-                             })
+                             expected_json_path: ['data/0/project_ids/0', 'data/0/timezone_information'],
+                             data_item_count: 2,
+                             response_body_content: '"timezone_information":{"identifier_alt":"Sydney","identifier":"Australia/Sydney","friendly_identifier":"Australia - Sydney","utc_offset":')
   end
 
   post '/sites/filter' do
@@ -602,16 +629,16 @@ resource 'Sites' do
       site2.tzinfo_tz = 'Australia - Brisbane'
       site2.save!
     }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'projection' => {
-            'include' => ['id', 'name']
+          'include' => ['id', 'name']
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as writer ensuring site timezone is valid)', :ok,
-                             {
-                                 data_item_count: 2,
-                                 response_body_content: ['"timezone_information":{"identifier_alt":"Brisbane","identifier":"Australia/Brisbane","friendly_identifier":"Australia - Brisbane"']
-                             })
+                             data_item_count: 2,
+                             response_body_content: ['"timezone_information":{"identifier_alt":"Brisbane","identifier":"Australia/Brisbane","friendly_identifier":"Australia - Brisbane"'])
   end
 
   post '/sites/filter' do
@@ -619,21 +646,21 @@ resource 'Sites' do
       project = FactoryGirl.create(:project, creator: owner_user, name: 'Anon Project')
       FactoryGirl.create(:permission, creator: owner_user, user: nil, project: project, allow_anonymous: true, level: 'reader')
       site = FactoryGirl.build(:site, creator: owner_user)
-      site.id = 99998712
+      site.id = 99_998_712
       site.projects << project
       site.save!
     }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'projection' => {
-            'include' => ['id', 'name']
+          'include' => ['id', 'name']
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as anonymous user)', :ok,
-                             {remove_auth: true,
-                              data_item_count: 1,
-                              response_body_content: ['99998712'],
-                              expected_json_path: ['data/0/project_ids/0', 'data/0/timezone_information'],
-                             })
+                             remove_auth: true,
+                             data_item_count: 1,
+                             response_body_content: ['99998712'],
+                             expected_json_path: ['data/0/project_ids/0', 'data/0/timezone_information'])
   end
-
 end

--- a/spec/acceptance/sites_spec.rb
+++ b/spec/acceptance/sites_spec.rb
@@ -70,28 +70,28 @@ resource 'Sites' do
     standard_request_options(:get, 'INDEX (as reader)', :ok, expected_json_path: 'data/0/custom_latitude', data_item_count: 1)
   end
 
-  Array[
-    'id',
-    'name',
-    'description',
-    'creator_id',
-    'updater_id',
-    'created_at',
-    'updated_at',
-    'project_ids',
-    'location_obfuscated',
-    'custom_latitude',
-    'custom_longitude',
-    'timezone_information',
-    'description_html',
-    'image_urls'
-  ].each do |x|
-    get '/projects/:project_id/sites' do
-      sites_project_id_param
-      let(:project_id) { project.id }
-      let(:authentication_token) { reader_token }
-      standard_request_options(:get, "INDEX (has #{x}, as reader)", :ok, expected_json_path: "data/0/#{x}", data_item_count: 1)
-    end
+  get '/projects/:project_id/sites' do
+    expected_paths = Array[
+      'id',
+      'name',
+      'description',
+      'creator_id',
+      'updater_id',
+      'created_at',
+      'updated_at',
+      'project_ids',
+      'location_obfuscated',
+      'custom_latitude',
+      'custom_longitude',
+      'timezone_information',
+      'description_html',
+      'image_urls'
+    ].map { |x| "data/0/#{x}" }
+
+    sites_project_id_param
+    let(:project_id) { project.id }
+    let(:authentication_token) { reader_token }
+    standard_request_options(:get, 'INDEX (has parameters, as reader)', :ok, expected_json_path: expected_paths, data_item_count: 1)
   end
 
   get '/projects/:project_id/sites' do

--- a/spec/acceptance/sites_spec.rb
+++ b/spec/acceptance/sites_spec.rb
@@ -86,7 +86,7 @@ resource 'Sites' do
       'timezone_information',
       'description_html',
       'image_urls'
-    ].map { |x| "data/0/#{x}" }
+    ].map { |path| "data/0/#{path}" }
 
     sites_project_id_param
     let(:project_id) { project.id }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -92,18 +92,11 @@ describe Site, type: :model do
       end
     }
   end
-  it 'should belong to many projects' do
-    is_expected.to have_and_belong_to_many :projects
-  end
-  it 'should have creator associated with foreign key' do
-    is_expected.to belong_to(:creator).with_foreign_key(:creator_id)
-  end
-  it 'should have updater associated with foreign key' do
-    is_expected.to belong_to(:updater).with_foreign_key(:updater_id)
-  end
-  it 'should have deleter associated with foreign key' do
-    is_expected.to belong_to(:deleter).with_foreign_key(:deleter_id)
-  end
+  it { is_expected.to have_and_belong_to_many :projects }
+
+  it { is_expected.to belong_to(:creator).with_foreign_key(:creator_id) }
+  it { is_expected.to belong_to(:updater).with_foreign_key(:updater_id) }
+  it { is_expected.to belong_to(:deleter).with_foreign_key(:deleter_id) }
 
   it 'should error on checking orphaned site if site is orphaned' do
     site = FactoryGirl.create(:site, projects: [])

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,38 +1,40 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 latitudes = [
-    {-100 => false},
-    {-91 => false},
-    {-90 => true},
-    {-89 => true},
-    {0 => true},
-    {89 => true},
-    {90 => true},
-    {91 => false},
-    {100 => false}
+  { -100 => false },
+  { -91 => false },
+  { -90 => true },
+  { -89 => true },
+  { 0 => true },
+  { 89 => true },
+  { 90 => true },
+  { 91 => false },
+  { 100 => false }
 ]
 
 longitudes = [
-    {-200 => false},
-    {-181 => false},
-    {-180 => true},
-    {-179 => true},
-    {0 => true},
-    {179 => true},
-    {180 => true},
-    {181 => false},
-    {200 => false}
+  { -200 => false },
+  { -181 => false },
+  { -180 => true },
+  { -179 => true },
+  { 0 => true },
+  { 179 => true },
+  { 180 => true },
+  { 181 => false },
+  { 200 => false }
 ]
 
-describe Site, :type => :model do
+describe Site, type: :model do
   it 'has a valid factory' do
     expect(FactoryGirl.create(:site)).to be_valid
   end
   it 'is invalid without a name' do
-    expect(FactoryGirl.build(:site, :name => nil)).not_to be_valid
+    expect(FactoryGirl.build(:site, name: nil)).not_to be_valid
   end
   it 'requires a name with at least two characters' do
-    s = FactoryGirl.build(:site, :name => 's')
+    s = FactoryGirl.build(:site, name: 's')
     expect(s).not_to be_valid
     expect(s.valid?).to be_falsey
     expect(s.errors[:name].size).to eq(1)
@@ -71,7 +73,7 @@ describe Site, :type => :model do
 
     latitudes.each { |value, pass|
       site.latitude = value
-      if pass then
+      if pass
         expect(site).to be_valid
       else
         expect(site).not_to be_valid
@@ -83,18 +85,25 @@ describe Site, :type => :model do
 
     longitudes.each { |value, pass|
       site.longitude = value
-      if pass then
+      if pass
         expect(site).to be_valid
       else
         expect(site).not_to be_valid
       end
     }
   end
-  it { is_expected.to have_and_belong_to_many :projects }
-
-  it { is_expected.to belong_to(:creator).with_foreign_key(:creator_id) }
-  it { is_expected.to belong_to(:updater).with_foreign_key(:updater_id) }
-  it { is_expected.to belong_to(:deleter).with_foreign_key(:deleter_id) }
+  it 'should belong to many projects' do
+    is_expected.to have_and_belong_to_many :projects
+  end
+  it 'should have creator associated with foreign key' do
+    is_expected.to belong_to(:creator).with_foreign_key(:creator_id)
+  end
+  it 'should have updater associated with foreign key' do
+    is_expected.to belong_to(:updater).with_foreign_key(:updater_id)
+  end
+  it 'should have deleter associated with foreign key' do
+    is_expected.to belong_to(:deleter).with_foreign_key(:deleter_id)
+  end
 
   it 'should error on checking orphaned site if site is orphaned' do
     site = FactoryGirl.create(:site, projects: [])
@@ -106,10 +115,10 @@ describe Site, :type => :model do
   it 'generates html for description' do
     md = "# Header\r\n [a link](https://github.com)."
     html = "<h1>Header</h1>\n<p><a href=\"https://github.com\">a link</a>.</p>\n"
-    projectHtml = FactoryGirl.create(:site, description: md)
+    project_html = FactoryGirl.create(:site, description: md)
 
-    expect(projectHtml.description).to eq(md)
-    expect(projectHtml.description_html).to eq(html)
+    expect(project_html.description).to eq(md)
+    expect(project_html.description_html).to eq(html)
 
   end
 


### PR DESCRIPTION
# Missing Site Model Details

Updated the `filter_settings` output of the sites model

## Changes

- Extracted image_urls from User model into `Api::Image.image_urls` so that it is reusable for other models
- Updated document formatting to be compatible with rubocop for some files
- Added model output checking for INDEX site route
- Modified `filter_settings` for Site model

## Closes 

Closes #453 
