### PR TITLE
Rename taxanomic to taxonomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ For the following commands:
 Common tasks that you may need:
 
 - `bundle install` to install a new gem
-- `rake db:xxx` to manipulate database
-    - `rake db:setup` - does all of the below
-    - `rake db:create` - create database
-    - `rake db:migrate` - run migrations
-    - `rake db:seed` - seed the database with default data
+- `rails db:xxx` to manipulate database
+    - `rails db:setup` - does all of the below
+    - `rails db:create` - create database
+    - `rails db:migrate` - run migrations
+    - `rails db:seed` - seed the database with default data
 - `rails console` to use the rails console
 - `rails start` to run a web server
 - `passenger-config restart-app /` to restart passenger and hot-reload code
@@ -179,9 +179,9 @@ Use this style guide as a reference: https://github.com/rubocop-hq/ruby-style-gu
 These commands should be executed automatically but are listed because they are helpful to know.
 
 
-- Create the test database: `rake db:create RAILS_ENV=test`
-- Then migrate and seed the test database: `rake db:migrate db:seed RAILS_ENV=test`
-- Prepare the local development database:`rake db:setup RAILS_ENV=development`
+- Create the test database: `rails db:create RAILS_ENV=test`
+- Then migrate and seed the test database: `rails db:migrate db:seed RAILS_ENV=test`
+- Prepare the local development database: `rails db:setup RAILS_ENV=development`
 - Run rspec tests: `rspec`
 - Generate API documentation: `rake docs:generate GENERATE_DOC=true`
 

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -12,7 +12,7 @@ module Admin
 
       filter = paging_params[:filter]
 
-      unless [:text, :is_taxanomic, :type_of_tag, :retired, :updated_at, :updater_id].include?(order_by)
+      unless [:text, :is_taxonomic, :type_of_tag, :retired, :updated_at, :updater_id].include?(order_by)
         raise 'Invalid order by.'
       end
       raise 'Invalid order dir.' unless [:asc, :desc].include?(order_dir)
@@ -98,7 +98,7 @@ module Admin
     private
 
     def tag_params
-      params.require(:tag).permit(:id, :text, :is_taxanomic, :type_of_tag, :retired, :notes)
+      params.require(:tag).permit(:id, :text, :is_taxonomic, :type_of_tag, :retired, :notes)
     end
 
     def paging_params

--- a/app/controllers/audio_events_controller.rb
+++ b/app/controllers/audio_events_controller.rb
@@ -207,7 +207,7 @@ class AudioEventsController < ApplicationController
       :start_time_seconds, :end_time_seconds,
       :low_frequency_hertz, :high_frequency_hertz,
       :is_reference,
-      tags_attributes: [:is_taxanomic, :text, :type_of_tag, :retired, :notes],
+      tags_attributes: [:is_taxonomic, :text, :type_of_tag, :retired, :notes],
       tag_ids: []
     )
   end

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -142,6 +142,6 @@ class TaggingsController < ApplicationController
   end
 
   def tagging_params
-    params.require(:tagging).permit(:audio_event_id, :tag_id, tag_attributes: [:is_taxanomic, :text, :type_of_tag, :retired, :notes])
+    params.require(:tagging).permit(:audio_event_id, :tag_id, tag_attributes: [:is_taxonomic, :text, :type_of_tag, :retired, :notes])
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -73,6 +73,6 @@ class TagsController < ApplicationController
   def tag_params
     sanitize_associative_array(:tag, :notes)
 
-    params.require(:tag).permit(:is_taxanomic, :text, :type_of_tag, :retired, :notes, notes: {})
+    params.require(:tag).permit(:is_taxonomic, :text, :type_of_tag, :retired, :notes, notes: {})
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -33,7 +33,7 @@ class Tag < ApplicationRecord
   validates_associated :creator
 
   # attribute validations
-  validates :is_taxanomic, inclusion: { in: [true, false] }
+  validates :is_taxonomic, inclusion: { in: [true, false] }
   validates :text, uniqueness: { case_sensitive: false }, presence: true
   validates :retired, inclusion: { in: [true, false] }
   validates :type_of_tag, presence: true
@@ -50,9 +50,9 @@ class Tag < ApplicationRecord
 
   def taxonomic_enforced
     if type_of_tag == 'common_name' || type_of_tag == 'species_name'
-      errors.add(:is_taxanomic, "must be true for #{type_of_tag}") unless is_taxanomic
+      errors.add(:is_taxonomic, "must be true for #{type_of_tag}") unless is_taxonomic
     else
-      errors.add(:is_taxanomic, "must be false for #{type_of_tag}") if is_taxanomic
+      errors.add(:is_taxonomic, "must be false for #{type_of_tag}") if is_taxonomic
     end
   end
 
