### PR TITLE
Missing tag model details

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
     - 'script/**/*'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 # Rails:
 #   Enabled: true
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,16 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Start Passenger",
+      "type": "shell",
+      "command": "passenger start",
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    },
+    {
       "label": "Stop Passenger",
       "type": "shell",
       "command": "passenger stop",

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module Admin
   class TagsController < BaseController
-
     # GET /admin/tags(.:format)
     def index
       page = paging_params[:page].blank? ? 1 : paging_params[:page].to_i
@@ -11,15 +12,15 @@ module Admin
 
       filter = paging_params[:filter]
 
-      fail 'Invalid order by.' unless [:text, :is_taxanomic, :type_of_tag, :retired, :updated_at, :updater_id].include?(order_by)
-      fail 'Invalid order dir.' unless [:asc, :desc].include?(order_dir)
+      raise 'Invalid order by.' unless [:text, :is_taxanomic, :type_of_tag, :retired, :updated_at, :updater_id].include?(order_by)
+      raise 'Invalid order dir.' unless [:asc, :desc].include?(order_dir)
 
       redirect_to admin_tags_path if commit.downcase == 'clear'
 
       @tags_info = {
-          order_by: order_by,
-          order_dir: order_dir,
-          filter: filter
+        order_by: order_by,
+        order_dir: order_dir,
+        filter: filter
       }
 
       query = Tag.includes(:updater).references(:users).all
@@ -101,6 +102,5 @@ module Admin
     def paging_params
       params.permit(:page, :order_by, :order_dir, :filter, :commit)
     end
-
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -628,19 +628,16 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     end
   end
 
-  def sanitize_notes(json)
-    if json.nil?
-      nil
-    elsif json.is_a? Hash
-      json
-    elsif json.is_a? String
-      begin
-        JSON.parse(json)
-      rescue JSON::ParserError => _e
-        { 'comment' => json }
-      end
-    else
-      raise CustomErrors::BadRequestError, 'Invalid notes input.'
+  def sanitize_associative_array(json, field_name, key = 'comment')
+    return nil if json.nil?
+    return { key => json } if json.is_a? Array
+    return json if json.is_a? Hash
+    raise CustomErrors::BadRequestError, "Invalid #{field_name} input." unless json.is_a? String
+
+    begin
+      return JSON.parse(json)
+    rescue JSON::ParserError => _e
+      return { key => json }
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
-class ApplicationController < ActionController::Base
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base # rubocop:disable Metrics/ClassLength
   include Api::ApiAuth
 
   layout :select_layout
@@ -48,7 +50,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from CustomErrors::BadRequestError, with: :bad_request_error_response
 
-  # error handling for cancan authorisation checks
+  # error handling for cancan authorization checks
   rescue_from CanCan::AccessDenied, with: :access_denied_response
 
   # Prevent CSRF attacks by raising an exception.
@@ -64,7 +66,8 @@ class ApplicationController < ActionController::Base
 
   # update users last activity log every 10 minutes
   before_action :set_last_seen_at,
-                if: Proc.new { user_signed_in? &&
+                if: proc {
+                  user_signed_in? &&
                     (session[:last_seen_at].blank? || Time.zone.at(session[:last_seen_at].to_i) < 10.minutes.ago)
                 }
 
@@ -88,17 +91,16 @@ class ApplicationController < ActionController::Base
   inflection_method :possessive_determiner
 
   def possessive_determiner
-    current_user&.id != nil && User.same_user?(current_user, @user) ? :my : :their
+    !current_user&.id.nil? && User.same_user?(current_user, @user) ? :my : :their
   end
 
   # Add archived at header to HTTP response
   # @param [ActiveRecord::Base] model
   # @return [void]
   def add_archived_at_header(model)
-    if model.respond_to?(:deleted_at) && !model.deleted_at.blank?
-      # response header must be a string, can't just pass a Date or Time
-      response.headers['X-Archived-At'] = model.deleted_at.httpdate
-    end
+    return if !model.respond_to?(:deleted_at) || model.deleted_at.blank?
+
+    response.headers['X-Archived-At'] = model.deleted_at.httpdate
   end
 
   def add_header_length(length)
@@ -106,11 +108,11 @@ class ApplicationController < ActionController::Base
   end
 
   def no_content_as_json
-    head :no_content, :content_type => 'application/json'
+    head :no_content, content_type: 'application/json'
   end
 
   def json_request?
-    request.format && request.format.json?
+    request.format&.json?
   end
 
   # CSRF protection is enabled for API.
@@ -146,21 +148,21 @@ class ApplicationController < ActionController::Base
     #authorize! :show, @audio_recording
 
     audio_recording = AudioRecording.where(id: request_params[:audio_recording_id]).first
-    fail CustomErrors::ItemNotFoundError, "Could not find audio recording with id #{request_params[:audio_recording_id]}." if audio_recording.blank?
+    raise CustomErrors::ItemNotFoundError, "Could not find audio recording with id #{request_params[:audio_recording_id]}." if audio_recording.blank?
 
     # can? also checks for admin access
     can_access_audio_recording = can? action, audio_recording
 
     # Can't do anything if can't access audio recording and no audio event id given
     has_any_permission = can_access_audio_recording || !request_params[:audio_event_id].blank?
-    fail CanCan::AccessDenied, "Permission denied to audio recording id #{request_params[:audio_recording_id]} and no audio event id given." unless has_any_permission
+    raise CanCan::AccessDenied, "Permission denied to audio recording id #{request_params[:audio_recording_id]} and no audio event id given." unless has_any_permission
 
     audio_recording
   end
 
   def auth_custom_audio_event(request_params, audio_recording)
     audio_event = AudioEvent.where(id: request_params[:audio_event_id]).first
-    fail CustomErrors::ItemNotFoundError, "Could not find audio event with id #{request_params[:audio_event_id]}." if audio_event.blank?
+    raise CustomErrors::ItemNotFoundError, "Could not find audio event with id #{request_params[:audio_event_id]}." if audio_event.blank?
 
     # can? also checks for admin access
     can_access_audio_event = can? :show, audio_event
@@ -169,21 +171,21 @@ class ApplicationController < ActionController::Base
     has_any_permission = can_access_audio_event || is_reference
 
     unless matching_ids
-      msg = "Requested audio event (#{audio_event.audio_recording_id}) " +
-          "and audio recording (#{audio_recording.id}) must be related."
-      fail CanCan::AccessDenied, msg
+      msg = "Requested audio event (#{audio_event.audio_recording_id}) " \
+            "and audio recording (#{audio_recording.id}) must be related."
+      raise CanCan::AccessDenied, msg
     end
 
     unless has_any_permission
-      msg = "Permission denied to audio event (#{audio_event.id})"+
-          'and it is not a marked as reference.'
-      fail CanCan::AccessDenied, msg
+      msg = "Permission denied to audio event (#{audio_event.id})" \
+            'and it is not a marked as reference.'
+      raise CanCan::AccessDenied, msg
     end
 
     audio_event
   end
 
-  # Authorise audio event by audio recording and offsets
+  # Authorize audio event by audio recording and offsets
   # @param [Hash] request_params
   # @param [AudioRecording] audio_recording
   # @param [AudioEvent] audio_event
@@ -210,19 +212,20 @@ class ApplicationController < ActionController::Base
 
     if start_offset < allowable_start_offset
       msg2 = "start offset (#{start_offset}) was less than allowable bounds (#{allowable_start_offset}) "
-      fail CanCan::AccessDenied, msg1 + msg2 + msg3
+      raise CanCan::AccessDenied, msg1 + msg2 + msg3
     end
 
     if end_offset > allowable_end_offset
       msg2 = "end offset (#{end_offset}) was greater than allowable bounds (#{allowable_end_offset}) "
-      fail CanCan::AccessDenied, msg1 + msg2 + msg3
+      raise CanCan::AccessDenied, msg1 + msg2 + msg3
     end
-
   end
 
+  # TODO: Simplify Function
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
   def render_error(status_symbol, detail_message, error, method_name, options = {})
-    options.merge!({ error_details: detail_message }) # overwrites error_details
-    options.reverse_merge!({ should_notify_error: true }) # default for should_notify_error is true, value in options will overwrite
+    options.merge!(error_details: detail_message) # overwrites error_details
+    options.reverse_merge!(should_notify_error: true) # default for should_notify_error is true, value in options will overwrite
 
     # notify of exception when head requests AND when should_notify_error is true
     should_notify_error = request.head? && (options.include?(:should_notify_error) && options[:should_notify_error])
@@ -231,12 +234,13 @@ class ApplicationController < ActionController::Base
 
     if should_notify_error
       ExceptionNotifier.notify_exception(
-          error,
-          env: request.env,
-          data: {
-              method_name: method_name,
-              json_response: json_response
-          })
+        error,
+        env: request.env,
+        data: {
+          method_name: method_name,
+          json_response: json_response
+        }
+      )
     end
 
     # method_name = __method__
@@ -248,10 +252,10 @@ class ApplicationController < ActionController::Base
     # add additional error message in here for sanity
     headers['X-Error-Message'] = error.message if request.head? && !error.nil?
 
-    respond_to do |format|
+    respond_to do |format| # rubocop:disable Metrics/BlockLength
       # format.all will be used for Accept: */* as it is first in the list
       # http://blogs.thewehners.net/josh/posts/354-obscure-rails-bug-respond_to-formatany
-      format.all {
+      format.all do
         actual_format = request.format.to_s
 
         if actual_format.start_with?('audio') || actual_format.start_with?('image')
@@ -264,10 +268,10 @@ class ApplicationController < ActionController::Base
         else
           render json: json_response, status: status_symbol, content_type: 'application/json'
         end
-      }
-      format.json {
+      end
+      format.json do
         render json: json_response, status: status_symbol
-      }
+      end
       format.html {
 
         status_code = Settings.api_response.status_code(status_symbol)
@@ -276,11 +280,11 @@ class ApplicationController < ActionController::Base
         response_links = Settings.api_response.response_error_links(options[:error_links])
 
         @details = {
-            code: status_code,
-            phrase: status_message,
-            message: detail_message,
-            links: response_links,
-            supported_media: []
+          code: status_code,
+          phrase: status_message,
+          message: detail_message,
+          links: response_links,
+          supported_media: []
         }
 
         if options[:error_info] && options[:error_info][:available_formats]
@@ -304,10 +308,15 @@ class ApplicationController < ActionController::Base
       }
     end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name, :email, :password, :password_confirmation])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:user_name, :email, :password, :password_confirmation, :current_password, :image, :tzinfo_tz])
