### PR TITLE
By permission keyword arguments

### DIFF
--- a/app/controllers/analysis_jobs_controller.rb
+++ b/app/controllers/analysis_jobs_controller.rb
@@ -154,6 +154,6 @@ class AnalysisJobsController < ApplicationController
   end
 
   def get_analysis_jobs
-    Access::ByPermission.analysis_jobs(current_user, Access::Core.levels)
+    Access::ByPermission.analysis_jobs(current_user)
   end
 end

--- a/app/controllers/audio_event_comments_controller.rb
+++ b/app/controllers/audio_event_comments_controller.rb
@@ -11,7 +11,7 @@ class AudioEventCommentsController < ApplicationController
 
     @audio_event_comments, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.audio_event_comments(current_user, Access::Core.levels, @audio_event),
+      Access::ByPermission.audio_event_comments(current_user, audio_event: @audio_event),
       AudioEventComment,
       AudioEventComment.filter_settings
     )

--- a/app/controllers/audio_events_controller.rb
+++ b/app/controllers/audio_events_controller.rb
@@ -14,7 +14,7 @@ class AudioEventsController < ApplicationController
 
     @audio_events, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.audio_events(current_user, Access::Core.levels, @audio_recording),
+      Access::ByPermission.audio_events(current_user, audio_recording: @audio_recording),
       AudioEvent,
       AudioEvent.filter_settings
     )

--- a/app/controllers/dataset_items_controller.rb
+++ b/app/controllers/dataset_items_controller.rb
@@ -9,7 +9,7 @@ class DatasetItemsController < ApplicationController
 
     @dataset_items, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.dataset_items(current_user, params[:dataset_id]),
+      Access::ByPermission.dataset_items(current_user, dataset_id: params[:dataset_id]),
       DatasetItem,
       DatasetItem.filter_settings
     )
@@ -31,7 +31,7 @@ class DatasetItemsController < ApplicationController
 
     filter_response, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.dataset_items(current_user, params[:dataset_id]),
+      Access::ByPermission.dataset_items(current_user, dataset_id: params[:dataset_id]),
       DatasetItem,
       DatasetItem.filter_settings(:reverse_order)
     )
@@ -45,7 +45,7 @@ class DatasetItemsController < ApplicationController
     #priority_algorithm = DatasetItem.next_for_user(current_user_id = current_user ? current_user.id : nil)
 
     # All dataset items that the user has permission to see
-    query = Access::ByPermission.dataset_items(current_user, params[:dataset_id])
+    query = Access::ByPermission.dataset_items(current_user, dataset_id: params[:dataset_id])
 
     query = query.joins("LEFT OUTER JOIN progress_events ON progress_events.dataset_item_id = dataset_items.id AND activity = 'viewed'")
     query = query.group('dataset_items.id')

--- a/app/controllers/progress_events_controller.rb
+++ b/app/controllers/progress_events_controller.rb
@@ -9,7 +9,7 @@ class ProgressEventsController < ApplicationController
 
     @progress_events, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.progress_events(current_user, params[:dataset_item_id]),
+      Access::ByPermission.progress_events(current_user, dataset_item_id: params[:dataset_item_id]),
       ProgressEvent,
       ProgressEvent.filter_settings
     )
@@ -30,7 +30,7 @@ class ProgressEventsController < ApplicationController
 
     filter_response, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.progress_events(current_user, params[:dataset_item_id]),
+      Access::ByPermission.progress_events(current_user, dataset_item_id: params[:dataset_item_id]),
       ProgressEvent,
       ProgressEvent.filter_settings
     )

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -141,7 +141,7 @@ ORDER BY project_count ASC, s.name ASC")
   def new_access_request
     do_authorize_class
 
-    @all_projects = Access::ByPermission.projects(current_user, Access::Core.levels_none).order(name: :asc)
+    @all_projects = Access::ByPermission.projects(current_user, levels: Access::Core.levels_none).order(name: :asc)
     respond_to do |format|
       format.html
     end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -301,7 +301,7 @@ class PublicController < ApplicationController
     if current_user.blank?
       @recent_audio_recordings = AudioRecording.order(order_by_coalesce).limit(7)
     else
-      @recent_audio_recordings = Access::ByPermission.audio_recordings(current_user, Access::Core.levels).includes(site: :projects).order(order_by_coalesce).limit(10)
+      @recent_audio_recordings = Access::ByPermission.audio_recordings(current_user).includes(site: :projects).order(order_by_coalesce).limit(10)
     end
   end
 
@@ -319,7 +319,7 @@ class PublicController < ApplicationController
                                .limit(10)
                            else
                              Access::ByPermission
-                               .audio_events(current_user, Access::Core.levels)
+                               .audio_events(current_user)
                                .includes([:updater, audio_recording: :site])
                                .order(order_by_coalesce).limit(10)
                            end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -10,7 +10,7 @@ class ResponsesController < ApplicationController
 
     @responses, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.responses(current_user, params[:study_id]),