@@ -92,11 +92,11 @@ class Tag < ApplicationRecord
   def self.filter_settings
     {
       valid_fields: [
-        :id, :text, :is_taxanomic, :type_of_tag, :retired, :notes,
+        :id, :text, :is_taxonomic, :type_of_tag, :retired, :notes,
         :creator_id, :created_at, :updater_id, :updated_at
       ],
       render_fields: [
-        :id, :text, :is_taxanomic, :type_of_tag, :retired, :creator_id,
+        :id, :text, :is_taxonomic, :type_of_tag, :retired, :creator_id,
         :updater_id, :created_at, :updated_at, :notes
       ],
       text_fields: [:text, :type_of_tag, :notes],

--- a/app/views/admin/tags/_form.html.haml
+++ b/app/views/admin/tags/_form.html.haml
@@ -17,5 +17,5 @@
     = f.input :type_of_tag, required: true
     = f.input :notes
     = f.input :retired, wrapper: :horizontal_boolean
-    = f.input :is_taxanomic, wrapper: :horizontal_boolean
+    = f.input :is_taxonomic, wrapper: :horizontal_boolean
     = f.button :submit_cancel, 'Submit', class: 'btn-default'

--- a/app/views/admin/tags/edit.html.haml
+++ b/app/views/admin/tags/edit.html.haml
@@ -9,7 +9,7 @@
   - else
     = render partial: 'shared/sidebar_metadata_user_updated', locals: {item: @tag}
   = render partial: 'shared/sidebar_metadata', locals: {title: 'Status', text: @tag.retired ? 'Retired' : 'In use'}
-  = render partial: 'shared/sidebar_metadata', locals: {title: 'Classification', text: @tag.is_taxanomic ? 'Taxonomic' : 'Folksonomic'}
+  = render partial: 'shared/sidebar_metadata', locals: {title: 'Classification', text: @tag.is_taxonomic ? 'Taxonomic' : 'Folksonomic'}
   - display_tag_type = Tag::AVAILABLE_TYPE_OF_TAGS_DISPLAY.select{ |i| i[:id] == @tag.type_of_tag.to_sym}.first
   = render partial: 'shared/sidebar_metadata', locals: {title: 'Type', text: display_tag_type[:name]}
   = render partial: 'shared/sidebar_metadata', locals: {title: 'Count', text: @tag.taggings.count}

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -42,10 +42,10 @@
               - if order_by == :text
                 %span.fa{class: "fa-#{order_dir_icon}"}
           %th
-            = link_to admin_tags_path order_by: :is_taxanomic, order_dir: order_by_opposite, filter: filter  do
+            = link_to admin_tags_path order_by: :is_taxonomic, order_dir: order_by_opposite, filter: filter  do
               %span.fa.fa-sticky-note{aria: {hidden: 'true'}}
               Taxonomic
-              - if order_by == :is_taxanomic
+              - if order_by == :is_taxonomic
                 %span.fa{class: "fa-#{order_dir_icon}"}
           %th
             = link_to admin_tags_path order_by: :retired, order_dir: order_by_opposite, filter: filter do
@@ -73,7 +73,7 @@
             %span.label{class: taggings_count > 0 ? 'label-primary' : 'label-default', style: 'margin-right: 5px;'}
               = taggings_count
           %td
-            = tag.is_taxanomic ? 'Taxonomic' : 'Folksonomic'
+            = tag.is_taxonomic ? 'Taxonomic' : 'Folksonomic'
           %td
             = tag.retired ? 'Retired' : 'In use'
           %td

--- a/db/migrate/20130715022212_devise_create_users.rb
+++ b/db/migrate/20130715022212_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20130715035926_create_projects.rb
+++ b/db/migrate/20130715035926_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2]
   def change
     create_table :projects do |t|
       t.string :name, :null => false

--- a/db/migrate/20130718000123_add_roles_mask_to_users.rb
+++ b/db/migrate/20130718000123_add_roles_mask_to_users.rb
@@ -1,4 +1,4 @@
-class AddRolesMaskToUsers < ActiveRecord::Migration
+class AddRolesMaskToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :roles_mask, :integer
   end

--- a/db/migrate/20130718063158_add_image_columns_to_user.rb
+++ b/db/migrate/20130718063158_add_image_columns_to_user.rb
@@ -1,4 +1,4 @@
-class AddImageColumnsToUser < ActiveRecord::Migration
+class AddImageColumnsToUser < ActiveRecord::Migration[4.2]
   def change
     add_attachment :users, :image
   end

--- a/db/migrate/20130719015419_create_permissions.rb
+++ b/db/migrate/20130719015419_create_permissions.rb
@@ -1,4 +1,4 @@
-class CreatePermissions < ActiveRecord::Migration
+class CreatePermissions < ActiveRecord::Migration[4.2]
   def change
     create_table :permissions do |t|
       t.integer :creator_id,  :null => false

--- a/db/migrate/20130724113058_create_sites.rb
+++ b/db/migrate/20130724113058_create_sites.rb
@@ -1,4 +1,4 @@
-class CreateSites < ActiveRecord::Migration
+class CreateSites < ActiveRecord::Migration[4.2]
   def change
     create_table :sites do |t|
       t.string  :name,        :null => false

--- a/db/migrate/20130724113348_create_project_site.rb
+++ b/db/migrate/20130724113348_create_project_site.rb
@@ -1,4 +1,4 @@
-class CreateProjectSite < ActiveRecord::Migration
+class CreateProjectSite < ActiveRecord::Migration[4.2]
   def change
     create_table :projects_sites, id: false do |t|
       t.integer :project_id, :null => false

--- a/db/migrate/20130725095559_create_datasets.rb
+++ b/db/migrate/20130725095559_create_datasets.rb
@@ -1,4 +1,4 @@
-class CreateDatasets < ActiveRecord::Migration
+class CreateDatasets < ActiveRecord::Migration[4.2]
   def change
     create_table :datasets do |t|
       t.string :name, :null => false

--- a/db/migrate/20130725100043_datasets_sites.rb
+++ b/db/migrate/20130725100043_datasets_sites.rb
@@ -1,4 +1,4 @@
-class DatasetsSites < ActiveRecord::Migration
+class DatasetsSites < ActiveRecord::Migration[4.2]
   def change
     create_table :datasets_sites, id: false do |t|
       t.integer :dataset_id, :null => false

--- a/db/migrate/20130729050807_create_jobs.rb
+++ b/db/migrate/20130729050807_create_jobs.rb
@@ -1,4 +1,4 @@
-class CreateJobs < ActiveRecord::Migration
+class CreateJobs < ActiveRecord::Migration[4.2]
   def change
     create_table :jobs do |t|
       t.string :name              , :null => false

--- a/db/migrate/20130729055348_create_scripts.rb
+++ b/db/migrate/20130729055348_create_scripts.rb
@@ -1,4 +1,4 @@
-class CreateScripts < ActiveRecord::Migration
+class CreateScripts < ActiveRecord::Migration[4.2]
   def change
     create_table :scripts do |t|
       t.string :name                 , null: false