+    devise_parameter_sanitizer.permit(
+      :account_update, keys: [
+        :user_name, :email, :password, :password_confirmation, :current_password, :image, :tzinfo_tz
+      ]
+    )
   end
 
   def after_sign_in_path_for(resource)
@@ -321,75 +330,78 @@ class ApplicationController < ActionController::Base
   # all create and update actions should have post parameters. If not, in addition to not doing anything,
   # they might cause errors where these parameters are expected
   def validate_contains_post_params
-
     # post values should be in the form {model => {attr => value, attr2 => value}}
     # an empty body parsed as json will have the form {model => {}}
     # json body with application/x-www-form-urlencoded content type will have the form {json_string => {}}
     # json or form encoded with text/plain content type will have the form {}
-    if request.POST.values.all? { |val| val.blank? }
+    return unless request.POST.values.all?(&:blank?)
 
-      if (request.body.string.blank?)
-        message = "Request body was empty"
-        status = :bad_request
-        # include link to 'new' endpoint if body was empty
-        options = {should_notify_error: true, error_links: [{text: "New Resource", url: self.send("new_#{resource_name}_path")}]}
+    if request.body.string.blank?
+      message = 'Request body was empty'
+      status = :bad_request
+      # include link to 'new' endpoint if body was empty
+      options = { should_notify_error: true, error_links: [{ text: 'New Resource', url: send("new_#{resource_name}_path") }] }
+    else
+      options = { should_notify_error: true }
+      status = :unsupported_media_type
+      if request.content_type == 'text/plain'
+        message = 'Request content-type text/plain not supported'
       else
-        options = {should_notify_error: true}
-        status = :unsupported_media_type
-        if request.content_type == "text/plain"
-          message = "Request content-type text/plain not supported"
-        else
-          # Catch anything else, but should not reach here because body parsing will have already crashed for
-          # malformed encoding for anything other than text/plain
-          message = "Failed to parse the request body. Ensure that it is formed correctly and matches the content-type (#{request.content_type})"
-        end
+        # Catch anything else, but should not reach here because body parsing will have already crashed for
+        # malformed encoding for anything other than text/plain
+        message = "Failed to parse the request body. Ensure that it is formed correctly and matches the content-type (#{request.content_type})"
       end
-      render_error(status, message, nil, 'validate_contains_params', options)
     end
+    render_error(status, message, nil, 'validate_contains_params', options)
   end
 
   private
 
   def record_not_found_response(error)
     render_error(
-        :not_found,
-        'Could not find the requested item.',
-        error,
-        'record_not_found_response'
+      :not_found,
+      'Could not find the requested item.',
+      error,
+      'record_not_found_response'
     )
   end
 
   def item_not_found_error_response(error)
     # #render json: {code: 404, phrase: 'Not Found', message: 'Audio recording is not ready'}, status: :not_found
     render_error(
-        :not_found,
-        "Could not find the requested item: #{error.message}",
-        error,
-        'item_not_found_error_response',
-        {should_notify_error: false}
+      :not_found,
+      "Could not find the requested item: #{error.message}",
+      error,
+      'item_not_found_error_response',
+      should_notify_error: false
     )
   end
 
   def record_not_unique_response(error)
     render_error(
-        :conflict,
-        'The item must be unique.',
-        error,
-        'record_not_unique_response'
+      :conflict,
+      'The item must be unique.',
+      error,
+      'record_not_unique_response'
     )
   end
 
   def unsupported_media_type_error_response(error)
     # 415 - Unsupported Media Type
     # they sent what we don't want
-    # render json: {code: 415, phrase: 'Unsupported Media Type', message: 'Requested format is invalid. It must be one of available_formats.', available_formats: @available_formats}, status: :unsupported_media_type
+    # render json: {
+    #   code: 415,
+    #   phrase: 'Unsupported Media Type',
+    #   message: 'Requested format is invalid. It must be one of available_formats.',
+    #   available_formats: @available_formats
+    # }, status: :unsupported_media_type
 
     render_error(
-        :unsupported_media_type,
-        "The format of the request is not supported: #{error.message}",
-        error,
-        'unsupported_media_type_error_response',
-        {error_info: {available_formats: error.available_formats_info}}
+      :unsupported_media_type,
+      "The format of the request is not supported: #{error.message}",
+      error,
+      'unsupported_media_type_error_response',
+      error_info: { available_formats: error.available_formats_info }
     )
   end
 
@@ -400,11 +412,11 @@ class ApplicationController < ActionController::Base
     request.format = :json
 
     render_error(
-        :method_not_allowed,
-        "The method received the request is known by the server but not supported by the target resource: #{error.message}",
-        error,
-        'method_not_allowed_error_response',
-        {error_info: {available_methods: error.available_methods.map { |x| x.to_s.upcase }}}
+      :method_not_allowed,
+      "The method received the request is known by the server but not supported by the target resource: #{error.message}",
+      error,
+      'method_not_allowed_error_response',
+      error_info: { available_methods: error.available_methods.map { |x| x.to_s.upcase } }
     )
   end
 
@@ -415,22 +427,22 @@ class ApplicationController < ActionController::Base
     request.format = :json
 
     render_error(
-        :not_acceptable,
-        "None of the acceptable response formats are available: #{error.message}",
-        error,
-        'not_acceptable_error_response',
-        {error_info: {available_formats: error.available_formats_info}}
+      :not_acceptable,
+      "None of the acceptable response formats are available: #{error.message}",
+      error,
+      'not_acceptable_error_response',
+      error_info: { available_formats: error.available_formats_info }
     )
   end
 
   def unprocessable_entity_error_response(error)
-    options = error.additional_details.nil? ? {} : {error_info: error.additional_details}
+    options = error.additional_details.nil? ? {} : { error_info: error.additional_details }
     render_error(
-        :unprocessable_entity,
-        "The request could not be understood: #{error.message}",
-        error,
-        'unprocessable_entity_error_response',
-        options
+      :unprocessable_entity,
+      "The request could not be understood: #{error.message}",
+      error,
+      'unprocessable_entity_error_response',
+      options
     )
   end
 
@@ -438,19 +450,19 @@ class ApplicationController < ActionController::Base
     # render json: {code: 400, phrase: 'Bad Request', message: 'Invalid request'}, status: :bad_request
 
     render_error(
-        :bad_request,
-        'The request was not valid.',
-        error,
-        'bad_request_response',
+      :bad_request,
+      'The request was not valid.',
+      error,
+      'bad_request_response'
     )
   end
 
   def invalid_csrf_response(error)
     render_error(
-        :bad_request,
-        'The request could not be verified.',
-        error,
-        'invalid_csrf_response',
+      :bad_request,
+      'The request could not be verified.',
+      error,
+      'invalid_csrf_response'
     )
   end
 
@@ -460,115 +472,117 @@ class ApplicationController < ActionController::Base
     request.format = :json
 
     render_error(
-        :not_acceptable,
-        "This resource is not available in this format '#{request.format}'.",
-        error,
-        'unknown_format_response'
+      :not_acceptable,
+      "This resource is not available in this format '#{request.format}'.",
+      error,
+      'unknown_format_response'
     )
   end
 
   def access_denied_response(error)