+      Access::ByPermission.responses(current_user, study_id: params[:study_id]),
       Response,
       Response.filter_settings
     )
@@ -30,7 +30,7 @@ class ResponsesController < ApplicationController
 
     filter_response, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.responses(current_user, nil),
+      Access::ByPermission.responses(current_user),
       Response,
       Response.filter_settings
     )

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -218,7 +218,7 @@ class SitesController < ApplicationController
     if @project.nil?
       Access::ByPermission.sites(current_user)
     else
-      Access::ByPermission.sites(current_user, Access::Core.levels, [@project.id])
+      Access::ByPermission.sites(current_user, project_ids: [@project.id])
     end
   end
 

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -12,7 +12,7 @@ class TaggingsController < ApplicationController
 
     @taggings, opts = Settings.api_response.response_advanced(
       api_filter_params,
-      Access::ByPermission.audio_events_tags(current_user, Access::Core.levels, @audio_event),
+      Access::ByPermission.audio_events_tags(current_user, audio_event: @audio_event),
       Tagging,
       Tagging.filter_settings
     )

--- a/app/modules/access/by_permission.rb
+++ b/app/modules/access/by_permission.rb
@@ -49,7 +49,7 @@ module Access
       def sites(user, levels: Access::Core.levels, project_ids: nil)
         # project can be nil
         query = Site.all
-        permission_sites(user, levels, query, project_ids)
+        permission_sites(user, levels, query, project_ids: project_ids)
       end
 
       # Get all audio recordings for which this user has these access levels.
@@ -73,7 +73,7 @@ module Access
         if audio_recording
           query = query.where(audio_recording_id: audio_recording.id)
           project_ids = audio_recording.site.projects.pluck(:id)
-          permission_sites(user, levels, query, project_ids)
+          permission_sites(user, levels, query, project_ids: project_ids)
         else
           permission_sites(user, levels, query)
         end
@@ -91,7 +91,7 @@ module Access
         if audio_event
           query = query.where(audio_event_id: audio_event.id)
           project_ids = audio_event.audio_recording.site.projects.pluck(:id)
-          permission_sites(user, levels, query, project_ids)
+          permission_sites(user, levels, query, project_ids: project_ids)
         else
           permission_sites(user, levels, query)
         end
@@ -109,7 +109,7 @@ module Access
         if audio_event
           query = query.where(audio_event_id: audio_event.id)
           project_ids = audio_event.audio_recording.site.projects.pluck(:id)
-          permission_sites(user, levels, query, project_ids)
+          permission_sites(user, levels, query, project_ids: project_ids)
         else
           permission_sites(user, levels, query)
         end

--- a/app/modules/api/analysis_jobs_items_shared.rb
+++ b/app/modules/api/analysis_jobs_items_shared.rb
@@ -52,9 +52,9 @@ module Api
 
     def get_query
       if @is_system_job
-        Access::ByPermission.analysis_jobs_items(nil, current_user, true)
+        Access::ByPermission.analysis_jobs_items(nil, current_user, system_mode: true)
       else
-        Access::ByPermission.analysis_jobs_items(@analysis_job, current_user, false)
+        Access::ByPermission.analysis_jobs_items(@analysis_job, current_user)
       end
     end
   end

--- a/spec/lib/modules/filter/query_spec.rb
+++ b/spec/lib/modules/filter/query_spec.rb
@@ -591,7 +591,7 @@ describe Filter::Query do
       user = writer_user
       filter_query = Filter::Query.new(
         posted_filter,
-        Access::ByPermission.audio_recordings(user, Access::Core.levels),
+        Access::ByPermission.audio_recordings(user),
         AudioRecording,
         AudioRecording.filter_settings
       )
@@ -855,7 +855,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_recordings(user, Access::Core.levels),
+        Access::ByPermission.audio_recordings(user),
         AudioRecording,
         AudioRecording.filter_settings
       )
@@ -983,7 +983,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_recordings(user, Access::Core.levels),
+        Access::ByPermission.audio_recordings(user),
         AudioRecording,
         AudioRecording.filter_settings
       )
@@ -1091,7 +1091,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.analysis_jobs_items(nil, user, true),
+        Access::ByPermission.analysis_jobs_items(nil, user, system_mode: true),
         AnalysisJobsItem,
         AnalysisJobsItem.filter_settings(true)
       )
@@ -1115,7 +1115,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_events(user, Access::Core.levels),
+        Access::ByPermission.audio_events(user),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1198,7 +1198,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_events(user, Access::Core.levels),
+        Access::ByPermission.audio_events(user),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1277,7 +1277,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_recordings(user, Access::Core.levels),
+        Access::ByPermission.audio_recordings(user),
         AudioRecording,
         AudioRecording.filter_settings
       )