--- a/db/migrate/20130819030336_create_audio_recordings.rb
+++ b/db/migrate/20130819030336_create_audio_recordings.rb
@@ -1,4 +1,4 @@
-class CreateAudioRecordings < ActiveRecord::Migration
+class CreateAudioRecordings < ActiveRecord::Migration[4.2]
   def change
     create_table :audio_recordings do |t|
 

--- a/db/migrate/20130828053819_create_audio_events.rb
+++ b/db/migrate/20130828053819_create_audio_events.rb
@@ -1,4 +1,4 @@
-class CreateAudioEvents < ActiveRecord::Migration
+class CreateAudioEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :audio_events do |t|
       t.integer :audio_recording_id       , :null => false

--- a/db/migrate/20130830045300_create_tags.rb
+++ b/db/migrate/20130830045300_create_tags.rb
@@ -1,4 +1,4 @@
-class CreateTags < ActiveRecord::Migration
+class CreateTags < ActiveRecord::Migration[4.2]
   def change
     create_table :tags do |t|
       t.string   :text         , :null => false

--- a/db/migrate/20130905033759_add_original_file_name_to_audio_recording.rb
+++ b/db/migrate/20130905033759_add_original_file_name_to_audio_recording.rb
@@ -1,4 +1,4 @@
-class AddOriginalFileNameToAudioRecording < ActiveRecord::Migration
+class AddOriginalFileNameToAudioRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :audio_recordings, :original_file_name, :string
   end

--- a/db/migrate/20130913001136_create_bookmarks.rb
+++ b/db/migrate/20130913001136_create_bookmarks.rb
@@ -1,4 +1,4 @@
-class CreateBookmarks < ActiveRecord::Migration
+class CreateBookmarks < ActiveRecord::Migration[4.2]
   def change
     create_table :bookmarks do |t|
       t.integer :audio_recording_id

--- a/db/migrate/20130919043216_change_misc_columns.rb
+++ b/db/migrate/20130919043216_change_misc_columns.rb
@@ -1,4 +1,4 @@
-class ChangeMiscColumns < ActiveRecord::Migration
+class ChangeMiscColumns < ActiveRecord::Migration[4.2]
   def up
     change_column :tags, :type_of_tag, :string  , :null => false, :default => 'general'
     change_column :scripts, :created_at, :datetime, :null => false

--- a/db/migrate/20131002065752_allow_null_site_location.rb
+++ b/db/migrate/20131002065752_allow_null_site_location.rb
@@ -1,4 +1,4 @@
-class AllowNullSiteLocation < ActiveRecord::Migration
+class AllowNullSiteLocation < ActiveRecord::Migration[4.2]
   def up
     change_column :sites, :longitude, :decimal, :null => true
     change_column :sites, :latitude, :decimal, :null => true

--- a/db/migrate/20131120070151_change_decimal_columns.rb
+++ b/db/migrate/20131120070151_change_decimal_columns.rb
@@ -1,4 +1,4 @@
-class ChangeDecimalColumns < ActiveRecord::Migration
+class ChangeDecimalColumns < ActiveRecord::Migration[4.2]
   def up
     # http://stackoverflow.com/questions/1196415/what-datatype-to-use-when-storing-latitude-and-longitude-data-in-sql-databases
     # http://en.wikipedia.org/wiki/Wikipedia:WikiProject_Geographical_coordinates#Precision

--- a/db/migrate/20131124234346_add_attachment_dataset_result_to_datasets.rb
+++ b/db/migrate/20131124234346_add_attachment_dataset_result_to_datasets.rb
@@ -1,4 +1,4 @@
-class AddAttachmentDatasetResultToDatasets < ActiveRecord::Migration
+class AddAttachmentDatasetResultToDatasets < ActiveRecord::Migration[4.2]
   def change
     add_attachment :datasets, :dataset_result
   end

--- a/db/migrate/20131230021055_add_tag_text_filters_to_datasets.rb
+++ b/db/migrate/20131230021055_add_tag_text_filters_to_datasets.rb
@@ -1,4 +1,4 @@
-class AddTagTextFiltersToDatasets < ActiveRecord::Migration
+class AddTagTextFiltersToDatasets < ActiveRecord::Migration[4.2]
   def change
     add_column :datasets, :tag_text_filters, :text
   end

--- a/db/migrate/20140125054808_add_preferences_to_users.rb
+++ b/db/migrate/20140125054808_add_preferences_to_users.rb
@@ -1,4 +1,4 @@
-class AddPreferencesToUsers < ActiveRecord::Migration
+class AddPreferencesToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :preferences, :text
   end

--- a/db/migrate/20140127011711_add_description_columns.rb
+++ b/db/migrate/20140127011711_add_description_columns.rb
@@ -1,4 +1,4 @@
-class AddDescriptionColumns < ActiveRecord::Migration
+class AddDescriptionColumns < ActiveRecord::Migration[4.2]
   def up
     change_table :sites do |t|
       t.text :description

--- a/db/migrate/20140222044740_remove_defaults_from_user.rb
+++ b/db/migrate/20140222044740_remove_defaults_from_user.rb
@@ -1,4 +1,4 @@
-class RemoveDefaultsFromUser < ActiveRecord::Migration
+class RemoveDefaultsFromUser < ActiveRecord::Migration[4.2]
   def up
     change_column_default(:users, :email, nil)
     change_column_default(:users, :user_name, nil)

--- a/db/migrate/20140404234458_add_indexes.rb
+++ b/db/migrate/20140404234458_add_indexes.rb
@@ -1,4 +1,4 @@
-class AddIndexes < ActiveRecord::Migration
+class AddIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index  :audio_recordings, [:created_at , :updated_at], name: 'audio_recordings_created_updated_at'
     add_index  :audio_recordings, :site_id