-    if current_user && current_user.confirmed?
+    if current_user&.confirmed?
       render_error(
-          :forbidden,
-          I18n.t('devise.failure.unauthorized'),
-          error,
-          'access_denied_response - forbidden',
-          {error_links: [:permissions]})
+        :forbidden,
+        I18n.t('devise.failure.unauthorized'),
+        error,
+        'access_denied_response - forbidden',
+        error_links: [:permissions]
+      )
 
     elsif current_user && !current_user.confirmed?
       render_error(
-          :forbidden,
-          I18n.t('devise.failure.unconfirmed'),
-          error,
-          'access_denied_response - unconfirmed',
-          {error_links: [:confirm]})
+        :forbidden,
+        I18n.t('devise.failure.unconfirmed'),
+        error,
+        'access_denied_response - unconfirmed',
+        error_links: [:confirm]
+      )
 
     else
 
       render_error(
-          :unauthorized,
-          I18n.t('devise.failure.unauthenticated'),
-          error,
-          'access_denied_response - unauthorised',
-          {error_links: [:sign_in, :sign_up, :confirm]})
+        :unauthorized,
+        I18n.t('devise.failure.unauthenticated'),
+        error,
+        'access_denied_response - unauthorized',
+        error_links: [:sign_in, :sign_up, :confirm]
+      )
 
     end
   end
 
   def routing_argument_error_response(error)
     render_error(
-        :not_found,
-        "Could not find the requested page: #{error.message}",
-        error,
-        'routing_argument_error_response',
-        {error_info: {original_route: request.env['PATH_INFO'], original_http_method: request.method}}
+      :not_found,
+      "Could not find the requested page: #{error.message}",
+      error,
+      'routing_argument_error_response',
+      error_info: { original_route: request.env['PATH_INFO'], original_http_method: request.method }
     )
   end
 
   def bad_request_error_response(error)
     render_error(
-        :bad_request,
-        "The request was not valid: #{error.message}",
-        error,
-        'bad_request_error_response',
+      :bad_request,
+      "The request was not valid: #{error.message}",
+      error,
+      'bad_request_error_response'
     )
   end
 
   def filter_argument_error_response(error)
     render_error(
-        :bad_request,
-        "Filter parameters were not valid: #{error.message}",
-        error,
-        'filter_argument_error_response',
-        {error_info: error.filter_segment}
+      :bad_request,
+      "Filter parameters were not valid: #{error.message}",
+      error,
+      'filter_argument_error_response',
+      error_info: error.filter_segment
     )
   end
 
   def audio_generation_error_response(error)
     render_error(
-        :internal_server_error,
-        "Audio generation failed: #{error.message}",
-        error,
-        'audio_generation_error_response',
-        {error_info: error.job_info}
+      :internal_server_error,
+      "Audio generation failed: #{error.message}",
+      error,
+      'audio_generation_error_response',
+      error_info: error.job_info
     )
   end
 
   def audio_tool_error_response(error)
     render_error(
-        :internal_server_error,
-        "Audio generation failed: #{error.message}",
-        error,
-        'audio_tool_error_response'
+      :internal_server_error,
+      "Audio generation failed: #{error.message}",
+      error,
+      'audio_tool_error_response'
     )
   end
 
   def not_implemented_response(error)
     render_error(
-        :not_implemented,
-        'The service is not ready for use',
-        error,
-        'not_implemented_response'
+      :not_implemented,
+      'The service is not ready for use',
+      error,
+      'not_implemented_response'
     )
   end
 
   def resource_representation_caching_fixes
     # send Vary: Accept for all text/html and application/json responses
-    if response.content_type == 'text/html' || response.content_type == 'application/json'
-      response.headers['Vary'] = 'Accept'
-    end
+    return unless response.content_type == 'text/html' || response.content_type == 'application/json'
+
+    response.headers['Vary'] = 'Accept'
   end
 
   def log_original_error(method_name, error, response_given)
-
     msg = "Error handled by #{method_name} in application or errors controller."
 
-    if error.blank?
-      msg += ' No original error.'
-    else
-      msg += " Original error: #{error.inspect}."
-    end
+    msg += if error.blank?
+             ' No original error.'
+           else
+             " Original error: #{error.inspect}."
+           end
 
     msg += " Response given: #{response_given}."
 
@@ -584,14 +598,12 @@ class ApplicationController < ActionController::Base
   end
 
   def set_then_reset_user_stamper
-    begin
-      # TODO: this causes a deprecation warning if nil is
-      # given to Devise::Strategies::DatabaseAuthenticatable#validate
-      User.stamper = self.current_user
-      yield
-    ensure
-      User.stamper = nil
-    end
+    # TODO: this causes a deprecation warning if nil is
+    # given to Devise::Strategies::DatabaseAuthenticatable#validate
+    User.stamper = current_user
+    yield
+  ensure
+    User.stamper = nil
   end
 
   def set_last_seen_at
@@ -608,12 +620,11 @@ class ApplicationController < ActionController::Base
   end
 
   def validate_headers
-    if response.headers.has_key?('Content-Length') && response.headers['Content-Length'].to_i < 0
+    if response.headers.key?('Content-Length') && response.headers['Content-Length'].to_i.negative?
       raise CustomErrors::BadHeaderError
     end
-    if response.headers.has_key?(:content_length) && response.headers[:content_length].to_i < 0
+    if response.headers.key?(:content_length) && response.headers[:content_length].to_i.negative?
       raise CustomErrors::BadHeaderError
     end
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -627,4 +627,20 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
       raise CustomErrors::BadHeaderError
     end
   end
+
+  def sanitize_notes(json)
+    if json.nil?
+      nil
+    elsif json.is_a? Hash
+      json
+    elsif json.is_a? String
+      begin
+        JSON.parse(json)
+      rescue JSON::ParserError => _e
+        { 'comment' => json }
+      end
+    else
+      raise CustomErrors::BadRequestError, 'Invalid notes input.'
+    end
+  end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -71,6 +71,11 @@ class TagsController < ApplicationController
   private
 
   def tag_params
-    params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired, :notes)
+    # TODO: Replace with the following after upgrading Ruby to v5.1.2 or later
+    # params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired, notes: {})
+    notes = params[:tag].delete(:notes)
+    params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired).tap do |whitelisted|
+      whitelisted[:notes] = notes
+    end
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -71,7 +71,10 @@ class TagsController < ApplicationController
   private
 
   def tag_params
-    # TODO: Replace with the following after upgrading Ruby to v5.1.2 or later
+    # Sanitize notes input
+    params[:tag][:notes] = sanitize_notes params[:tag][:notes]
+
+    # TODO: Replace with the following after upgrading Rails to v5.1.2 or later
     # params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired, notes: {})
     notes = params[:tag].delete(:notes)
     params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired).tap do |whitelisted|

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TagsController < ApplicationController
   include Api::ControllerHelper
 
@@ -15,10 +17,10 @@ class TagsController < ApplicationController
     end
 
     @tags, opts = Settings.api_response.response_advanced(
-        api_filter_params,
-        query,
-        Tag,
-        Tag.filter_settings
+      api_filter_params,
+      query,
+      Tag,
+      Tag.filter_settings
     )
     respond_index(opts)
   end
@@ -58,10 +60,10 @@ class TagsController < ApplicationController
     do_authorize_class
 
     filter_response, opts = Settings.api_response.response_advanced(
-        api_filter_params,
-        Tag.all,
-        Tag,
-        Tag.filter_settings
+      api_filter_params,
+      Tag.all,
+      Tag,
+      Tag.filter_settings
     )
     respond_filter(filter_response, opts)
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -72,7 +72,7 @@ class TagsController < ApplicationController
 
   def tag_params
     # Sanitize notes input
-    params[:tag][:notes] = sanitize_notes params[:tag][:notes]
+    params[:tag][:notes] = sanitize_associative_array(params[:tag][:notes], 'notes')
 
     # TODO: Replace with the following after upgrading Rails to v5.1.2 or later
     # params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired, notes: {})

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -95,7 +95,10 @@ class Tag < ActiveRecord::Base
         :id, :text, :is_taxanomic, :type_of_tag, :retired, :notes,
         :creator_id, :created_at, :updater_id, :updated_at
       ],
-      render_fields: [:id, :text, :is_taxanomic, :type_of_tag, :retired],
+      render_fields: [
+        :id, :text, :is_taxanomic, :type_of_tag, :retired, :creator_id,
+        :updater_id, :created_at, :updated_at, :notes
+      ],
       text_fields: [:text, :type_of_tag, :notes],
       controller: :tags,
       action: :filter,

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -118,7 +118,6 @@ class Tag < ActiveRecord::Base
               available: true
             }
           ]
-
         }
       ]
     }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -74,7 +74,7 @@ class Tag < ActiveRecord::Base
     return nil if tags.empty?
 
     first = tags.first
-    return first if first.type_of_tag.to_s == 'common_name'
+    return first if first.type_of_tag == 'common_name'
 
     first_common = nil
     first_species = nil

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tag < ActiveRecord::Base
   extend Enumerize
 
@@ -14,16 +16,16 @@ class Tag < ActiveRecord::Base
   accepts_nested_attributes_for :audio_events
 
   # enums
-  AVAILABLE_TYPE_OF_TAGS_SYMBOLS = [:general, :common_name, :species_name, :looks_like, :sounds_like]
-  AVAILABLE_TYPE_OF_TAGS = AVAILABLE_TYPE_OF_TAGS_SYMBOLS.map { |item| item.to_s }
+  AVAILABLE_TYPE_OF_TAGS_SYMBOLS = [:general, :common_name, :species_name, :looks_like, :sounds_like].freeze
+  AVAILABLE_TYPE_OF_TAGS = AVAILABLE_TYPE_OF_TAGS_SYMBOLS.map(&:to_s)
 
   AVAILABLE_TYPE_OF_TAGS_DISPLAY = [
-      {id: :general, name: 'General'},
-      {id: :common_name, name: 'Common Name'},
-      {id: :species_name, name: 'Scientific Name'},
-      {id: :looks_like, name: 'Looks like'},
-      {id: :sounds_like, name: 'Sounds Like'},
-  ]
+    { id: :general, name: 'General' },
+    { id: :common_name, name: 'Common Name' },
+    { id: :species_name, name: 'Scientific Name' },
+    { id: :looks_like, name: 'Looks like' },
+    { id: :sounds_like, name: 'Sounds Like' }
+  ].freeze
 
   enumerize :type_of_tag, in: AVAILABLE_TYPE_OF_TAGS, predicates: true
 