@@ -1351,7 +1351,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_events(user, Access::Core.levels),
+        Access::ByPermission.audio_events(user),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1379,7 +1379,7 @@ describe Filter::Query do
 
       filter_query = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_event_comments(user, Access::Core.levels),
+        Access::ByPermission.audio_event_comments(user),
         AudioEventComment,
         AudioEventComment.filter_settings
       )
@@ -1403,7 +1403,7 @@ describe Filter::Query do
 
       filter_query_inaccessible = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.projects(the_user, Access::Core.levels_none),
+        Access::ByPermission.projects(the_user, levels: Access::Core.levels_none),
         Project,
         Project.filter_settings
       )
@@ -1454,7 +1454,7 @@ describe Filter::Query do
 
       filter_query_project2 = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.sites(the_user, Access::Core.levels, [project_new.id]),
+        Access::ByPermission.sites(the_user, project_ids: [project_new.id]),
         Site,
         Site.filter_settings
       )
@@ -1485,7 +1485,7 @@ describe Filter::Query do
 
       filter_query_site = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.sites(the_user, Access::Core.levels_none, [project3.id]),
+        Access::ByPermission.sites(the_user, levels: Access::Core.levels_none, project_ids: [project3.id]),
         Site,
         Site.filter_settings
       )
@@ -1543,7 +1543,7 @@ describe Filter::Query do
 
       filter_query_project2 = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_events(the_user, Access::Core.levels, audio_recording2),
+        Access::ByPermission.audio_events(the_user, audio_recording: audio_recording2),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1588,7 +1588,7 @@ describe Filter::Query do
 
       filter_query_project2 = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_event_comments(the_user, Access::Core.levels, audio_event2),
+        Access::ByPermission.audio_event_comments(the_user, audio_event: audio_event2),
         AudioEventComment,
         AudioEventComment.filter_settings
       )
@@ -1623,7 +1623,7 @@ describe Filter::Query do
 
       filter_query_project2 = Filter::Query.new(
         request_body_obj,
-        Access::ByPermission.audio_event_comments(the_user, Access::Core.levels_none, audio_event2),
+        Access::ByPermission.audio_event_comments(the_user, levels: Access::Core.levels_none, audio_event: audio_event2),
         AudioEventComment,
         AudioEventComment.filter_settings
       )
@@ -1660,7 +1660,7 @@ describe Filter::Query do
 
       filter = Filter::Query.new(
         { filter_start_time_seconds: 10, filter_end_time_seconds: 88 },
-        Access::ByPermission.audio_events(admin_user, Access::Core.levels, audio_recording),
+        Access::ByPermission.audio_events(admin_user, audio_recording: audio_recording),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1685,7 +1685,7 @@ describe Filter::Query do
 
       filter = Filter::Query.new(
         { filter_duration_seconds: 78 },
-        Access::ByPermission.audio_events(admin_user, Access::Core.levels, audio_recording),
+        Access::ByPermission.audio_events(admin_user, audio_recording: audio_recording),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1727,7 +1727,7 @@ describe Filter::Query do
           duration_seconds: { eq: 78 }, start_time_seconds: { eq: 20 }
         },
           filter_start_time_seconds: 10, filter_end_time_seconds: 88 },
-        Access::ByPermission.audio_events(admin_user, Access::Core.levels, audio_recording),
+        Access::ByPermission.audio_events(admin_user, audio_recording: audio_recording),
         AudioEvent,
         AudioEvent.filter_settings
       )
@@ -1881,7 +1881,7 @@ describe Filter::Query do
     it 'returns no sites for admin' do
       filter_hash = { filter: {} }
       project_id = FactoryBot.create(:project, creator: admin_user).id
-      filter_query = Access::ByPermission.sites(admin_user, Access::Core.levels, project_id)
+      filter_query = Access::ByPermission.sites(admin_user, project_ids: project_id)
       filter = Filter::Query.new(
         filter_hash,
         filter_query,
@@ -1898,7 +1898,7 @@ describe Filter::Query do
     it 'returns no sites for regular user' do
       filter_hash = { filter: {} }
       project_id = FactoryBot.create(:project, creator: writer_user).id
-      filter_query = Access::ByPermission.sites(writer_user, Access::Core.levels, project_id)
+      filter_query = Access::ByPermission.sites(writer_user, project_ids: project_id)
       filter = Filter::Query.new(
         filter_hash,
         filter_query,

--- a/spec/models/analysis_jobs_item_spec.rb
+++ b/spec/models/analysis_jobs_item_spec.rb
@@ -227,7 +227,7 @@ describe AnalysisJobsItem, type: :model do
         user = no_access_user
 
         # augment the system with query with permissions
-        query = Access::ByPermission.analysis_jobs_items(nil, user, true)
+        query = Access::ByPermission.analysis_jobs_items(nil, user, system_mode: true)
 
         rows = query.all
 


### PR DESCRIPTION
# Access::ByPermission keyword arguments

Modified `Access::ByPermission` functions to utilise keyword arguments instead of positional arguments for default values.