--- a/db/migrate/20140621014304_add_category_to_bookmarks.rb
+++ b/db/migrate/20140621014304_add_category_to_bookmarks.rb
@@ -1,4 +1,4 @@
-class AddCategoryToBookmarks < ActiveRecord::Migration
+class AddCategoryToBookmarks < ActiveRecord::Migration[4.2]
   def change
     add_column :bookmarks, :category, :string
   end

--- a/db/migrate/20140819034103_user_name_unique.rb
+++ b/db/migrate/20140819034103_user_name_unique.rb
@@ -1,4 +1,4 @@
-class UserNameUnique < ActiveRecord::Migration
+class UserNameUnique < ActiveRecord::Migration[4.2]
   def change
     add_index  :users, :user_name, name: 'users_user_name_unique', unique: true
   end

--- a/db/migrate/20140901005918_create_audio_event_comments.rb
+++ b/db/migrate/20140901005918_create_audio_event_comments.rb
@@ -1,4 +1,4 @@
-class CreateAudioEventComments < ActiveRecord::Migration
+class CreateAudioEventComments < ActiveRecord::Migration[4.2]
   def change
     create_table :audio_event_comments do |t|
       t.integer :audio_event_id,   null: false

--- a/db/migrate/20141115234848_change_audio_recording_data_length_bytes_limit.rb
+++ b/db/migrate/20141115234848_change_audio_recording_data_length_bytes_limit.rb
@@ -1,4 +1,4 @@
-class ChangeAudioRecordingDataLengthBytesLimit < ActiveRecord::Migration
+class ChangeAudioRecordingDataLengthBytesLimit < ActiveRecord::Migration[4.2]
   def up
     change_column :audio_recordings, :data_length_bytes, :integer, null: false, limit: 8
   end

--- a/db/migrate/20150306224910_add_timezone_columns.rb
+++ b/db/migrate/20150306224910_add_timezone_columns.rb
@@ -1,4 +1,4 @@
-class AddTimezoneColumns < ActiveRecord::Migration
+class AddTimezoneColumns < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :tzinfo_tz, :string, null: true, limit: 255
     add_column :users, :rails_tz, :string, null: true, limit: 255

--- a/db/migrate/20150306235304_add_last_seen_at_to_users.rb
+++ b/db/migrate/20150306235304_add_last_seen_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddLastSeenAtToUsers < ActiveRecord::Migration
+class AddLastSeenAtToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :last_seen_at, :datetime, null: true
   end

--- a/db/migrate/20150307010121_add_foreign_keys.rb
+++ b/db/migrate/20150307010121_add_foreign_keys.rb
@@ -1,4 +1,4 @@
-class AddForeignKeys < ActiveRecord::Migration
+class AddForeignKeys < ActiveRecord::Migration[4.2]
   def up
     add_foreign_key "audio_event_comments", "audio_events", name: "audio_event_comments_audio_event_id_fk"
     add_foreign_key "audio_event_comments", "users", column: "creator_id", name: "audio_event_comments_creator_id_fk"

--- a/db/migrate/20150709112116_create_saved_searches.rb
+++ b/db/migrate/20150709112116_create_saved_searches.rb
@@ -1,4 +1,4 @@
-class CreateSavedSearches < ActiveRecord::Migration
+class CreateSavedSearches < ActiveRecord::Migration[4.2]
   def change
 
     reversible do |direction|

--- a/db/migrate/20150709141712_rename_jobs.rb
+++ b/db/migrate/20150709141712_rename_jobs.rb
@@ -1,4 +1,4 @@
-class RenameJobs < ActiveRecord::Migration
+class RenameJobs < ActiveRecord::Migration[4.2]
   def change
 
     reversible do |direction|

--- a/db/migrate/20150710080933_change_scripts.rb
+++ b/db/migrate/20150710080933_change_scripts.rb
@@ -1,4 +1,4 @@
-class ChangeScripts < ActiveRecord::Migration
+class ChangeScripts < ActiveRecord::Migration[4.2]
   def change
     reversible do |direction|
       direction.up do

--- a/db/migrate/20150710082554_change_analysis_jobs.rb
+++ b/db/migrate/20150710082554_change_analysis_jobs.rb
@@ -1,4 +1,4 @@
-class ChangeAnalysisJobs < ActiveRecord::Migration
+class ChangeAnalysisJobs < ActiveRecord::Migration[4.2]
   def change
 
     change_table :analysis_jobs do |t|

--- a/db/migrate/20150807150417_add_missing_indexes.rb
+++ b/db/migrate/20150807150417_add_missing_indexes.rb
@@ -1,4 +1,4 @@
-class AddMissingIndexes < ActiveRecord::Migration
+class AddMissingIndexes < ActiveRecord::Migration[4.2]
   def change
     # from lol_dba: add indexes on foreign keys
     add_index :analysis_jobs, :creator_id

--- a/db/migrate/20150819005323_add_audio_recording_lower_indexes.rb
+++ b/db/migrate/20150819005323_add_audio_recording_lower_indexes.rb
@@ -1,4 +1,4 @@
-class AddAudioRecordingLowerIndexes < ActiveRecord::Migration
+class AddAudioRecordingLowerIndexes < ActiveRecord::Migration[4.2]
   def up
     execute 'CREATE INDEX audio_recordings_icase_file_hash_idx ON audio_recordings ((LOWER(file_hash)));'
     execute 'CREATE INDEX audio_recordings_icase_uuid_idx ON audio_recordings ((LOWER(uuid)));'

--- a/db/migrate/20150904234334_modify_script_versions.rb
+++ b/db/migrate/20150904234334_modify_script_versions.rb
@@ -1,4 +1,4 @@
-class ModifyScriptVersions < ActiveRecord::Migration
+class ModifyScriptVersions < ActiveRecord::Migration[4.2]
   def change
     reversible do |direction|
       direction.up do