@@ -31,9 +33,9 @@ class Tag < ActiveRecord::Base
   validates :creator, existence: true
 
   # attribute validations
-  validates :is_taxanomic, inclusion: {in: [true, false]}
-  validates :text, uniqueness: {case_sensitive: false}, presence: true
-  validates :retired, inclusion: {in: [true, false]}
+  validates :is_taxanomic, inclusion: { in: [true, false] }
+  validates :text, uniqueness: { case_sensitive: false }, presence: true
+  validates :retired, inclusion: { in: [true, false] }
   validates :type_of_tag, presence: true
   validate :taxonomic_enforced
 
@@ -47,30 +49,29 @@ class Tag < ActiveRecord::Base
   #Tag.joins(:taggings).select('tags.*, count(tag_id) as "tag_count"').group(:tag_id).order(' tag_count desc')
 
   def taxonomic_enforced
-    if self.type_of_tag == 'common_name' || self.type_of_tag == 'species_name'
-      errors.add(:is_taxanomic, "must be true for #{self.type_of_tag}") unless self.is_taxanomic
+    if type_of_tag == 'common_name' || type_of_tag == 'species_name'
+      errors.add(:is_taxanomic, "must be true for #{type_of_tag}") unless is_taxanomic
     else
-      errors.add(:is_taxanomic, "must be false for #{self.type_of_tag}") if self.is_taxanomic
+      errors.add(:is_taxanomic, "must be false for #{type_of_tag}") if is_taxanomic
     end