--- a/db/migrate/20150905234917_create_tag_groups.rb
+++ b/db/migrate/20150905234917_create_tag_groups.rb
@@ -1,4 +1,4 @@
-class CreateTagGroups < ActiveRecord::Migration
+class CreateTagGroups < ActiveRecord::Migration[4.2]
   def change
 
     create_table :tag_groups do |t|

--- a/db/migrate/20160226103516_add_executable_settings_media_type_to_scripts_table.rb
+++ b/db/migrate/20160226103516_add_executable_settings_media_type_to_scripts_table.rb
@@ -1,4 +1,4 @@
-class AddExecutableSettingsMediaTypeToScriptsTable < ActiveRecord::Migration
+class AddExecutableSettingsMediaTypeToScriptsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :scripts, :executable_settings_media_type, :string, limit: 255, default: 'text/plain'
   end

--- a/db/migrate/20160226130353_add_overall_data_length_bytes_to_analysis_jobs_table.rb
+++ b/db/migrate/20160226130353_add_overall_data_length_bytes_to_analysis_jobs_table.rb
@@ -1,4 +1,4 @@
-class AddOverallDataLengthBytesToAnalysisJobsTable < ActiveRecord::Migration
+class AddOverallDataLengthBytesToAnalysisJobsTable < ActiveRecord::Migration[4.2]
   def change
     add_column :analysis_jobs, :overall_data_length_bytes, :integer, limit: 8, null: false, default: 0
   end

--- a/db/migrate/20160306083845_enable_anonymous_access.rb
+++ b/db/migrate/20160306083845_enable_anonymous_access.rb
@@ -1,4 +1,4 @@
-class EnableAnonymousAccess < ActiveRecord::Migration
+class EnableAnonymousAccess < ActiveRecord::Migration[4.2]
   def up
     add_column :permissions, :allow_logged_in, :boolean, default: false, null: false
     add_column :permissions, :allow_anonymous, :boolean, default: false, null: false

--- a/db/migrate/20160420030414_add_analysis_jobs_items_table.rb
+++ b/db/migrate/20160420030414_add_analysis_jobs_items_table.rb
@@ -1,4 +1,4 @@
-class AddAnalysisJobsItemsTable < ActiveRecord::Migration
+class AddAnalysisJobsItemsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :analysis_jobs_items do |t|
 

--- a/db/migrate/20160614230504_analysis_jobs_column_changes.rb
+++ b/db/migrate/20160614230504_analysis_jobs_column_changes.rb
@@ -1,4 +1,4 @@
-class AnalysisJobsColumnChanges < ActiveRecord::Migration
+class AnalysisJobsColumnChanges < ActiveRecord::Migration[4.2]
   def change
 
     # playing with the state machines, we don't want defaults set

--- a/db/migrate/20160712051359_add_extra_scripts_fields.rb
+++ b/db/migrate/20160712051359_add_extra_scripts_fields.rb
@@ -1,4 +1,4 @@
-class AddExtraScriptsFields < ActiveRecord::Migration
+class AddExtraScriptsFields < ActiveRecord::Migration[4.2]
   def change
 
     # extra options to be passed to actions as part of hash when creating actions

--- a/db/migrate/20160726014747_add_cancel_started_at_to_analysis_jobs_items.rb
+++ b/db/migrate/20160726014747_add_cancel_started_at_to_analysis_jobs_items.rb
@@ -1,4 +1,4 @@
-class AddCancelStartedAtToAnalysisJobsItems < ActiveRecord::Migration
+class AddCancelStartedAtToAnalysisJobsItems < ActiveRecord::Migration[4.2]
   def change
     add_column :analysis_jobs_items, :cancel_started_at, :datetime,  null: true
   end

--- a/db/migrate/20180118002015_create_datasets_v2.rb
+++ b/db/migrate/20180118002015_create_datasets_v2.rb
@@ -1,4 +1,4 @@
-class CreateDatasetsV2 < ActiveRecord::Migration
+class CreateDatasetsV2 < ActiveRecord::Migration[4.2]
   def change
     create_table :datasets do |t|
 

--- a/db/migrate/20181210052707_create_studies.rb
+++ b/db/migrate/20181210052707_create_studies.rb
@@ -1,4 +1,4 @@
-class CreateStudies < ActiveRecord::Migration
+class CreateStudies < ActiveRecord::Migration[4.2]
   def change
     create_table :studies do |t|
 

--- a/db/migrate/20181210052725_create_questions.rb
+++ b/db/migrate/20181210052725_create_questions.rb
@@ -1,4 +1,4 @@
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :questions do |t|
       t.integer :creator_id

--- a/db/migrate/20181210052735_create_responses.rb
+++ b/db/migrate/20181210052735_create_responses.rb
@@ -1,4 +1,4 @@
-class CreateResponses < ActiveRecord::Migration
+class CreateResponses < ActiveRecord::Migration[4.2]
   def change
     create_table :responses do |t|
 

--- a/db/migrate/20200714005247_change_tag_is_taxanomic_to_is_taxonomic.rb
+++ b/db/migrate/20200714005247_change_tag_is_taxanomic_to_is_taxonomic.rb
@@ -1,0 +1,7 @@
+class ChangeTagIsTaxanomicToIsTaxonomic < ActiveRecord::Migration[6.0]
+  def change
+    change_table :tags do |t|
+      t.rename :is_taxanomic, :is_taxonomic
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -13,7 +13,7 @@ SET row_security = off;
 -- Name: is_json(text); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.is_json(input text) RETURNS boolean
+CREATE OR REPLACE FUNCTION public.is_json(input text) RETURNS boolean
     LANGUAGE plpgsql IMMUTABLE
     AS $$
   DECLARE

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -13,7 +13,7 @@ SET row_security = off;
 -- Name: is_json(text); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE OR REPLACE FUNCTION public.is_json(input text) RETURNS boolean
+CREATE FUNCTION public.is_json(input text) RETURNS boolean
     LANGUAGE plpgsql IMMUTABLE
     AS $$
   DECLARE
@@ -67,6 +67,7 @@ CREATE TABLE public.analysis_jobs (
 --
 
 CREATE SEQUENCE public.analysis_jobs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -104,6 +105,7 @@ CREATE TABLE public.analysis_jobs_items (
 --
 
 CREATE SEQUENCE public.analysis_jobs_items_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -156,6 +158,7 @@ CREATE TABLE public.audio_event_comments (
 --
 
 CREATE SEQUENCE public.audio_event_comments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -196,6 +199,7 @@ CREATE TABLE public.audio_events (
 --
 
 CREATE SEQUENCE public.audio_events_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -230,6 +234,7 @@ CREATE TABLE public.audio_events_tags (
 --
 
 CREATE SEQUENCE public.audio_events_tags_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -279,6 +284,7 @@ CREATE TABLE public.audio_recordings (
 --
 
 CREATE SEQUENCE public.audio_recordings_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -316,6 +322,7 @@ CREATE TABLE public.bookmarks (
 --
 
 CREATE SEQUENCE public.bookmarks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -351,6 +358,7 @@ CREATE TABLE public.dataset_items (
 --
 
 CREATE SEQUENCE public.dataset_items_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -385,6 +393,7 @@ CREATE TABLE public.datasets (
 --
 
 CREATE SEQUENCE public.datasets_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -423,6 +432,7 @@ CREATE TABLE public.permissions (
 --
 
 CREATE SEQUENCE public.permissions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -455,6 +465,7 @@ CREATE TABLE public.progress_events (
 --
 
 CREATE SEQUENCE public.progress_events_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -485,7 +496,7 @@ CREATE TABLE public.projects (
     deleted_at timestamp without time zone,
     image_file_name character varying,
     image_content_type character varying,
-    image_file_size integer,
+    image_file_size bigint,
     image_updated_at timestamp without time zone,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
@@ -497,6 +508,7 @@ CREATE TABLE public.projects (
 --
 
 CREATE SEQUENCE public.projects_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -551,6 +563,7 @@ CREATE TABLE public.questions (
 --
 
 CREATE SEQUENCE public.questions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -595,6 +608,7 @@ CREATE TABLE public.responses (
 --
 
 CREATE SEQUENCE public.responses_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -630,6 +644,7 @@ CREATE TABLE public.saved_searches (
 --
 
 CREATE SEQUENCE public.saved_searches_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -679,6 +694,7 @@ CREATE TABLE public.scripts (
 --
 
 CREATE SEQUENCE public.scripts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -709,7 +725,7 @@ CREATE TABLE public.sites (
     deleted_at timestamp without time zone,
     image_file_name character varying,
     image_content_type character varying,
-    image_file_size integer,
+    image_file_size bigint,
     image_updated_at timestamp without time zone,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -724,6 +740,7 @@ CREATE TABLE public.sites (
 --
 
 CREATE SEQUENCE public.sites_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -758,6 +775,7 @@ CREATE TABLE public.studies (
 --
 
 CREATE SEQUENCE public.studies_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -790,6 +808,7 @@ CREATE TABLE public.tag_groups (
 --
 
 CREATE SEQUENCE public.tag_groups_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -811,7 +830,7 @@ ALTER SEQUENCE public.tag_groups_id_seq OWNED BY public.tag_groups.id;
 CREATE TABLE public.tags (
     id integer NOT NULL,
     text character varying NOT NULL,
-    is_taxanomic boolean DEFAULT false NOT NULL,
+    is_taxonomic boolean DEFAULT false NOT NULL,
     type_of_tag character varying DEFAULT 'general'::character varying NOT NULL,
     retired boolean DEFAULT false NOT NULL,
     notes jsonb,
@@ -827,6 +846,7 @@ CREATE TABLE public.tags (
 --
 
 CREATE SEQUENCE public.tags_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -872,7 +892,7 @@ CREATE TABLE public.users (
     roles_mask integer,
     image_file_name character varying,
     image_content_type character varying,
-    image_file_size integer,
+    image_file_size bigint,
     image_updated_at timestamp without time zone,
     preferences text,
     tzinfo_tz character varying(255),
@@ -886,6 +906,7 @@ CREATE TABLE public.users (
 --
 
 CREATE SEQUENCE public.users_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1173,6 +1194,14 @@ ALTER TABLE ONLY public.responses
 
 ALTER TABLE ONLY public.saved_searches
     ADD CONSTRAINT saved_searches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
 --
@@ -1711,13 +1740,6 @@ CREATE UNIQUE INDEX tag_groups_uidx ON public.tag_groups USING btree (tag_id, gr
 --
 
 CREATE UNIQUE INDEX tags_text_uidx ON public.tags USING btree (text);
-
-
---
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
 
 
 --
@@ -2323,6 +2345,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181210052735'),
 ('20200612004608'),
 ('20200625025540'),
-('20200625040615');
+('20200625040615'),
+('20200714005247');
 
 

--- a/spec/acceptance/audio_events_spec.rb
+++ b/spec/acceptance/audio_events_spec.rb
@@ -46,7 +46,7 @@ resource 'AudioEvents' do
     { tags_attributes: [
       FactoryBot.attributes_for(:tag),
       {
-        is_taxanomic: existing_tag.is_taxanomic,
+        is_taxonomic: existing_tag.is_taxonomic,
         text: existing_tag.text,
         type_of_tag: existing_tag.type_of_tag,
         retired: existing_tag.retired

--- a/spec/acceptance/taggings_spec.rb
+++ b/spec/acceptance/taggings_spec.rb
@@ -168,7 +168,7 @@ resource 'Taggings' do
     parameter :audio_recording_id, 'Requested audio recording ID (in path/route)', required: true
     parameter :audio_event_id, 'Requested audio event ID (in path/route)', required: true
 
-    let(:raw_post) { { tagging: { tag_attributes: { is_taxanomic: false, text: existing_tag.text, type_of_tag: 'looks like', retired: false } } }.to_json }
+    let(:raw_post) { { tagging: { tag_attributes: { is_taxonomic: false, text: existing_tag.text, type_of_tag: 'looks like', retired: false } } }.to_json }
 
     let(:authentication_token) { writer_token }
 
@@ -180,7 +180,7 @@ resource 'Taggings' do
     #
     #  do_request
     #  status.should == 200
-    #  response_body.should have_json_path('2/is_taxanomic')
+    #  response_body.should have_json_path('2/is_taxonomic')
     #end
     standard_request_options(:post, 'CREATE (with tag_attributes but existing tag text as writer, with shallow path)', :created,
                              { expected_json_path: 'data/tag_id' })

--- a/spec/acceptance/tags_spec.rb
+++ b/spec/acceptance/tags_spec.rb
@@ -14,7 +14,7 @@ def tag_extras_id_params
 end
 
 def tag_body_params
-  parameter :is_taxanomic, 'is taxanomic', scope: :tag, required: true
+  parameter :is_taxonomic, 'is taxonomic', scope: :tag, required: true
   parameter :text, 'text', scope: :tag, required: true
   parameter :type_of_tag, 'choose from [general, common_name, species_name, looks_like, sounds_like]', scope: :tag, required: true
   parameter :retired, 'true or false', scope: :tag, required: true
@@ -50,26 +50,26 @@ resource 'Tags' do
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'LIST for audio_event (as admin)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as admin)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'LIST for audio_event (as owner)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as owner)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     tag_extras_id_params
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'LIST for audio_event (as writer)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as writer)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
     expected_paths = Array[
       'id',
       'text',
-      'is_taxanomic',
+      'is_taxonomic',
       'type_of_tag',
       'retired',
       'creator_id',
@@ -81,7 +81,7 @@ resource 'Tags' do
 
     tag_extras_id_params
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'LIST for audio_event (as reader)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as reader)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/audio_recordings/:audio_recording_id/audio_events/:audio_event_id/tags' do
@@ -108,32 +108,32 @@ resource 'Tags' do
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'LIST for audio_event (as admin, shallow route)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as admin, shallow route)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'LIST for audio_event (as owner, shallow route)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as owner, shallow route)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'LIST for audio_event (as writer, shallow route)', :ok, { expected_json_path: 'data/0/is_taxanomic', data_item_count: 1 })
+    standard_request_options(:get, 'LIST for audio_event (as writer, shallow route)', :ok, { expected_json_path: 'data/0/is_taxonomic', data_item_count: 1 })
   end
 
   get '/tags' do
     tag_extras_id_params
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'LIST for audio_event (as reader, shallow route)', :ok, expected_json_path: 'data/0/is_taxanomic', data_item_count: 1)
+    standard_request_options(:get, 'LIST for audio_event (as reader, shallow route)', :ok, expected_json_path: 'data/0/is_taxonomic', data_item_count: 1)
   end
 
   get '/tags' do
     expected_paths = Array[
       'id',
       'text',
-      'is_taxanomic',
+      'is_taxonomic',
       'type_of_tag',
       'retired',
       'creator_id',
@@ -171,27 +171,27 @@ resource 'Tags' do
 
   get '/tags/new' do
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'NEW for audio_event (as admin)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'NEW for audio_event (as admin)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/new' do
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'NEW for audio_event (as owner)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'NEW for audio_event (as owner)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/new' do
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'NEW for audio_event (as writer)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'NEW for audio_event (as writer)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/new' do
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'NEW for audio_event (as reader)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'NEW for audio_event (as reader)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/new' do
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'NEW for audio_event (as no access user)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'NEW for audio_event (as no access user)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/new' do
@@ -210,31 +210,31 @@ resource 'Tags' do
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'SHOW (as admin)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'SHOW (as admin)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'SHOW (as owner)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'SHOW (as owner)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'SHOW (as writer)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'SHOW (as writer)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'SHOW (as reader)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'SHOW (as reader)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/:id' do
     tag_id_param
     let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'SHOW (as no access user)', :ok, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'SHOW (as no access user)', :ok, { expected_json_path: 'data/is_taxonomic' })
   end
 
   get '/tags/:id' do
@@ -245,7 +245,7 @@ resource 'Tags' do
 
   get '/tags/:id' do
     tag_id_param
-    standard_request_options(:get, 'SHOW (as anonymous user)', :ok, { remove_auth: true, expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:get, 'SHOW (as anonymous user)', :ok, { remove_auth: true, expected_json_path: 'data/is_taxonomic' })
   end
 
   ################################
@@ -256,35 +256,35 @@ resource 'Tags' do
     tag_body_params
     let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { admin_token }
-    standard_request_options(:post, 'CREATE (as admin)', :created, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:post, 'CREATE (as admin)', :created, { expected_json_path: 'data/is_taxonomic' })
   end
 
   post '/tags' do
     tag_body_params
     let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { owner_token }
-    standard_request_options(:post, 'CREATE (as owner)', :created, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:post, 'CREATE (as owner)', :created, { expected_json_path: 'data/is_taxonomic' })
   end
 
   post '/tags' do
     tag_body_params
     let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { writer_token }
-    standard_request_options(:post, 'CREATE (as writer)', :created, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:post, 'CREATE (as writer)', :created, { expected_json_path: 'data/is_taxonomic' })
   end
 
   post '/tags' do
     tag_body_params
     let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { reader_token }
-    standard_request_options(:post, 'CREATE (as reader)', :created, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:post, 'CREATE (as reader)', :created, { expected_json_path: 'data/is_taxonomic' })
   end
 
   post '/tags' do
     tag_body_params
     let(:raw_post) { { 'tag' => post_attributes }.to_json }
     let(:authentication_token) { no_access_token }
-    standard_request_options(:post, 'CREATE (as no access user)', :created, { expected_json_path: 'data/is_taxanomic' })
+    standard_request_options(:post, 'CREATE (as no access user)', :created, { expected_json_path: 'data/is_taxonomic' })
   end
 
   post '/tags' do
@@ -314,15 +314,15 @@ resource 'Tags' do
           }
         },
         'projection' => {
-          'include' => ['id', 'text', 'is_taxanomic', 'retired']
+          'include' => ['id', 'text', 'is_taxonomic', 'retired']
         }
       }.to_json
     }
     standard_request_options(:post, 'FILTER (as reader, with projection)', :ok,
                              {
-                               expected_json_path: 'data/0/is_taxanomic',
+                               expected_json_path: 'data/0/is_taxonomic',
                                data_item_count: 1,
-                               response_body_content: ['"retired":false', '"projection":{"include":["id","text","is_taxanomic","retired"]}']
+                               response_body_content: ['"retired":false', '"projection":{"include":["id","text","is_taxonomic","retired"]}']
                              })
   end
 

--- a/spec/factories/tag_factory.rb
+++ b/spec/factories/tag_factory.rb
@@ -6,15 +6,15 @@ FactoryBot.define do
 
     creator
     type_of_tag { 'general' }
-    is_taxanomic { false }
+    is_taxonomic { false }
 
     trait :taxonomic_true_common do
-      is_taxanomic { true }
+      is_taxonomic { true }
       type_of_tag { :common_name }
     end
 
     trait :taxonomic_false_sounds_like do
-      is_taxanomic { false }
+      is_taxonomic { false }
       type_of_tag { :sounds_like }
     end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -18,18 +18,18 @@ describe Tag, type: :model do
   # .with_predicates(true).with_multiple(false)
   it { is_expected.to enumerize(:type_of_tag).in(*Tag::AVAILABLE_TYPE_OF_TAGS) }
 
-  it 'should not allow nil for is_taxanomic' do
-    expect(build(:tag, is_taxanomic: nil)).not_to be_valid
+  it 'should not allow nil for is_taxonomic' do
+    expect(build(:tag, is_taxonomic: nil)).not_to be_valid
   end
-  it 'ensures is_taxanomic can be true or false' do
+  it 'ensures is_taxonomic can be true or false' do
     t = build(:tag)
     expect(t).to be_valid
 
-    t.is_taxanomic = true
+    t.is_taxonomic = true
     t.type_of_tag = :common_name
     expect(t).to be_valid
 
-    t.is_taxanomic = false
+    t.is_taxonomic = false
     t.type_of_tag = :general
     expect(t).to be_valid
   end
@@ -60,12 +60,12 @@ describe Tag, type: :model do
   type_of_tags = [:general, :common_name, :species_name, :looks_like, :sounds_like]
 
   type_of_tags.each do |tag_type|
-    expected_is_taxanomic_value = tag_type == :common_name || tag_type == :species_name
+    expected_is_taxonomic_value = tag_type == :common_name || tag_type == :species_name
     it "ensures type_of_tag can be set to #{tag_type}" do
       t = build(:tag)
       expect(t).to be_valid
       t.type_of_tag = tag_type
-      t.is_taxanomic = expected_is_taxanomic_value
+      t.is_taxonomic = expected_is_taxonomic_value
       expect(t).to be_valid
 
       type_of_tags.each { |type_of_tag|
@@ -73,16 +73,16 @@ describe Tag, type: :model do
       }
     end
 
-    it "ensures is_taxanomic is set to #{expected_is_taxanomic_value} for #{tag_type}" do
+    it "ensures is_taxonomic is set to #{expected_is_taxonomic_value} for #{tag_type}" do
       t = build(:tag)
       expect(t).to be_valid
 
       t.type_of_tag = tag_type
 
-      t.is_taxanomic = !expected_is_taxanomic_value
+      t.is_taxonomic = !expected_is_taxonomic_value
       expect(t).not_to be_valid
 
-      t.is_taxanomic = expected_is_taxanomic_value
+      t.is_taxonomic = expected_is_taxonomic_value
       expect(t).to be_valid
     end
   end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -58,10 +58,10 @@ describe 'Tags' do
     end
 
     it 'creates a taxonomic tag' do
-      post @tag_url, params: create('is_taxanomic': true, 'type_of_tag': 'common_name').to_json, headers: @env
+      post @tag_url, params: create('is_taxonomic': true, 'type_of_tag': 'common_name').to_json, headers: @env
       parsed_response = JSON.parse(response.body)
       expect(response).to have_http_status(201)
-      expect(parsed_response['data']['is_taxanomic']).to be true
+      expect(parsed_response['data']['is_taxonomic']).to be true
       expect(parsed_response['data']['type_of_tag']).to eq 'common_name'
     end
 


### PR DESCRIPTION
# Rename Taxanomic to Taxonomic

Fixed a common spelling mistake in API where taxonomic was written as "taxanomic". This affected the database, tags model, and tag api routes.

## Changes

- Updated old migrations to declare `ActiveRecord::Migration[4.2]` instead of `ActiveRecord::Migration`
- Fixed taxonomic spelling mistakes
- Created migration for fixing database spelling mistake
- Updated parts of README to change `rake` to `rails` where relevant
  - Kept focus on db commands as I have not verified the others

## Issues

- Had to manually tested migrations worked
  - Successfully converted `is_taxanomic` column to `is_taxonomic` for true and false cases
- Missing unit tests for migration

## Closes

Closes #466 
Relates to #469 