-
   end
 
   def self.user_top_tags(user)
     query = sanitize_sql_array(
-['select (select tags.text from tags where tags.id = audio_events_tags.tag_id) as tag_name, count(*) as tag_count
-from audio_events_tags
-inner join tags on audio_events_tags.tag_id = tags.id
-where audio_events_tags.creator_id = :user_id
-group by audio_events_tags.tag_id
-order by count(*) DESC
-limit 10', {user_id: user.id}])
+      ['select (select tags.text from tags where tags.id = audio_events_tags.tag_id) as tag_name, count(*) as tag_count
+      from audio_events_tags
+      inner join tags on audio_events_tags.tag_id = tags.id
+      where audio_events_tags.creator_id = :user_id
+      group by audio_events_tags.tag_id
+      order by count(*) DESC
+      limit 10', { user_id: user.id }]
+    )
     Tag.connection.select_all(query)
   end
 
   # @param [Tag] tags
   def self.get_priority_tag(tags)
-
-    return nil if tags.size < 1
+    return nil if tags.empty?
 
     first = tags.first
     return first if first.type_of_tag.to_s == 'common_name'
@@ -79,9 +80,9 @@ limit 10', {user_id: user.id}])
     first_species = nil
     first_other = nil
     tags.each do |tag|
-      first_common = tag if tag.type_of_tag == 'common_name' && first_common == nil
-      first_species = tag if tag.type_of_tag == 'species_name' && first_common == nil
-      first_other = tag if first_other == nil
+      first_common = tag if tag.type_of_tag == 'common_name' && first_common.nil?
+      first_species = tag if tag.type_of_tag == 'species_name' && first_common.nil?
+      first_other = tag if first_other.nil?
     end
 
     first_common || first_species || first_other
@@ -90,34 +91,33 @@ limit 10', {user_id: user.id}])
   # Define filter api settings
   def self.filter_settings
     {
-        valid_fields: [
-            :id, :text, :is_taxanomic, :type_of_tag, :retired, :notes,
-            :creator_id, :created_at, :updater_id, :updated_at
-        ],
-        render_fields: [:id, :text, :is_taxanomic, :type_of_tag, :retired],
-        text_fields: [:text, :type_of_tag, :notes],
-        controller: :tags,
-        action: :filter,
-        defaults: {
-            order_by: :text,
-            direction: :asc
-        },
-        valid_associations: [
+      valid_fields: [
+        :id, :text, :is_taxanomic, :type_of_tag, :retired, :notes,
+        :creator_id, :created_at, :updater_id, :updated_at
+      ],
+      render_fields: [:id, :text, :is_taxanomic, :type_of_tag, :retired],
+      text_fields: [:text, :type_of_tag, :notes],
+      controller: :tags,
+      action: :filter,
+      defaults: {
+        order_by: :text,
+        direction: :asc
+      },
+      valid_associations: [
+        {
+          join: Tagging,
+          on: Tag.arel_table[:id].eq(Tagging.arel_table[:tag_id]),
+          available: true,
+          associations: [
             {
-                join: Tagging,
-                on: Tag.arel_table[:id].eq(Tagging.arel_table[:tag_id]),
-                available: true,
-                associations: [
-                    {
-                        join: AudioEvent,
-                        on: Tagging.arel_table[:audio_event_id].eq(AudioEvent.arel_table[:id]),
-                        available: true
-                    }
-                ]
-
+              join: AudioEvent,
+              on: Tagging.arel_table[:audio_event_id].eq(AudioEvent.arel_table[:id]),
+              available: true
             }
-        ]
+          ]
+
+        }
+      ]
     }
   end
-
 end

--- a/db/migrate/20200612004608_change_tag_notes_to_json.rb
+++ b/db/migrate/20200612004608_change_tag_notes_to_json.rb
@@ -11,15 +11,15 @@ class ChangeTagNotesToJson < ActiveRecord::Migration
           EXCEPTION WHEN others THEN
             RETURN FALSE;
           END;
-          RETURN TRUE;
+
+          RETURN json_typeof(x) = 'object';
         END;
       $$ LANGUAGE plpgsql IMMUTABLE;
 
       ALTER TABLE "tags"
         ALTER COLUMN "notes" TYPE jsonb
         USING CASE
-          WHEN notes is NULL THEN '{}'::json
-          WHEN notes = '' THEN '{}'::json
+          WHEN (notes <> '') is NOT TRUE THEN NULL
           WHEN pg_temp.is_json(notes) THEN notes::json
           ELSE json_build_object('comment', notes)
         END

--- a/db/migrate/20200612004608_change_tag_notes_to_json.rb
+++ b/db/migrate/20200612004608_change_tag_notes_to_json.rb
@@ -2,27 +2,30 @@ class ChangeTagNotesToJson < ActiveRecord::Migration
   def change
     # https://www.citusdata.com/blog/2016/07/14/choosing-nosql-hstore-json-jsonb/
     execute <<~SQL
-      CREATE OR REPLACE FUNCTION pg_temp.is_json(varchar) RETURNS boolean AS $$
+      CREATE OR REPLACE FUNCTION pg_temp.is_json(input TEXT) RETURNS boolean AS $$
         DECLARE
-          x json;
+          data json;
         BEGIN
           BEGIN
-            x := $1;
+            data := input;
           EXCEPTION WHEN others THEN
             RETURN FALSE;
           END;
-
-          RETURN json_typeof(x) = 'object';
+          RETURN TRUE;
         END;
       $$ LANGUAGE plpgsql IMMUTABLE;
 
       ALTER TABLE "tags"
         ALTER COLUMN "notes" TYPE jsonb
         USING CASE
-          WHEN (notes <> '') is NOT TRUE THEN NULL
-          WHEN pg_temp.is_json(notes) THEN notes::json
+          WHEN (notes <> '') is NOT TRUE
+            THEN NULL
+          WHEN pg_temp.is_json(notes) AND json_typeof(notes::json) = 'object'
+            THEN notes::json
+          WHEN pg_temp.is_json(notes) AND NOT json_typeof(notes::json) = 'string'
+            THEN json_build_object('comment', notes::json)
           ELSE json_build_object('comment', notes)
-        END
+      END
     SQL
   end
 end

--- a/db/migrate/20200612004608_change_tag_notes_to_json.rb
+++ b/db/migrate/20200612004608_change_tag_notes_to_json.rb
@@ -1,14 +1,28 @@
 class ChangeTagNotesToJson < ActiveRecord::Migration
   def change
     # https://www.citusdata.com/blog/2016/07/14/choosing-nosql-hstore-json-jsonb/
-    change_column :tags, :notes, :jsonb, using: <<~SQL
-      CASE
-        WHEN notes is NULL
-          THEN \'{}\'::json
-        WHEN notes = \'\'
-          THEN \'{}\'::json
-        ELSE json_build_object(\'comment\', notes)
-      END
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION pg_temp.is_json(varchar) RETURNS boolean AS $$
+        DECLARE
+          x json;
+        BEGIN
+          BEGIN
+            x := $1;
+          EXCEPTION WHEN others THEN
+            RETURN FALSE;
+          END;
+          RETURN TRUE;
+        END;
+      $$ LANGUAGE plpgsql IMMUTABLE;
+
+      ALTER TABLE "tags"
+        ALTER COLUMN "notes" TYPE jsonb
+        USING CASE
+          WHEN notes is NULL THEN '{}'::json
+          WHEN notes = '' THEN '{}'::json
+          WHEN pg_temp.is_json(notes) THEN notes::json
+          ELSE json_build_object('comment', notes)
+        END
     SQL
   end
 end

--- a/db/migrate/20200612004608_change_tag_notes_to_json.rb
+++ b/db/migrate/20200612004608_change_tag_notes_to_json.rb
@@ -1,0 +1,14 @@
+class ChangeTagNotesToJson < ActiveRecord::Migration
+  def change
+    # https://www.citusdata.com/blog/2016/07/14/choosing-nosql-hstore-json-jsonb/
+    change_column :tags, :notes, :jsonb, using: <<~SQL
+      CASE
+        WHEN notes is NULL
+          THEN \'{}\'::json
+        WHEN notes = \'\'
+          THEN \'{}\'::json
+        ELSE json_build_object(\'comment\', notes)
+      END
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -789,7 +789,7 @@ CREATE TABLE public.tags (
     is_taxanomic boolean DEFAULT false NOT NULL,
     type_of_tag character varying DEFAULT 'general'::character varying NOT NULL,
     retired boolean DEFAULT false NOT NULL,
-    notes text,
+    notes jsonb,
     creator_id integer NOT NULL,
     updater_id integer,
     created_at timestamp without time zone,
@@ -2337,4 +2337,6 @@ INSERT INTO schema_migrations (version) VALUES ('20181210052707');
 INSERT INTO schema_migrations (version) VALUES ('20181210052725');
 
 INSERT INTO schema_migrations (version) VALUES ('20181210052735');
+
+INSERT INTO schema_migrations (version) VALUES ('20200612004608');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -54,6 +54,7 @@ CREATE TABLE public.analysis_jobs (
 --
 
 CREATE SEQUENCE public.analysis_jobs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -91,6 +92,7 @@ CREATE TABLE public.analysis_jobs_items (
 --
 
 CREATE SEQUENCE public.analysis_jobs_items_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -131,6 +133,7 @@ CREATE TABLE public.audio_event_comments (
 --
 
 CREATE SEQUENCE public.audio_event_comments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -171,6 +174,7 @@ CREATE TABLE public.audio_events (
 --
 
 CREATE SEQUENCE public.audio_events_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -205,6 +209,7 @@ CREATE TABLE public.audio_events_tags (
 --
 
 CREATE SEQUENCE public.audio_events_tags_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -254,6 +259,7 @@ CREATE TABLE public.audio_recordings (
 --
 
 CREATE SEQUENCE public.audio_recordings_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -291,6 +297,7 @@ CREATE TABLE public.bookmarks (
 --
 
 CREATE SEQUENCE public.bookmarks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -326,6 +333,7 @@ CREATE TABLE public.dataset_items (
 --
 
 CREATE SEQUENCE public.dataset_items_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -360,6 +368,7 @@ CREATE TABLE public.datasets (
 --
 
 CREATE SEQUENCE public.datasets_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -398,6 +407,7 @@ CREATE TABLE public.permissions (
 --
 
 CREATE SEQUENCE public.permissions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -430,6 +440,7 @@ CREATE TABLE public.progress_events (
 --
 
 CREATE SEQUENCE public.progress_events_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -472,6 +483,7 @@ CREATE TABLE public.projects (
 --
 
 CREATE SEQUENCE public.projects_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -526,6 +538,7 @@ CREATE TABLE public.questions (
 --
 
 CREATE SEQUENCE public.questions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -570,6 +583,7 @@ CREATE TABLE public.responses (
 --
 
 CREATE SEQUENCE public.responses_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -605,6 +619,7 @@ CREATE TABLE public.saved_searches (
 --
 
 CREATE SEQUENCE public.saved_searches_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -654,6 +669,7 @@ CREATE TABLE public.scripts (
 --
 
 CREATE SEQUENCE public.scripts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -699,6 +715,7 @@ CREATE TABLE public.sites (
 --
 
 CREATE SEQUENCE public.sites_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -733,6 +750,7 @@ CREATE TABLE public.studies (
 --
 
 CREATE SEQUENCE public.studies_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -765,6 +783,7 @@ CREATE TABLE public.tag_groups (
 --
 
 CREATE SEQUENCE public.tag_groups_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -802,6 +821,7 @@ CREATE TABLE public.tags (
 --
 
 CREATE SEQUENCE public.tags_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -861,6 +881,7 @@ CREATE TABLE public.users (
 --
 
 CREATE SEQUENCE public.users_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE

--- a/spec/acceptance/tags_spec.rb
+++ b/spec/acceptance/tags_spec.rb
@@ -18,6 +18,7 @@ def tag_body_params
   parameter :text, 'text', scope: :tag, required: true
   parameter :type_of_tag, 'choose from [general, common_name, species_name, looks_like, sounds_like]', scope: :tag, required: true
   parameter :retired, 'true or false', scope: :tag, required: true
+  parameter :notes, 'Json formatted notes', scope: :tag, required: false
 end
 
 # https://github.com/zipmark/rspec_api_documentation
@@ -133,6 +134,25 @@ resource 'Tags' do
     tag_extras_id_params
     let(:authentication_token) { reader_token }
     standard_request_options(:get, 'LIST for audio_event (as reader, shallow route)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
+  end
+
+  get '/tags' do
+    expected_paths = Array[
+      'id',
+      'text',
+      'is_taxanomic',
+      'type_of_tag',
+      'retired',
+      'creator_id',
+      'updater_id',
+      'created_at',
+      'updated_at',
+      'notes',
+    ].map { |path| "data/0/#{path}" }
+
+    tag_extras_id_params
+    let(:authentication_token) { reader_token }
+    standard_request_options(:get, 'LIST for audio_event (has parameters, as reader, shallow route)', :ok, expected_json_path: expected_paths, data_item_count: 1)
   end
 
   get '/tags' do

--- a/spec/acceptance/tags_spec.rb
+++ b/spec/acceptance/tags_spec.rb
@@ -72,6 +72,25 @@ resource 'Tags' do
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
+    expected_paths = Array[
+      'id',
+      'text',
+      'is_taxanomic',
+      'type_of_tag',
+      'retired',
+      'creator_id',
+      'updater_id',
+      'created_at',
+      'updated_at',
+      'notes',
+    ].map { |path| "data/0/#{path}" }
+
+    tag_extras_id_params
+    let(:authentication_token) { reader_token }
+    standard_request_options(:get, 'LIST for audio_event (has parameters, as reader)', :ok, expected_json_path: expected_paths, data_item_count: 1)
+  end
+
+  get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { no_access_token }
     standard_request_options(:get, 'LIST for audio_event (as no access user)', :forbidden, expected_json_path: get_json_error_path(:permissions))

--- a/spec/acceptance/tags_spec.rb
+++ b/spec/acceptance/tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 require 'helpers/acceptance_spec_helper'
@@ -48,42 +50,42 @@ resource 'Tags' do
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'LIST for audio_event (as admin)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as admin)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'LIST for audio_event (as owner)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as owner)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'LIST for audio_event (as writer)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as writer)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'LIST for audio_event (as reader)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as reader)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'LIST for audio_event (as no access user)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:get, 'LIST for audio_event (as no access user)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'LIST for audio_event (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'LIST for audio_event (with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
-    standard_request_options(:get, 'LIST for audio_event (as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_in)})
+    standard_request_options(:get, 'LIST for audio_event (as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_in))
   end
 
   ################################
@@ -93,42 +95,42 @@ resource 'Tags' do
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'LIST for audio_event (as admin, shallow route)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as admin, shallow route)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'LIST for audio_event (as owner, shallow route)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as owner, shallow route)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'LIST for audio_event (as writer, shallow route)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as writer, shallow route)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'LIST for audio_event (as reader, shallow route)', :ok, {expected_json_path: 'data/0/is_taxanomic', data_item_count: 1})
+    standard_request_options(:get, 'LIST for audio_event (as reader, shallow route)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'LIST for audio_event (as no access user, shallow route)', :forbidden, {expected_json_path: get_json_error_path(:permissions)})
+    standard_request_options(:get, 'LIST for audio_event (as no access user, shallow route)', :forbidden, expected_json_path: get_json_error_path(:permissions))
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'LIST for audio_event (with invalid token, shallow route)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'LIST for audio_event (with invalid token, shallow route)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/tags' do
     tag_extras_id_params
-    standard_request_options(:get, 'LIST for audio_event (as anonymous user, shallow route)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_in)})
+    standard_request_options(:get, 'LIST for audio_event (as anonymous user, shallow route)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_in))
   end
 
   ################################
@@ -137,36 +139,36 @@ resource 'Tags' do
 
   get '/tags/new' do
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'NEW for audio_event (as admin)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'NEW for audio_event (as admin)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/new' do
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'NEW for audio_event (as owner)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'NEW for audio_event (as owner)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/new' do
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'NEW for audio_event (as writer)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'NEW for audio_event (as writer)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/new' do
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'NEW for audio_event (as reader)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'NEW for audio_event (as reader)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/new' do
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'NEW for audio_event (as no access user)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'NEW for audio_event (as no access user)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/new' do
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'NEW for audio_event (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'NEW for audio_event (with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/tags/new' do
-    standard_request_options(:get, 'NEW for audio_event (as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_in)})
+    standard_request_options(:get, 'NEW for audio_event (as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_in))
   end
 
   ################################
@@ -176,42 +178,42 @@ resource 'Tags' do
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'SHOW (as admin)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'SHOW (as admin)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'SHOW (as owner)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'SHOW (as owner)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'SHOW (as writer)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'SHOW (as writer)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'SHOW (as reader)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'SHOW (as reader)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'SHOW (as no access user)', :ok, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'SHOW (as no access user)', :ok, expected_json_path: 'data/is_taxanomic')
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'SHOW (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_up)})
+    standard_request_options(:get, 'SHOW (with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_up))
   end
 
   get '/tags/:id' do
     tag_id_param
-    standard_request_options(:get, 'SHOW (as anonymous user)', :ok, {remove_auth: true, expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:get, 'SHOW (as anonymous user)', :ok, remove_auth: true, expected_json_path: 'data/is_taxanomic')
   end
 
   ################################
@@ -220,50 +222,50 @@ resource 'Tags' do
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { admin_token }
-    standard_request_options(:post, 'CREATE (as admin)', :created, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:post, 'CREATE (as admin)', :created, expected_json_path: 'data/is_taxanomic')
   end
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { owner_token }
-    standard_request_options(:post, 'CREATE (as owner)', :created, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:post, 'CREATE (as owner)', :created, expected_json_path: 'data/is_taxanomic')
   end
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { writer_token }
-    standard_request_options(:post, 'CREATE (as writer)', :created, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:post, 'CREATE (as writer)', :created, expected_json_path: 'data/is_taxanomic')
   end
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { reader_token }
-    standard_request_options(:post, 'CREATE (as reader)', :created, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:post, 'CREATE (as reader)', :created, expected_json_path: 'data/is_taxanomic')
   end
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:post, 'CREATE (as no access user)', :created, {expected_json_path: 'data/is_taxanomic'})
+    standard_request_options(:post, 'CREATE (as no access user)', :created, expected_json_path: 'data/is_taxanomic')
   end
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { invalid_token }
-    standard_request_options(:post, 'CREATE (with invalid token)', :unauthorized, {expected_json_path: get_json_error_path(:sign_in)})
+    standard_request_options(:post, 'CREATE (with invalid token)', :unauthorized, expected_json_path: get_json_error_path(:sign_in))
   end
 
   post '/tags' do
     tag_body_params
-    let(:raw_post) { {'tag' => post_attributes}.to_json }
-    standard_request_options(:post, 'CREATE (as anonymous user)', :unauthorized, {remove_auth: true, expected_json_path: get_json_error_path(:sign_up)})
+    let(:raw_post) { { 'tag' => post_attributes }.to_json }
+    standard_request_options(:post, 'CREATE (as anonymous user)', :unauthorized, remove_auth: true, expected_json_path: get_json_error_path(:sign_up))
   end
 
   #####################
@@ -272,92 +274,91 @@ resource 'Tags' do
 
   post '/tags/filter' do
     let(:authentication_token) { reader_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'retired' => {
-                'eq' => false
-            }
+          'retired' => {
+            'eq' => false
+          }
         },
         'projection' => {
-            'include' => ['id', 'text', 'is_taxanomic', 'retired']
+          'include' => ['id', 'text', 'is_taxanomic', 'retired']
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as reader, with projection)', :ok,
-                             {
-                                 expected_json_path: 'data/0/is_taxanomic',
-                                 data_item_count: 1,
-                                 response_body_content: ["\"retired\":false", '"projection":{"include":["id","text","is_taxanomic","retired"]}']
-                             })
+                             expected_json_path: 'data/0/is_taxanomic',
+                             data_item_count: 1,
+                             response_body_content: ['"retired":false', '"projection":{"include":["id","text","is_taxanomic","retired"]}'])
   end
 
   post '/tags/filter' do
     let(:authentication_token) { reader_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'type_of_tag' => {
-                'eq' => 'general'
-            }
+          'type_of_tag' => {
+            'eq' => 'general'
+          }
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as reader, simple filter)', :ok,
-                             {
-                                 expected_json_path: 'data/0/type_of_tag',
-                                 data_item_count: 1,
-                                 response_body_content: "general",
-                                 invalid_content: "\"taggings\":[{\""
-                             })
+                             expected_json_path: 'data/0/type_of_tag',
+                             data_item_count: 1,
+                             response_body_content: 'general',
+                             invalid_content: '"taggings":[{"')
   end
-
 
   post '/tags/filter' do
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'text' => {
-                'contains' => 'tag text'
-            }
+          'text' => {
+            'contains' => 'tag text'
+          }
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as writer, simple projection)', :ok,
-                             {
-                                 expected_json_path: 'data/0/text',
-                                 data_item_count: 1,
-                                 response_body_content: ['tag text', "\"filter\":{\"text\":{\"contains\":\"tag text\"}}"]
-                             })
+                             expected_json_path: 'data/0/text',
+                             data_item_count: 1,
+                             response_body_content: ['tag text', '"filter":{"text":{"contains":"tag text"}}'])
   end
 
   post '/tags/filter' do
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'audio_events.id' => {
-                'in' => [9999, audio_event_id]
-            }
+          'audio_events.id' => {
+            'in' => [9999, audio_event_id]
+          }
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as writer, audio_events.id )', :ok,
-                             {
-                                 expected_json_path: 'data/0/text',
-                                 data_item_count: 1,
-                                 response_body_content: ['audio_events.id', "\"filter\":{\"audio_events.id\":{\"in\":[9999,"]
-                             })
+                             expected_json_path: 'data/0/text',
+                             data_item_count: 1,
+                             response_body_content: ['audio_events.id', '"filter":{"audio_events.id":{"in":[9999,'])
   end
 
   post '/tags/filter' do
     let(:authentication_token) { writer_token }
-    let(:raw_post) { {
+    let(:raw_post) {
+      {
         'filter' => {
-            'AudioEvents.Id' => {
-                'in' => [9999, audio_event_id]
-            }
+          'AudioEvents.Id' => {
+            'in' => [9999, audio_event_id]
+          }
         }
-    }.to_json }
+      }.to_json
+    }
     standard_request_options(:post, 'FILTER (as writer, AudioEvents.Id )', :ok,
-                             {
-                                 expected_json_path: 'data/0/text',
-                                 data_item_count: 1,
-                                 response_body_content: ['audio_events.id', "\"filter\":{\"audio_events.id\":{\"in\":[9999,"]
-                             })
+                             expected_json_path: 'data/0/text',
+                             data_item_count: 1,
+                             response_body_content: ['audio_events.id', '"filter":{"audio_events.id":{"in":[9999,'])
   end
 
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,20 +1,115 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-describe ApplicationController, { type: :controller } do
-  controller do
-    skip_authorization_check
-
-    def index
-      response.headers['Content-Length'] = -100
-      render({ text: 'test response' })
-    end
-  end
-
+describe ApplicationController, type: :controller do
   describe 'Application wide tests' do
+    controller do
+      skip_authorization_check
+
+      def index
+        response.headers['Content-Length'] = -100
+        render(text: 'test response')
+      end
+    end
+
     it 'it fails if content-length is negative' do
       expect {
         get :index
       }.to raise_error(CustomErrors::BadHeaderError)
+    end
+  end
+
+  describe 'sanitize_associative_array', type: :controller do
+    let!(:field_name) { 'field_name' }
+    let!(:controller) { ApplicationController.new }
+
+    describe 'string inputs' do
+      it 'should handle empty string' do
+        expect {
+          controller.instance_eval { sanitize_associative_array('', :field_name) }
+        }.to raise_error(CustomErrors::NotAcceptableError)
+      end
+
+      it 'should handle single quotes' do
+        expect {
+          controller.instance_eval { sanitize_associative_array('\'\'', :field_name) }
+        }.to raise_error(CustomErrors::NotAcceptableError)
+      end
+
+      it 'should handle double quotes' do
+        expect {
+          controller.instance_eval { sanitize_associative_array('""', :field_name) }
+        }.to raise_error(CustomErrors::NotAcceptableError)
+      end
+
+      it 'should handle invalid stringified object' do
+        expect {
+          controller.instance_eval { sanitize_associative_array('{123:123}', :field_name) }
+        }.to raise_error(CustomErrors::NotAcceptableError)
+      end
+
+      it 'should handle stringified array' do
+        expect {
+          controller.instance_eval { sanitize_associative_array('[1,2,3]', :field_name) }
+        }.to raise_error(CustomErrors::BadRequestError)
+      end
+    end
+
+    describe 'scalar inputs' do
+      it 'should handle nil input' do
+        expect(
+          controller.instance_eval { sanitize_associative_array(nil, :field_name) }
+        ).to be_nil
+      end
+
+      it 'should handle number' do
+        expect {
+          controller.instance_eval { sanitize_associative_array(42, :field_name) }
+        }.to raise_error(CustomErrors::BadRequestError)
+      end
+
+      it 'should handle boolean' do
+        expect {
+          controller.instance_eval { sanitize_associative_array(true, :field_name) }
+        }.to raise_error(CustomErrors::BadRequestError)
+      end
+    end
+
+    describe 'non-scalar inputs' do
+
+      it 'should handle empty object' do
+        expect(
+          controller.instance_eval { sanitize_associative_array({}, :field_name) }
+        ).to include({})
+      end
+
+      it 'should handle object' do
+        expect(
+          controller.instance_eval { sanitize_associative_array({ 'test': 'value' }, :field_name) }
+        ).to include('test': 'value')
+      end
+
+      it 'should handle array' do
+        expect {
+          controller.instance_eval { sanitize_associative_array([1, 2, 3], :field_name) }
+        }.to raise_error(CustomErrors::BadRequestError)
+      end
+
+    end
+
+    describe 'error messages' do
+      it 'should return not acceptable error' do
+        expect {
+          controller.instance_eval { sanitize_associative_array('', 'custom_field') }
+        }.to raise_error(CustomErrors::NotAcceptableError).with_message(/custom_field/)
+      end
+
+      it 'should return bad request error' do
+        expect {
+          controller.instance_eval { sanitize_associative_array([1, 2, 3], 'custom_field') }
+        }.to raise_error(CustomErrors::BadRequestError).with_message(/custom_field/)
+      end
     end
   end
 end

--- a/spec/factories/tag_factory.rb
+++ b/spec/factories/tag_factory.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 FactoryGirl.define do
 
-  factory :tag do |f|
+  factory :tag do |_f|
     sequence(:text) { |n| "tag text #{n}" }
-    sequence(:notes) { |n| "note number #{n}" }
 
     creator
     type_of_tag 'general'
@@ -22,10 +23,14 @@ FactoryGirl.define do
       retired true
     end
 
+    trait :notes do
+      notes { { 'comment' => 'value' } }
+    end
+
     factory :tag_taxonomic_true_common, traits: [:taxonomic_true_common]
+    factory :tag_taxonomic_true_common_notes, traits: [:tag_taxonomic_true_common, :notes]
     factory :tag_taxonomic_false_sounds_like, traits: [:taxonomic_false_sounds_like]
     factory :tag_retired_taxonomic_true_common, traits: [:taxonomic_true_common, :retired]
     factory :tag_retired_taxonomic_false_sounds_like, traits: [:taxonomic_false_sounds_like, :retired]
   end
 end
-

--- a/spec/helpers/creation.rb
+++ b/spec/helpers/creation.rb
@@ -2,7 +2,7 @@
 
 module Creation
   # accessible in describe/context blocks
-  module ExampleGroup
+  module ExampleGroup # rubocop:disable Metrics/ModuleLength
     def create_entire_hierarchy
       prepare_users
 

--- a/spec/helpers/migrations_helper.rb
+++ b/spec/helpers/migrations_helper.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+# ! version: 12.7.0-pre
+# ! author: GitLab B.V.
+# ! license MIT Expat https://gitlab.com/gitlab-org/gitlab/-/blob/f81fa6ab1dd788b70ef44b85aaba1f31ffafae7d/LICENSE
+# ! https://gitlab.com/gitlab-org/gitlab/-/blob/f81fa6ab1dd788b70ef44b85aaba1f31ffafae7d/spec/support/helpers/migrations_helpers.rb
+module MigrationsHelpers
+  def active_record_base
+    ActiveRecord::Base
+  end
+
+  def table(name)
+    Class.new(active_record_base) do
+      self.table_name = name
+      self.inheritance_column = :_type_disabled
+
+      def self.name
+        table_name.singularize.camelcase
+      end
+    end
+  end
+
+  def migrations_paths
+    ActiveRecord::Migrator.migrations_paths
+  end
+
+  def migration_context
+    ActiveRecord::MigrationContext.new(migrations_paths, ActiveRecord::SchemaMigration)
+  end
+
+  def migrations
+    migration_context.migrations
+  end
+
+  def clear_schema_cache!
+    active_record_base.connection_pool.connections.each do |conn|
+      conn.schema_cache.clear!
+    end
+  end
+
+  def foreign_key_exists?(source, target = nil, column: nil)
+    ActiveRecord::Base.connection.foreign_keys(source).any? do |key|
+      if column
+        key.options[:column].to_s == column.to_s
+      else
+        key.to_table.to_s == target.to_s
+      end
+    end
+  end
+
+  def reset_column_in_all_models
+    clear_schema_cache!
+
+    # Reset column information for the most offending classes **after** we
+    # migrated the schema up, otherwise, column information could be
+    # outdated. We have a separate method for this so we can override it in EE.
+    active_record_base.descendants.each(&method(:reset_column_information))
+  end
+
+  def refresh_attribute_methods
+    # Without this, we get errors because of missing attributes, e.g.
+    # super: no superclass method `elasticsearch_indexing' for #<ApplicationSetting:0x00007f85628508d8>
+    # attr_encrypted also expects ActiveRecord attribute methods to be
+    # defined, or it will override the accessors:
+    # https://gitlab.com/gitlab-org/gitlab/issues/8234#note_113976421
+    [ApplicationSetting, SystemHook].each(&:define_attribute_methods)
+  end
+
+  def reset_column_information(klass)
+    klass.reset_column_information
+  end
+
+  # In some migration tests, we're using factories to create records,
+  # however those models might be depending on a schema version which
+  # doesn't have the columns we want in application_settings.
+  # In these cases, we'll need to use the fake application settings
+  # as if we have migrations pending
+  def use_fake_application_settings
+    # We stub this way because we can't stub on
+    # `current_application_settings` due to `method_missing` is
+    # depending on current_application_settings...
+    allow(ActiveRecord::Base.connection)
+      .to receive(:active?)
+      .and_return(false)
+
+    stub_env('IN_MEMORY_APPLICATION_SETTINGS', 'false')
+  end
+
+  def previous_migration
+    migrations.each_cons(2) do |previous, migration|
+      break previous if migration.name == described_class.name
+    end
+  end
+
+  def migration_schema_version
+    metadata_schema = self.class.metadata[:schema]
+
+    if metadata_schema == :latest
+      migrations.last.version
+    else
+      metadata_schema || previous_migration.version
+    end
+  end
+
+  def schema_migrate_down!
+    disable_migrations_output do
+      migration_context.down(migration_schema_version)
+    end
+
+    reset_column_in_all_models
+  end
+
+  def schema_migrate_up!
+    reset_column_in_all_models
+
+    disable_migrations_output do
+      migration_context.up
+    end
+
+    reset_column_in_all_models
+    refresh_attribute_methods
+  end
+
+  def disable_migrations_output
+    ActiveRecord::Migration.verbose = false
+
+    yield
+  ensure
+    ActiveRecord::Migration.verbose = true
+  end
+
+  def migrate!
+    migration_context.up do |migration|
+      migration.name == described_class.name
+    end
+  end
+
+  class ReversibleMigrationTest
+    attr_reader :before_up, :after_up
+
+    def initialize
+      @before_up = -> {}
+      @after_up = -> {}
+    end
+
+    def before(expectations)
+      @before_up = expectations
+
+      self
+    end
+
+    def after(expectations)
+      @after_up = expectations
+
+      self
+    end
+  end
+
+  def reversible_migration
+    tests = yield(ReversibleMigrationTest.new)
+
+    tests.before_up.call
+
+    migrate!
+
+    tests.after_up.call
+
+    schema_migrate_down!
+
+    tests.before_up.call
+  end
+end

--- a/spec/migrations/change_tag_notes_to_json_spec.rb
+++ b/spec/migrations/change_tag_notes_to_json_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db', 'migrate', '20200612004608_change_tag_notes_to_json.rb')
+
+# TODO: Implement tests
+xdescribe 'ChangeTagNotesToJson', :migration do
+  # Create test data
+  let(:tags) { table(:tags) }
+  let(:users) { table(:users) }
+
+  # Test scenarios
+  let(:open_brackets) { tags.create!(id: 1, text: 'open_brackets', creator_id: 1, notes: '{{{{{') }
+  let(:array) { tags.create!(id: 2, text: 'array', creator_id: 1, notes: [1, 2, 3]) }
+  let(:valid_object) { tags.create!(id: 3, text: 'valid_object', creator_id: 1, notes: '{"testing": "data_loss"}') }
+  let(:valid_multi_object) { tags.create!(id: 4, text: 'valid_multi_object', creator_id: 1, notes: '{"test": 42,"value": "bob"}') }
+  let(:empty_object) { tags.create!(id: 5, text: 'empty_object', creator_id: 1, notes: '{}') }
+  let(:single_quotes) { tags.create!(id: 6, text: 'single_quotes', creator_id: 1, notes: '\'\'') }
+  let(:double_quotes) { tags.create!(id: 7, text: 'double_quotes', creator_id: 1, notes: '""') }
+  let(:object_containing_array) { tags.create!(id: 8, text: 'object_containing_array', creator_id: 1, notes: '{"123": [1,2,3]}') }
+  let(:empty_string) { tags.create!(id: 9, text: 'empty_string', creator_id: 1, notes: '') }
+  let(:null) { tags.create!(id: 10, text: 'null', creator_id: 1, notes: nil) }
+
+  before do
+    # Create user?
+    # users.create!(
+    #   id: 1,
+    #   user_name: 'test_user',
+    #   email: 'a@c.com',
+    #   encrypted_password: '$2a$10$xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    # )
+  end
+
+  it 'should handle open brackets' do
+    tags.create!(id: 1, text: 'open_brackets', creator_id: 1, notes: '{{{{{')
+    migrate!
+    expect(tags.count).to eq 1
+    #expect(tags.all.pluck(:notes)).to match_array []
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -106,4 +106,15 @@ describe Tag, type: :model do
     expect(t.retired).to be_falsey
   end
 
+  it 'ensures notes can be nil' do
+    t = build(:tag)
+    t.notes = nil
+    expect(t).to be_valid
+  end
+
+  it 'ensures notes can be a hash' do
+    t = build(:tag)
+    t.notes = { comment: 'testing' }
+    expect(t).to be_valid
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-
-describe Tag, :type => :model do
+describe Tag, type: :model do
   it 'has a valid factory' do
     t = create(:tag)
 
@@ -27,7 +28,7 @@ describe Tag, :type => :model do
     t.is_taxanomic = true
     t.type_of_tag = :common_name
     expect(t).to be_valid
-    
+
     t.is_taxanomic = false
     t.type_of_tag = :general
     expect(t).to be_valid
@@ -58,7 +59,7 @@ describe Tag, :type => :model do
 
   type_of_tags = [:general, :common_name, :species_name, :looks_like, :sounds_like]
 
-  type_of_tags.each { |tag_type|
+  type_of_tags.each do |tag_type|
     expected_is_taxanomic_value = tag_type == :common_name || tag_type == :species_name
     it "ensures type_of_tag can be set to #{tag_type}" do
       t = build(:tag)
@@ -84,7 +85,7 @@ describe Tag, :type => :model do
       t.is_taxanomic = expected_is_taxanomic_value
       expect(t).to be_valid
     end
-  }
+  end
 
   it 'should not allow nil for retired' do
     t = build(:tag)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,8 +8,8 @@ if ENV['RAILS_ENV'] != 'test'
   puts \
     <<~MESSAGE
       ***
-      Tests must be run in the test envrionment.
-      The current envrionment `#{ENV['RAILS_ENV']}` has been changed to `test`.
+      Tests must be run in the test environment.
+      The current environment `#{ENV['RAILS_ENV']}` has been changed to `test`.
       See rails_helper.rb to disable this check
       ***
     MESSAGE
@@ -52,15 +52,14 @@ if ENV['CI'] || ENV['COVERAGE']
     # coveralls
     Coveralls.wear!('rails')
 
-    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                     Coveralls::SimpleCov::Formatter,
-                                                                     CodeClimate::TestReporter::Formatter
-                                                                   ])
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+      [Coveralls::SimpleCov::Formatter, CodeClimate::TestReporter::Formatter]
+    )
 
   else
-    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                     SimpleCov::Formatter::HTMLFormatter
-                                                                   ])
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+      [SimpleCov::Formatter::HTMLFormatter]
+    )
   end
 
   # start code coverage
@@ -114,7 +113,7 @@ Warden.test_mode!
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-RSpec.configure do |config|
+RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   #config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -125,11 +124,11 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.use_transactional_examples = false
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
+  # RSpec Rails can automatically mix in different behaviors to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
   #
-  # You can disable this behaviour by removing the line below, and instead
+  # You can disable this behavior by removing the line below, and instead
   # explicitly tag your specs with their type, e.g.:
   #
   #     RSpec.describe UsersController, :type => :controller do
@@ -152,6 +151,9 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Paperclip::Shoulda::Matchers
   config.include FactoryGirl::Syntax::Methods
+
+  require_relative 'helpers/migrations_helper'
+  config.include MigrationsHelpers, :migration
 
   require_relative 'helpers/creation'
   config.include Creation::Example
@@ -253,7 +255,7 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-# Customise rspec api documentation
+# Customize rspec api documentation
 ENV['DOC_FORMAT'] ||= 'json'
 
 RspecApiDocumentation.configure do |config_rspec_api|

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec/mocks'
+
+describe 'Tags' do
+  create_entire_hierarchy
+
+  def create(attributes = {})
+    default_attributes = { text: 'test tag' }
+    FactoryGirl.attributes_for(:tag, default_attributes.merge(attributes))
+  end
+
+  before(:each) do
+    @env ||= {}
+    @env['HTTP_AUTHORIZATION'] = admin_token
+    @env['CONTENT_TYPE'] = 'application/json'
+
+    @tag_url = '/tags'
+    @tag_url_with_id = "/tags/#{tag.id}"
+  end
+
+  describe 'index' do
+    it 'finds all (1) tag as admin' do
+      get @tag_url, nil, @env
+      expect(response).to have_http_status(200)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['data'].count).to eq(1)
+      expect(parsed_response['data'][0]['text']).to eq(tag['text'])
+    end
+  end
+
+  describe 'filter' do
+    it 'finds all (1) tag as admin' do
+      get "#{@tag_url}/filter", nil, @env
+      expect(response).to have_http_status(200)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['data'].count).to eq(1)
+      expect(parsed_response['data'][0]['text']).to eq(tag['text'])
+    end
+  end
+
+  describe 'show' do
+    it 'show tag as admin' do
+      get @tag_url_with_id, nil, @env
+      expect(response).to have_http_status(200)
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['data'].to_json).to eq(tag.to_json)
+    end
+  end
+
+  describe 'create' do
+    it 'creates a tag' do
+      post @tag_url, create.to_json, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(201)
+      expect(parsed_response['data']['text']).to eq 'test tag'
+    end
+
+    it 'creates a taxonomic tag' do
+      post @tag_url, create('is_taxanomic': true, 'type_of_tag': 'common_name').to_json, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(201)
+      expect(parsed_response['data']['is_taxanomic']).to be true
+      expect(parsed_response['data']['type_of_tag']).to eq 'common_name'
+    end
+
+    it 'creates a retired tag' do
+      post @tag_url, create('retired': true).to_json, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(201)
+      expect(parsed_response['data']['retired']).to be true
+    end
+
+    it 'creates a tag with notes' do
+      post @tag_url, create('notes': { 'testing': 'value' }).to_json, @env
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(201)
+      expect(parsed_response['data']['notes']).to eq('testing' => 'value')
+    end
+  end
+end


### PR DESCRIPTION
# Tag API Route Update

Minor modifications to the tag model, table, and API.

## Changes

- Updated the tag model to expose the following properties:
  - `notes`
  - `creator_id`
  - `updater_id`
  - `created_at`
  - `updated_at`

  ```JSON
  {
    "id": 1,
    "text": "test tag #1",
    "is_taxanomic": false,
    "type_of_tag": "general",
    "retired": false,
    "notes": null,
    "creator_id": 1,
    "updater_id": null,
    "created_at": "2020-06-22T13:30:37.832+10:00",
    "updated_at": "2020-06-22T13:30:37.832+10:00"
  }
  ```

- Modified tags table to change notes column from type `Text` to `JsonB`. Following migration cases were tested manually:

|          test           |              before            |                      after                      |
|-------------------------|----------------------------------|-------------------------------------------------|
| null                    |                                  |                                                 |
| empty_string            |                                  |                                                 |
| object_containing_array | {"123": [1,2,3]}                 | {"123": [1, 2, 3]}                              |
| number                  | 42                               | {"comment": 42}                                 |
| boolean                 | true                             | {"comment": true}                               |
| single_quotes           | ''                               | {"comment": "''"}                               |
| double_quotes           | ""                               | {"comment": "\"\""}                             |
| empty_object            | {}                               | {}                                              |
| valid_multi_object      | {"test": 42,"value": "bob"}      | {"test": 42, "value": "bob"}                    |
| valid_object            | {"testing": "dataloss"}          | {"testing": "dataloss"}                         |
| array                   | [1,2,3]                          | {"comment": [1, 2, 3]}                          |
| open_brackets           | {{{{                             | {"comment": "{{{{"}                             |
| Australian Reed-Warbler | added via powershell rest import | {"comment": "added via powershell rest import"} |

- Enabled tag creation routes to accept notes input  using the following formats:

|          test           |              input                  |              result                     |
|-------------------------|-------------------------------------|-----------------------------------------|
| null                    | { "notes": null }                   | { "notes": null }                       |
| empty_string            | { "notes": "" }                     | { "notes": { } }                        |
| string                  | { "notes": "invalid" }              | 409!                                    |
| string_object           | "{"notes":{ "testing":"value"}}"    | { "notes": { "testing": "value" } }     |
| valid_object            | { "notes": { "testing": "value" } } | { "notes": { "testing": "value" } }     |
| array                   | { "notes": [ 1, 2, 3 ] }            | 409!                                    |

- Created generic `sanitize_associative_array` function in `src/app/controllers/application_controller.rb`. Handles converting an associative array or scalar input strong parameter, and outputs a jsonb compatible hash
  ```ruby
  params[:tag][:notes] = sanitize_associative_array(params[:tag][:notes], 'notes')
  ```

## Issues

- Have not updated admin tag routes (`app/controllers/admin/tags_controller.rb)
  - Currently the route re-uses a lot of the code from the default tags controller. It could be updated to potentially `implement` the default class, or import the `tag_params`
- Test cases need to be built for the following changes
  - [x] Update tag model unit tests
  - [x] Create tag route unit tests
  - [ ] Create migration unit tests #469

## Closes

Closes #464 
Closes #436 
Related #449 
Related #467 



