### PR TITLE
Standardizes description markdown conversion in API

### DIFF
--- a/app/controllers/analysis_jobs_controller.rb
+++ b/app/controllers/analysis_jobs_controller.rb
@@ -143,7 +143,8 @@ class AnalysisJobsController < ApplicationController
       :saved_search_id,
       :name,
       :custom_settings,
-      :description
+      :description,
+      :annotation_name
     )
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,7 @@ class ApplicationController < ActionController::Base
   rescue_from CustomErrors::UnprocessableEntityError, with: :unprocessable_entity_error_response
   rescue_from CustomErrors::FilterArgumentError, with: :filter_argument_error_response
   rescue_from CustomErrors::AudioGenerationError, with: :audio_generation_error_response
+  rescue_from CustomErrors::OrphanedSiteError, with: :orpan_site_error_response
   rescue_from BawAudioTools::Exceptions::AudioToolError, with: :audio_tool_error_response
 
   # Don't rescue this, it is the base for 406 and 415
@@ -580,6 +581,15 @@ class ApplicationController < ActionController::Base
       error,
       'audio_generation_error_response',
       { error_info: error.job_info }
+    )
+  end
+
+  def orpan_site_error_response(error)
+    render_error(
+      :bad_request,
+      error.message,
+      error,
+      'orpan_site_error_response'
     )
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -399,7 +399,7 @@ class Ability
     can [:index, :filter, :new], Bookmark
   end
 
-  def to_analysis_job(user, is_guest)
+  def to_analysis_job(user, _is_guest)
     # must have read permission or higher on ANY saved_search.projects to create analysis job
 
     can [:show, :create], AnalysisJob do |analysis_job|
@@ -419,7 +419,9 @@ class Ability
     can [:update, :destroy], AnalysisJob, creator_id: user.id
 
     # actions any logged in user can access
-    can [:new], AnalysisJob unless is_guest
+    # AT: 2020 - disabled unless guest filter. Anyone should be able to new
+    #   I'm unsure why it was disabled
+    can [:new], AnalysisJob #unless is_guest
 
     # available to any user, including guest
     can [:index, :filter], AnalysisJob

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -420,11 +420,11 @@ class Ability
 
     # actions any logged in user can access
     # AT: 2020 - disabled unless guest filter. Anyone should be able to new
-    #   I'm unsure why it was disabled
-    can [:new], AnalysisJob #unless is_guest
+    #   I'm unsure why it was being excluded to guest
+    #can [:new], AnalysisJob #unless is_guest
 
     # available to any user, including guest
-    can [:index, :filter], AnalysisJob
+    can [:index, :filter, :new], AnalysisJob
   end
 
   def to_analysis_jobs_item(user)

--- a/app/models/analysis_job.rb
+++ b/app/models/analysis_job.rb
@@ -113,7 +113,7 @@ class AnalysisJob < ApplicationRecord
         overall_count: { type: 'integer', readOnly: true },
         overall_duration_seconds: { type: 'number', readOnly: true },
         overall_data_length_bytes: { type: 'integer', readOnly: true },
-        **Api::Schema.all_ids_and_ats
+        **Api::Schema.all_user_stamps
       },
       required: [
         :id,

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,4 +4,5 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   include AlphabeticalPaginatorQuery
+  include RendersMarkdown
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -55,7 +55,7 @@ class Bookmark < ApplicationRecord
         category: { type: 'string' },
         offset_seconds: { type: 'number' },
         **Api::Schema.rendered_markdown(:description),
-        **Api::Schema.updater_and_creator_ids_and_ats
+        **Api::Schema.updater_and_creator_user_stamps
       },
       required: [
         :id,

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -22,9 +22,12 @@ class Bookmark < ApplicationRecord
   # Define filter api settings
   def self.filter_settings
     {
-      valid_fields: [:id, :audio_recording_id, :name, :category, :description, :offset_seconds, :created_at, :creator_id],
-      render_fields: [:id, :audio_recording_id, :name, :category, :description, :offset_seconds, :creator_id],
+      valid_fields: [:id, :audio_recording_id, :name, :category, :description, :offset_seconds, :created_at, :creator_id, :updater_id, :updated_at],
+      render_fields: [:id, :audio_recording_id, :name, :category, :description, :offset_seconds, :created_at, :creator_id, :updater_id, :updated_at],
       text_fields: [:name, :description, :category],
+      custom_fields: lambda { |item, _user|
+        [item, item.render_markdown_for_api_for(:description)]
+      },
       controller: :bookmarks,
       action: :filter,
       defaults: {
@@ -39,5 +42,35 @@ class Bookmark < ApplicationRecord
         }
       ]
     }
+  end
+
+  def self.schema
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        audio_recording_id: { '$ref' => '#/components/schemas/id' },
+        name: { type: 'string' },
+        category: { type: 'string' },
+        offset_seconds: { type: 'number' },
+        **Api::Schema.rendered_markdown(:description),
+        **Api::Schema.updater_and_creator_ids_and_ats
+      },
+      required: [
+        :id,
+        :audio_recording_id,
+        :name,
+        :category,
+        :offset_seconds,
+        :description,
+        :description_html,
+        :description_html_tagline,
+        :creator_id,
+        :created_at,
+        :updater_id,
+        :updated_at
+      ]
+    }.freeze
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -44,6 +44,9 @@ class Dataset < ApplicationRecord
       render_fields: [
         :id, :name, :description, :created_at, :creator_id, :updated_at, :updater_id
       ],
+      custom_fields: lambda { |item, _user|
+        [item, item.render_markdown_for_api_for(:description)]
+      },
       new_spec_fields: lambda { |_user|
                          {
                            name: nil,
@@ -80,5 +83,27 @@ class Dataset < ApplicationRecord
         }
       ]
     }
+  end
+
+  def self.schema
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        name: { type: 'string' },
+        **Api::Schema.rendered_markdown(:description),
+        **Api::Schema.updater_and_creator_ids_and_ats
+      },
+      required: [
+        :id,
+        :name,
+        :description,
+        :created_at,
+        :creator_id,
+        :updated_at,
+        :updater_id
+      ]
+    }.freeze
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -93,7 +93,7 @@ class Dataset < ApplicationRecord
         id: { '$ref' => '#/components/schemas/id', readOnly: true },
         name: { type: 'string' },
         **Api::Schema.rendered_markdown(:description),
-        **Api::Schema.updater_and_creator_ids_and_ats
+        **Api::Schema.updater_and_creator_user_stamps
       },
       required: [
         :id,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -67,7 +67,7 @@ class Project < ApplicationRecord
                        project_hash = {}
                        project_hash[:site_ids] = fresh_project.nil? ? nil : fresh_project.sites.pluck(:id).flatten
                        project_hash[:owner_ids] = fresh_project.nil? ? nil : fresh_project.owners.pluck(:id).flatten
-
+                       project_hash[:image_urls] = Api::Image.image_urls(fresh_project.image)
                        project_hash.merge!(item.render_markdown_for_api_for(:description))
 
                        [item, project_hash]
@@ -126,7 +126,8 @@ class Project < ApplicationRecord
         notes: { type: 'string' },
         **Api::Schema.all_ids_and_ats,
         site_ids: { type: 'array', items: { '$ref' => '#/components/schemas/id' } },
-        owner_ids: { type: 'array', items: { '$ref' => '#/components/schemas/id' }, readOnly: true }
+        owner_ids: { type: 'array', items: { '$ref' => '#/components/schemas/id' }, readOnly: true },
+        image_urls: Api::Schema.image_urls
       },
       required: [
         :id,
@@ -142,7 +143,8 @@ class Project < ApplicationRecord
         :deleter_id,
         :deleted_at,
         :owner_ids,
-        :site_ids
+        :site_ids,
+        :image_urls
       ]
     }.freeze
   end

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -77,7 +77,7 @@ class SavedSearch < ApplicationRecord
         name: { type: 'string' },
         **Api::Schema.rendered_markdown(:description),
         stored_query: { type: 'object' },
-        **Api::Schema.creator_and_deleter_ids_and_ats
+        **Api::Schema.creator_and_deleter_user_stamps
       },
       required: [
         :id,

--- a/app/models/script.rb
+++ b/app/models/script.rb
@@ -94,12 +94,13 @@ class Script < ApplicationRecord
       valid_fields: [:id, :group_id, :name, :description, :analysis_identifier, :executable_settings_media_type,
                      :version, :created_at, :creator_id, :is_last_version, :is_first_version, :analysis_action_params],
       render_fields: [:id, :group_id, :name, :description, :analysis_identifier, :executable_settings,
-                      :executable_settings_media_type, :version, :created_at, :creator_id],
+                      :executable_settings_media_type, :version, :created_at, :creator_id, :analysis_action_params],
       text_fields: [:name, :description, :analysis_identifier, :executable_settings_media_type, :analysis_action_params],
       custom_fields: lambda { |item, _user|
                        virtual_fields = {
                          is_last_version: item.is_last_version?,
-                         is_first_version: item.is_first_version?
+                         is_first_version: item.is_first_version?,
+                         **item.render_markdown_for_api_for(:description)
                        }
                        [item, virtual_fields]
                      },
@@ -132,6 +133,31 @@ class Script < ApplicationRecord
         direction: :asc
       }
     }
+  end
+
+  def self.schema
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        group_id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        name: { type: 'string' },
+        **Api::Schema.rendered_markdown(:description),
+        analysis_identifier: { type: 'string' },
+        executable_settings: { type: 'string' },
+        executable_settings_media_type: { type: 'string' },
+        version: { type: 'number' },
+        **Api::Schema.creator_ids_and_ats,
+        is_last_version: { type: 'boolean', readOnly: true },
+        is_first_version: { type: 'boolean', readOnly: true },
+        analysis_action_params: { type: 'object' }
+      },
+      required: [
+        :id, :group_id, :name, :description, :analysis_identifier, :executable_settings_media_type,
+        :version, :created_at, :creator_id, :is_last_version, :is_first_version, :analysis_action_params
+      ]
+    }.freeze
   end
 
   private

--- a/app/models/script.rb
+++ b/app/models/script.rb
@@ -148,7 +148,7 @@ class Script < ApplicationRecord
         executable_settings: { type: 'string' },
         executable_settings_media_type: { type: 'string' },
         version: { type: 'number' },
-        **Api::Schema.creator_ids_and_ats,
+        **Api::Schema.creator_user_stamp,
         is_last_version: { type: 'boolean', readOnly: true },
         is_first_version: { type: 'boolean', readOnly: true },
         analysis_action_params: { type: 'object' }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -7,7 +7,7 @@ class Site < ApplicationRecord
   # ensures timezones are handled consistently
   include TimeZoneAttribute
 
-  attr_accessor :project_ids, :custom_latitude, :custom_longitude, :location_obfuscated
+  attr_accessor :custom_latitude, :custom_longitude, :location_obfuscated
 
   # relations
   has_and_belongs_to_many :projects, -> { distinct }
@@ -253,7 +253,7 @@ class Site < ApplicationRecord
         id: { '$ref' => '#/components/schemas/id', readOnly: true },
         name: { type: 'string' },
         **Api::Schema.rendered_markdown(:description),
-        **Api::Schema.all_ids_and_ats,
+        **Api::Schema.all_user_stamps,
         #notes: { type: 'object' }, # TODO: https://github.com/QutEcoacoustics/baw-server/issues/467
         notes: { type: 'string' },
         project_ids: { type: 'array', items: { type: 'integer' } },

--- a/app/modules/api/schema.rb
+++ b/app/modules/api/schema.rb
@@ -1,38 +1,50 @@
+# frozen_string_literal: true
+
+# Namespace module for API related functionality.
 module Api
+  # A small module that helps output boilerplate JSON schema definitions.
+  # All the declarations here could be inlined with no ill-effect.
   module Schema
-    def self.all_ids_and_ats
+    def self.creator_user_stamp
       {
         creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
-        updater_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
-        deleter_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
-        created_at: { type: 'date', readOnly: true },
-        updated_at: { type: ['null', 'date'], readOnly: true },
-        deleted_at: { type: ['null', 'date'], readOnly: true }
+        created_at: { type: 'date', readOnly: true }
       }
     end
 
-    def self.updater_and_creator_ids_and_ats
+    def self.updater_user_stamp
       {
-        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
         updater_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
-        created_at: { type: 'date', readOnly: true },
         updated_at: { type: ['null', 'date'], readOnly: true }
       }
     end
 
-    def self.creator_and_deleter_ids_and_ats
+    def self.deleter_user_stamp
       {
-        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
         deleter_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
-        created_at: { type: 'date', readOnly: true },
         deleted_at: { type: ['null', 'date'], readOnly: true }
       }
     end
 
-    def self.creator_ids_and_ats
+    def self.all_user_stamps
       {
-        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
-        created_at: { type: 'date', readOnly: true }
+        **creator_user_stamp,
+        **updater_user_stamp,
+        **deleter_user_stamp
+      }
+    end
+
+    def self.updater_and_creator_user_stamps
+      {
+        **creator_user_stamp,
+        **updater_user_stamp
+      }
+    end
+
+    def self.creator_and_deleter_user_stamps
+      {
+        **creator_user_stamp,
+        **deleter_user_stamp
       }
     end
 
@@ -50,6 +62,10 @@ module Api
 
     def self.image_urls
       { '$ref' => '#/components/schemas/image_urls' }
+    end
+
+    def self.permission_levels
+      { '$ref' => '#/components/schemas/permission_levels' }
     end
   end
 end

--- a/app/modules/api/schema.rb
+++ b/app/modules/api/schema.rb
@@ -1,0 +1,55 @@
+module Api
+  module Schema
+    def self.all_ids_and_ats
+      {
+        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        updater_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
+        deleter_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
+        created_at: { type: 'date', readOnly: true },
+        updated_at: { type: ['null', 'date'], readOnly: true },
+        deleted_at: { type: ['null', 'date'], readOnly: true }
+      }
+    end
+
+    def self.updater_and_creator_ids_and_ats
+      {
+        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        updater_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
+        created_at: { type: 'date', readOnly: true },
+        updated_at: { type: ['null', 'date'], readOnly: true }
+      }
+    end
+
+    def self.creator_and_deleter_ids_and_ats
+      {
+        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        deleter_id: { '$ref' => '#/components/schemas/nullableId', readOnly: true },
+        created_at: { type: 'date', readOnly: true },
+        deleted_at: { type: ['null', 'date'], readOnly: true }
+      }
+    end
+
+    def self.creator_ids_and_ats
+      {
+        creator_id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        created_at: { type: 'date', readOnly: true }
+      }
+    end
+
+    def self.rendered_markdown(attr)
+      {
+        "#{attr}": { type: ['string', 'null'] },
+        "#{attr}_html": { type: ['string', 'null'], readOnly: true },
+        "#{attr}_html_tagline": { type: ['string', 'null'], readOnly: true }
+      }
+    end
+
+    def self.timezone_information
+      { '$ref' => '#/components/schemas/timezone_information' }
+    end
+
+    def self.image_urls
+      { '$ref' => '#/components/schemas/image_urls' }
+    end
+  end
+end

--- a/app/modules/renders_markdown.rb
+++ b/app/modules/renders_markdown.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Standardizes rendering markdown in models
+module RendersMarkdown
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Adds the convenience methods #{attr}_html for the given attributes.
+    # These methods convert a markdown body to sanitized HTML.
+    # @!parse
+    def renders_markdown_for(*attrs)
+      attrs.each do |attr|
+        define_method("#{attr}_html".to_sym) do
+          render_markdown_for(attr, inline: false)
+        end
+      end
+    end
+  end
+
+  # Renders markdown for a given attribute
+  def render_markdown_for(attr, inline: false)
+    CustomRender.render_markdown(read_attribute(attr), inline: inline)
+  end
+
+  def render_markdown_tagline_for(attr, words: 20)
+    CustomRender.render_markdown(read_attribute(attr), inline: true, words: words)
+  end
+
+  # @returns Hash of values to be merged into the custom fields property of filter_settings
+  def render_markdown_for_api_for(attr, words: 20)
+    {
+      "#{attr}_html".to_sym => render_markdown_for(attr),
+      "#{attr}_html_tagline".to_sym => render_markdown_tagline_for(attr, words: words)
+    }
+  end
+end

--- a/baw-server.code-workspace
+++ b/baw-server.code-workspace
@@ -8,6 +8,7 @@
     "cSpell.words": [
       "Bootsnap",
       "Gemfile",
+      "KRAMDOWN",
       "Kramdown",
       "Railtie",
       "autoload",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Rails.application.routes.draw do
 
   # path for orphaned sites
   get 'sites/orphans' => 'sites#orphans'
+  post 'sites/orphans/filter' => 'sites#orphans'
 
   # shallow path to sites
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,8 +261,8 @@ Rails.application.routes.draw do
   get 'sites/orphans' => 'sites#orphans'
 
   # shallow path to sites
-  get '/sites' => 'sites#index', defaults: { format: 'json' }, as: 'shallow_site_index'
-  get '/sites/:id' => 'sites#show_shallow', defaults: { format: 'json' }, as: 'shallow_site'
+
+  resources :sites, except: [:edit], defaults: { format: 'json' }, as: 'shallow_site'
 
   match 'datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds' =>
     'progress_events#create_by_dataset_item_params',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,16 @@ services:
     <<: *worker
     environment:
       RAILS_ENV: test
+  # upload:
+  #   image: caddy:2-alpine
+  #   volumes:
+  #     - type: volume
+  #       source: caddy_data
+  #       target: /data
+      # - type: bind
+      #   source: caddy_data
+      #   target: /data
+
   web:
     #image: qutecoacoustics/baw-server:dev
     build:
@@ -96,3 +106,5 @@ volumes:
   # out hosts for dev work.
   baw_docker_shared_storage:
   postgres-data:
+  caddy_data:
+

--- a/spec/acceptance/analysis_jobs_spec.rb
+++ b/spec/acceptance/analysis_jobs_spec.rb
@@ -44,198 +44,6 @@ resource 'AnalysisJobs' do
       .to_json
   }
 
-  ################################
-  # INDEX
-  ################################
-
-  get '/analysis_jobs' do
-    let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'INDEX (as admin)', :ok, { expected_json_path: 'data/0/saved_search_id', data_item_count: 1 })
-  end
-
-  get '/analysis_jobs' do
-    let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'INDEX (as owner)', :ok, { expected_json_path: 'data/0/saved_search_id', data_item_count: 1 })
-  end
-
-  get '/analysis_jobs' do
-    let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'INDEX (as writer)', :ok, { expected_json_path: 'data/0/saved_search_id', data_item_count: 1 })
-  end
-
-  get '/analysis_jobs' do
-    let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'INDEX (as reader)', :ok, { expected_json_path: 'data/0/saved_search_id', data_item_count: 1 })
-  end
-
-  get '/analysis_jobs' do
-    let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'INDEX (as no access user)', :ok, { response_body_content: ['"total":0,', '"data":[]'] })
-  end
-
-  get '/analysis_jobs' do
-    let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'INDEX (invalid token)', :unauthorized, { expected_json_path: get_json_error_path(:sign_in) })
-  end
-
-  get '/analysis_jobs' do
-    standard_request_options(:get, 'INDEX (as anonymous user)', :ok, { remove_auth: true, response_body_content: ['"total":0,', '"data":[]'] })
-  end
-
-  ################################
-  # SHOW
-  ################################
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'SHOW (as admin)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'SHOW (as owner)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'SHOW (as writer)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'SHOW (as reader)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'SHOW (as no access)', :forbidden, { expected_json_path: get_json_error_path(:permissions) })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'SHOW (invalid token)', :unauthorized, { expected_json_path: get_json_error_path(:sign_in) })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { 'system' }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'SHOW system (as admin)', :not_implemented, {
-                               response_body_content: '"error":{"details":"The service is not ready for use"'
-                             })
-  end
-
-  get '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    standard_request_options(:get, 'SHOW (as anonymous user)', :unauthorized, {
-                               remove_auth: true,
-                               expected_json_path: get_json_error_path(:sign_in)
-                             })
-  end
-
-  ################################
-  # NEW
-  ################################
-
-  get '/analysis_jobs/new' do
-    let(:authentication_token) { admin_token }
-    standard_request_options(:get, 'NEW (as admin)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/new' do
-    let(:authentication_token) { owner_token }
-    standard_request_options(:get, 'NEW (as owner)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/new' do
-    let(:authentication_token) { writer_token }
-    standard_request_options(:get, 'NEW (as writer)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/new' do
-    let(:authentication_token) { reader_token }
-    standard_request_options(:get, 'NEW (as reader)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/new' do
-    let(:authentication_token) { no_access_token }
-    standard_request_options(:get, 'NEW (as no access)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  get '/analysis_jobs/new' do
-    let(:authentication_token) { invalid_token }
-    standard_request_options(:get, 'NEW (invalid token)', :unauthorized, { expected_json_path: get_json_error_path(:sign_up) })
-  end
-
-  get '/analysis_jobs/new' do
-    standard_request_options(:get, 'NEW (as anonymous user)', :unauthorized, { remove_auth: true, expected_json_path: get_json_error_path(:sign_up) })
-  end
-
-  ################################
-  # CREATE
-  ################################
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:post, 'CREATE (as admin)', :created, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { owner_token }
-    standard_request_options(:post, 'CREATE (as owner)', :created, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { writer_token }
-    standard_request_options(:post, 'CREATE (as writer)', :created, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { reader_token }
-    standard_request_options(:post, 'CREATE (as reader)', :created, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { no_access_token }
-    standard_request_options(:post, 'CREATE (as other)', :forbidden, { expected_json_path: get_json_error_path(:permissions) })
-  end
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { invalid_token }
-    standard_request_options(:post, 'CREATE (invalid token)', :unauthorized, { expected_json_path: get_json_error_path(:sign_up) })
-  end
-
-  post '/analysis_jobs' do
-    body_params
-    let(:raw_post) { body_attributes }
-    standard_request_options(:post, 'CREATE (as anonymous user)', :unauthorized, { remove_auth: true, expected_json_path: get_json_error_path(:sign_up) })
-  end
-
   post '/analysis_jobs' do
     let(:authentication_token) { writer_token }
     let(:raw_post) {
@@ -266,85 +74,6 @@ resource 'AnalysisJobs' do
       saved_search
     }
     standard_request_options(:post, 'CREATE (as writer, testing projects error)', :created, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  ################################
-  # UPDATE
-  ################################
-
-  put '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes_update }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:put, 'UPDATE (as admin)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  patch '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes_update }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:patch, 'UPDATE (as admin)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  put '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes_update }
-    let(:authentication_token) { writer_token }
-    standard_request_options(:put, 'UPDATE (as writer)', :ok, { expected_json_path: 'data/saved_search_id' })
-  end
-
-  put '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { reader_token }
-    standard_request_options(:put, 'UPDATE (as reader)', :forbidden, { expected_json_path: get_json_error_path(:permissions) })
-  end
-
-  put '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { no_access_token }
-    standard_request_options(:put, 'UPDATE (as no access)', :forbidden, { expected_json_path: get_json_error_path(:permissions) })
-  end
-
-  put '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { invalid_token }
-    standard_request_options(:put, 'UPDATE (invalid token)', :unauthorized, { expected_json_path: get_json_error_path(:sign_up) })
-  end
-
-  put '/analysis_jobs/:id' do
-    id_params
-    let(:id) { 'system' }
-    let(:raw_post) { body_attributes }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:put, 'UPDATE system (as admin)', :method_not_allowed, {
-                               response_body_content: '"info":{"available_methods":["GET","HEAD","OPTIONS"]}}}'
-                             })
-  end
-
-  put '/analysis_jobs/:id' do
-    id_params
-    body_params
-    let(:id) { analysis_job.id }
-    let(:raw_post) { body_attributes }
-    standard_request_options(:put, 'UPDATE (as anonymous user)', :unauthorized, {
-                               remove_auth: true,
-                               expected_json_path: get_json_error_path(:sign_up)
-                             })
   end
 
   describe 'update special case - retrying the job' do
@@ -456,99 +185,6 @@ resource 'AnalysisJobs' do
   end
 
   ################################
-  # DESTROY
-  ################################
-
-  def mock_processing_state(_opts)
-    analysis_job.update_columns(
-      overall_status: 'processing',
-      overall_status_modified_at: Time.zone.now,
-      started_at: Time.zone.now
-    )
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { admin_token }
-    standard_request_options(
-      :delete,
-      'DESTROY (as admin)',
-      :no_content,
-      {
-        expected_response_has_content: false,
-        expected_response_content_type: nil
-      },
-      &:mock_processing_state
-    )
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { writer_token }
-    standard_request_options(
-      :delete,
-      'DESTROY (as writer, when [:processing|:suspended|:complete])',
-      :no_content,
-      {
-        expected_response_has_content: false,
-        expected_response_content_type: nil
-      },
-      &:mock_processing_state
-    )
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { writer_token }
-    standard_request_options(:delete, 'DESTROY (as writer, when [:new|:preparing])', :conflict, {
-                               expected_json_path: 'meta/error/details',
-                               response_body_content: '"message":"Conflict"'
-                             })
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { reader_token }
-    standard_request_options(:delete, 'DESTROY (as reader)', :forbidden, { expected_json_path: get_json_error_path(:permissions) })
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { no_access_token }
-    standard_request_options(:delete, 'DESTROY (as no access user)', :forbidden, { expected_json_path: get_json_error_path(:permissions) })
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    let(:authentication_token) { invalid_token }
-    standard_request_options(:delete, 'DESTROY (invalid token)', :unauthorized, { expected_json_path: get_json_error_path(:sign_up) })
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { 'system' }
-    let(:authentication_token) { admin_token }
-    standard_request_options(:delete, 'DESTROY system (as admin)', :method_not_allowed, {
-                               response_body_content: '"info":{"available_methods":["GET","HEAD","OPTIONS"]}}}'
-                             })
-  end
-
-  delete '/analysis_jobs/:id' do
-    id_params
-    let(:id) { analysis_job.id }
-    standard_request_options(:delete, 'DESTROY (as anonymous user)', :unauthorized, {
-                               remove_auth: true,
-                               expected_json_path: get_json_error_path(:sign_up)
-                             })
-  end
-
-  ################################
   # FILTER
   ################################
 
@@ -567,11 +203,11 @@ resource 'AnalysisJobs' do
       }.to_json
     }
     standard_request_options(:post, 'FILTER (as reader)', :ok, {
-                               expected_json_path: 'meta/filter/saved_searches.stored_query',
-                               data_item_count: 1,
-                               response_body_content: ['"saved_searches.stored_query":{"contains":"blah"}'],
-                               invalid_content: ['"saved_search":', '"script":']
-                             })
+      expected_json_path: 'meta/filter/saved_searches.stored_query',
+      data_item_count: 1,
+      response_body_content: ['"saved_searches.stored_query":{"contains":"blah"}'],
+      invalid_content: ['"saved_search":', '"script":']
+    })
   end
 
   post '/analysis_jobs/filter' do
@@ -586,11 +222,11 @@ resource 'AnalysisJobs' do
       }.to_json
     }
     standard_request_options(:post, 'FILTER (as no access user)', :ok, {
-                               response_body_content: [
-                                 '{"meta":{"status":200,"message":"OK","filter":{"name":{"contains":"name"}},',
-                                 '"paging":{"page":1,"items":25,"total":0,"max_page":0,'
-                               ],
-                               data_item_count: 0
-                             })
+      response_body_content: [
+        '{"meta":{"status":200,"message":"OK","filter":{"name":{"contains":"name"}},',
+        '"paging":{"page":1,"items":25,"total":0,"max_page":0,'
+      ],
+      data_item_count: 0
+    })
   end
 end

--- a/spec/acceptance/audio_recordings_spec.rb
+++ b/spec/acceptance/audio_recordings_spec.rb
@@ -301,7 +301,8 @@ def test_overlap
         do_request
 
         # ensure current state of audio recordings in db matches output
-        if status_code == 201
+        case status_code
+        when 201
           expect(status).to eq(201), "expected status 201 but was #{status}. Response body was #{response_body}"
           expect(response_body).to have_json_path('data/bit_rate_bps'), "could not find bit_rate_bps in #{response_body}"
 
@@ -315,7 +316,7 @@ def test_overlap
             expect(new_recording.notes).to include('duration_adjustment_for_overlap')
           end
 
-        elsif status_code == 422
+        when 422
           expect(status).to eq(422), "expected status 422 but was #{status}. Response body was #{response_body}"
           expect(response_body).to have_json_path('meta/error/info/overlap/count')
           expect(response_body).to have_json_path('meta/error/info/overlap/items/0/overlap_amount')
@@ -987,9 +988,9 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader matching)', :ok, {
-                               expected_json_path: 'data/0/sample_rate_hertz',
-                               data_item_count: 1
-                             })
+      expected_json_path: 'data/0/sample_rate_hertz',
+      data_item_count: 1
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1010,9 +1011,9 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader no match)', :ok, {
-                               expected_json_path: 'meta/message',
-                               data_item_count: 0
-                             })
+      expected_json_path: 'meta/message',
+      data_item_count: 0
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1036,10 +1037,10 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader with paging)', :ok, {
-                               expected_json_path: 'meta/paging/page',
-                               data_item_count: 0,
-                               response_body_content: '/audio_recordings/filter?direction=desc\u0026items=30\u0026order_by=recorded_date\u0026page=1'
-                             })
+      expected_json_path: 'meta/paging/page',
+      data_item_count: 0,
+      response_body_content: '/audio_recordings/filter?direction=desc\u0026items=30\u0026order_by=recorded_date\u0026page=1'
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1063,10 +1064,10 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader with sorting)', :ok, {
-                               expected_json_path: 'meta/sorting/direction',
-                               data_item_count: 1,
-                               response_body_content: '/audio_recordings/filter?direction=asc\u0026items=25\u0026order_by=channels\u0026page=1'
-                             })
+      expected_json_path: 'meta/sorting/direction',
+      data_item_count: 1,
+      response_body_content: '/audio_recordings/filter?direction=asc\u0026items=25\u0026order_by=channels\u0026page=1'
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1089,10 +1090,10 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader with projection)', :ok, {
-                               expected_json_path: 'meta/projection/include',
-                               data_item_count: 1,
-                               response_body_content: '/audio_recordings/filter?direction=desc\u0026items=25\u0026order_by=recorded_date\u0026page=1'
-                             })
+      expected_json_path: 'meta/projection/include',
+      data_item_count: 1,
+      response_body_content: '/audio_recordings/filter?direction=desc\u0026items=25\u0026order_by=recorded_date\u0026page=1'
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1108,11 +1109,11 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader checking camel case)', :ok, {
-                               expected_json_path: 'meta/projection/include',
-                               data_item_count: 1,
-                               invalid_data_content: (AudioRecording.filter_settings[:render_fields] - [:id, :site_id, :duration_seconds, :recorded_date, :created_at]).map { |i| "\"#{i}\":" },
-                               response_body_content: '/audio_recordings/filter?direction=desc\u0026items=10\u0026order_by=created_at\u0026page=1'
-                             })
+      expected_json_path: 'meta/projection/include',
+      data_item_count: 1,
+      invalid_data_content: (AudioRecording.filter_settings[:render_fields] - [:id, :site_id, :duration_seconds, :recorded_date, :created_at]).map { |i| "\"#{i}\":" },
+      response_body_content: '/audio_recordings/filter?direction=desc\u0026items=10\u0026order_by=created_at\u0026page=1'
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1143,9 +1144,9 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader filtering by project id)', :ok, {
-                               response_body_content: '"projection":{"include":["id","site_id","duration_seconds","recorded_date","created_at"]},"filter":{"and":{"projects.id":{"less_than":123456},"duration_seconds":{"not_eq":40}}},"sorting":{"order_by":"created_at","direction":"desc"},"paging":{"page":1,"items":20,"total":1,"max_page":1,"current":"http://localhost:3000/audio_recordings/filter?direction=desc\u0026items=20\u0026order_by=created_at\u0026page=1"',
-                               data_item_count: 1
-                             })
+      response_body_content: '"projection":{"include":["id","site_id","duration_seconds","recorded_date","created_at"]},"filter":{"and":{"projects.id":{"less_than":123456},"duration_seconds":{"not_eq":40}}},"sorting":{"order_by":"created_at","direction":"desc"},"paging":{"page":1,"items":20,"total":1,"max_page":1,"current":"http://localhost:3000/audio_recordings/filter?direction=desc\u0026items=20\u0026order_by=created_at\u0026page=1"',
+      data_item_count: 1
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1153,7 +1154,7 @@ resource 'AudioRecordings' do
       {
         filter: {
           and: {
-            'projects.image_file_name' => {
+            'projects.description' => {
               eq: 'test'
             },
             duration_seconds: {
@@ -1176,8 +1177,8 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader filtering by project image_file_name)', :bad_request, {
-                               response_body_content: 'Filter parameters were not valid: Name must be in [:id, :name, :description, :created_at, :creator_id], got image_file_name'
-                             })
+      response_body_content: 'Filter parameters were not valid: Name must be in [:id, :name, :description, :created_at, :creator_id], got image_file_name'
+    })
   end
 
   post '/audio_recordings/filter' do
@@ -1212,8 +1213,8 @@ resource 'AudioRecordings' do
 
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader filtering by recorded_end_date)', :ok, {
-                               response_body_content: "\"recorded_date\":\"#{Time.use_zone('Brisbane') { Time.zone.parse('2016-03-01 11:55:00') }.in_time_zone.iso8601(3).gsub(/\s+/, '')}\"",
-                               data_item_count: 1
-                             })
+      response_body_content: "\"recorded_date\":\"#{Time.use_zone('Brisbane') { Time.zone.parse('2016-03-01 11:55:00') }.in_time_zone.iso8601(3).gsub(/\s+/, '')}\"",
+      data_item_count: 1
+    })
   end
 end

--- a/spec/acceptance/audio_recordings_spec.rb
+++ b/spec/acceptance/audio_recordings_spec.rb
@@ -1154,7 +1154,7 @@ resource 'AudioRecordings' do
       {
         filter: {
           and: {
-            'projects.description' => {
+            'projects.image_file_name' => {
               eq: 'test'
             },
             duration_seconds: {
@@ -1177,7 +1177,7 @@ resource 'AudioRecordings' do
     }
     let(:authentication_token) { reader_token }
     standard_request_options(:post, 'FILTER (as reader filtering by project image_file_name)', :bad_request, {
-      response_body_content: 'Filter parameters were not valid: Name must be in [:id, :name, :description, :created_at, :creator_id], got image_file_name'
+      response_body_content: 'Filter parameters were not valid: Name must be in [:id, :name, :description, :creator_id, :created_at, :updater_id, :updated_at, :deleter_id, :deleted_at], got image_file_name'
     })
   end
 

--- a/spec/api/analysis_job_spec.rb
+++ b/spec/api/analysis_job_spec.rb
@@ -1,0 +1,101 @@
+require 'swagger_helper'
+
+describe 'analysis jobs', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model AnalysisJob
+  which_has_schema ref(:analysis_job)
+
+  path '/analysis_jobs/filter' do
+    post('filter analysis_job') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/analysis_jobs' do
+    get('list analysis_jobs') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create analysis_job') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/analysis_jobs/new' do
+    get('new analysis_job') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/analysis_jobs/{id}' do
+    with_id_route_parameter
+    let(:id) { analysis_job.id }
+
+    before do
+      # can only delete an analysis job if it is suspended or completed
+      analysis_job.update_column(:overall_status, :completed)
+    end
+
+    get('show analysis_job') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(analysis_job)
+        end
+      end
+    end
+
+    patch('update analysis_job') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        # only a subset of the writable properties can be updated
+        auto_send_model subset: [:name, :description]
+        run_test! do
+          expect_id_matches(analysis_job)
+        end
+      end
+    end
+
+    put('update analysis_job') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        # only a subset of the writable properties can be updated
+        auto_send_model subset: [:name, :description]
+        run_test! do
+          expect_id_matches(analysis_job)
+        end
+      end
+    end
+
+    delete('delete analysis_job') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end

--- a/spec/api/bookmarks_spec.rb
+++ b/spec/api/bookmarks_spec.rb
@@ -1,0 +1,99 @@
+require 'swagger_helper'
+
+describe 'bookmarks', type: :request do
+  create_entire_hierarchy
+
+  # bookmarks are ties to user that made them
+  let(:bookmark) {
+    FactoryBot.create(:bookmark, creator: admin_user, audio_recording: audio_recording)
+  }
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Bookmark
+  which_has_schema ref(:bookmark)
+
+  path '/bookmarks/filter' do
+    post('filter bookmark') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/bookmarks' do
+    get('list bookmarks') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create bookmark') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/bookmarks/new' do
+    get('new bookmark') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/bookmarks/{id}' do
+    with_id_route_parameter
+    let(:id) { bookmark.id }
+
+    get('show bookmark') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(bookmark)
+        end
+      end
+    end
+
+    patch('update bookmark') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(bookmark)
+        end
+      end
+    end
+
+    put('update bookmark') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(bookmark)
+        end
+      end
+    end
+
+    delete('delete bookmark') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end

--- a/spec/api/dataset_spec.rb
+++ b/spec/api/dataset_spec.rb
@@ -1,0 +1,94 @@
+require 'swagger_helper'
+
+describe 'datasets', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Dataset
+  which_has_schema ref(:dataset)
+
+  path '/datasets/filter' do
+    post('filter dataset') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/datasets' do
+    get('list datasets') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create dataset') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/datasets/new' do
+    get('new dataset') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/datasets/{id}' do
+    with_id_route_parameter
+    let(:id) { dataset.id }
+
+    get('show dataset') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(dataset)
+        end
+      end
+    end
+
+    patch('update dataset') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(dataset)
+        end
+      end
+    end
+
+    put('update dataset') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(dataset)
+        end
+      end
+    end
+
+    delete('can\'t delete a dataset') do
+      response(404, 'not found') do
+        schema nil
+        run_test! do
+          expect_error(404, 'Could not find the requested page.')
+        end
+      end
+    end
+  end
+end

--- a/spec/api/saved_search_spec.rb
+++ b/spec/api/saved_search_spec.rb
@@ -1,0 +1,94 @@
+require 'swagger_helper'
+
+describe 'saved_searches', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model SavedSearch
+  which_has_schema ref(:saved_search)
+
+  path '/saved_searches/filter' do
+    post('filter saved_search') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/saved_searches' do
+    get('list saved_searches') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create saved_search') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/saved_searches/new' do
+    get('new saved_search') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/saved_searches/{id}' do
+    with_id_route_parameter
+    let(:id) { saved_search.id }
+
+    get('show saved_search') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(saved_search)
+        end
+      end
+    end
+
+    patch('can\'t update saved_search') do
+      model_sent_as_parameter_in_body
+      response(404, 'not found') do
+        schema nil
+        auto_send_model
+        run_test! do
+          expect_error(404, 'Could not find the requested page.')
+        end
+      end
+    end
+
+    put('can\'t update saved_search') do
+      model_sent_as_parameter_in_body
+      response(404, 'not found') do
+        schema nil
+        auto_send_model
+        run_test! do
+          expect_error(404, 'Could not find the requested page.')
+        end
+      end
+    end
+
+    delete('delete saved_search') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end

--- a/spec/api/script_spec.rb
+++ b/spec/api/script_spec.rb
@@ -1,0 +1,96 @@
+require 'swagger_helper'
+
+describe 'scripts', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Script
+  which_has_schema ref(:script)
+
+  path '/scripts/filter' do
+    post('filter script') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/scripts' do
+    get('list scripts') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    # NOT IMPLEMENTED YET IN CONTROLLER
+    #   post('create script') do
+    #     model_sent_as_parameter_in_body
+    #     response(201, 'successful') do
+    #       schema_for_single
+    #       auto_send_model
+    #       run_test!
+    #     end
+    #   end
+    # end
+
+    # path '/scripts/new' do
+    #   get('new script') do
+    #     response(200, 'successful') do
+    #       run_test!
+    #     end
+    #   end
+    # end
+
+    path '/scripts/{id}' do
+      with_id_route_parameter
+      let(:id) { script.id }
+
+      get('show script') do
+        response(200, 'successful') do
+          schema_for_single
+          run_test! do
+            expect_id_matches(script)
+          end
+        end
+      end
+
+      # NOT YET IMPLEMENTED IN CONTROLLER
+      # patch('update script') do
+      #   model_sent_as_parameter_in_body
+      #   response(200, 'successful') do
+      #     schema_for_single
+      #     auto_send_model
+      #     run_test! do
+      #       expect_id_matches(script)
+      #     end
+      #   end
+      # end
+
+      # put('update script') do
+      #   model_sent_as_parameter_in_body
+      #   response(200, 'successful') do
+      #     schema_for_single
+      #     auto_send_model
+      #     run_test! do
+      #       expect_id_matches(script)
+      #     end
+      #   end
+      # end
+
+      # delete('delete script') do
+      #   response(204, 'successful') do
+      #     schema nil
+      #     run_test! do
+      #       expect_empty_body
+      #     end
+      #   end
+    end
+  end
+end

--- a/spec/api/site_spec.rb
+++ b/spec/api/site_spec.rb
@@ -1,0 +1,94 @@
+require 'swagger_helper'
+
+describe 'sites', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Site
+  which_has_schema ref(:site)
+
+  path '/sites/filter' do
+    post('filter site') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/sites' do
+    get('list sites') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create site') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/sites/new' do
+    get('new site') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/sites/{id}' do
+    with_id_route_parameter
+    let(:id) { site.id }
+
+    get('show site') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(site)
+        end
+      end
+    end
+
+    patch('update site') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(site)
+        end
+      end
+    end
+
+    put('update site') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(site)
+        end
+      end
+    end
+
+    delete('delete site') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end

--- a/spec/api/site_spec.rb
+++ b/spec/api/site_spec.rb
@@ -92,3 +92,135 @@ describe 'sites', type: :request do
     end
   end
 end
+
+describe 'sites (nested)', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Site
+  which_has_schema ref(:site)
+
+  let(:project_id) { project.id }
+  with_route_parameter(:project_id)
+
+  path '/projects/{project_id}/sites/filter' do
+    post('filter site') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/projects/{project_id}/sites' do
+    get('list sites') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create site') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/projects/{project_id}/sites/new' do
+    get('new site') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/projects/{project_id}/sites/{id}' do
+    with_route_parameter(:project_id)
+    with_id_route_parameter
+    let(:id) { site.id }
+
+    get('show site') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(site)
+        end
+      end
+    end
+
+    patch('update site') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(site)
+        end
+      end
+    end
+
+    put('update site') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(site)
+        end
+      end
+    end
+
+    delete('delete site') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end
+
+describe 'sites (orphans)', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Site
+  which_has_schema ref(:site)
+
+  let!(:orphaned_site) {
+    create(:site, projects: [], project_ids: [])
+  }
+
+  path '/sites/orphans/filter' do
+    post('filter site') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_has_ids(orphaned_site.id)
+        end
+      end
+    end
+  end
+
+  path '/sites/orphans' do
+    get('list sites') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_has_ids(orphaned_site.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/analysis_job_factory.rb
+++ b/spec/factories/analysis_job_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :analysis_job do
     sequence(:name) { |n| "job name #{n}" }
     sequence(:custom_settings) { |n| "custom settings #{n}" }
+    sequence(:description) { |n| "job description #{n}" }
 
     creator
     saved_search
@@ -19,5 +20,9 @@ FactoryBot.define do
     # should be set by the workflow
     #overall_status_modified_at { Time.zone.now }
     overall_progress_modified_at { Time.zone.now }
+
+    factory :analysis_job_with_valid_saved_search do
+      association :saved_search, factory: :saved_search_with_projects
+    end
   end
 end

--- a/spec/factories/saved_search_factory.rb
+++ b/spec/factories/saved_search_factory.rb
@@ -22,5 +22,11 @@ FactoryBot.define do
     end
 
     factory :saved_search_with_analysis_jobs, traits: [:with_analysis_jobs]
+
+    factory :saved_search_with_projects do
+      after(:create) do |saved_search, _evaluator|
+        saved_search.projects << Project.all
+      end
+    end
   end
 end

--- a/spec/helpers/api_spec_helpers.rb
+++ b/spec/helpers/api_spec_helpers.rb
@@ -158,6 +158,17 @@ module ApiSpecDescribeHelpers
     }
   end
 
+  def with_route_parameter(name, description = name)
+    self.baw_route_params ||= []
+    self.baw_route_params << {
+      name: name.to_s,
+      in: :path,
+      type: :integer,
+      description: description.to_s,
+      required: true
+    }
+  end
+
   def model_sent_as_parameter_in_body
     self.baw_body_params ||= []
     self.baw_body_params << {

--- a/spec/helpers/request_spec_helpers.rb
+++ b/spec/helpers/request_spec_helpers.rb
@@ -115,6 +115,8 @@ module RequestSpecExampleHelpers
         case status
         when 400
           'Bad Request'
+        when 404
+          'Not Found'
         else
           raise "Message not yet implemented for status #{status}"
         end

--- a/spec/lib/modules/custom_render_spec.rb
+++ b/spec/lib/modules/custom_render_spec.rb
@@ -8,11 +8,11 @@ describe 'rendering markdown' do
       # Testy **test**!
 
       This is a test that tests tests!
-      
+
       - a list
       - really
       - so many items
-      
+
       ~~~
         some code
       ~~~
@@ -21,8 +21,8 @@ describe 'rendering markdown' do
       |-------|-------------------|
       | WAVE  | .wav              |
       | WAC   | .wac              |
-             
-      
+
+
       an image ![user](/images/user/user_spanhalf.png)
     MARKDOWN
   }
@@ -38,7 +38,7 @@ describe 'rendering markdown' do
   end
 
   it 'converts markdown via a attr access helper method' do
-    html = CustomRender.render_model_markdown({ description: markdown_fixture }, :description)
+    html = CustomRender.render_model_markdown(markdown_fixture, inline: false)
 
     expect(html).to match '<h1>Testy <strong>test</strong>!</h1>'
     expect(html).to match(%r{<li>a list</li>})
@@ -48,7 +48,7 @@ describe 'rendering markdown' do
   end
 
   it 'converts markdown via a attr access helper method and can strip block tags' do
-    html = CustomRender.render_model_markdown({ description: markdown_fixture }, :description, true)
+    html = CustomRender.render_model_markdown(markdown_fixture, inline: true)
 
     expect(html).to_not match '<h1>Testy <strong>test</strong>!</h1>'
     expect(html).to match 'Testy <strong>test</strong>!'
@@ -60,5 +60,18 @@ describe 'rendering markdown' do
     expect(html).to match(/WAVE\s*.wav/)
     expect(html).to_not match(%r{<img src="/images/user/user_spanhalf\.png"})
     expect(html).to match 'an image'
+  end
+
+  context 'values are sanitized' do
+    it 'removes script tags' do
+      malicious = '<script src="https://www.whatever.org />'
+      html = CustomRender.render_model_markdown(malicious, inline: false)
+      expect(html).to be_empty
+    end
+    it 'removes script blocks' do
+      malicious = '<script>console.log("i iz l33t hackz0rs")</script>'
+      html = CustomRender.render_model_markdown(malicious, inline: false)
+      expect(html).to be_empty
+    end
   end
 end

--- a/spec/lib/modules/custom_render_spec.rb
+++ b/spec/lib/modules/custom_render_spec.rb
@@ -30,24 +30,24 @@ describe 'rendering markdown' do
   it 'converts markdown documents correctly' do
     html = CustomRender.render_markdown(markdown_fixture)
 
-    expect(html).to match '<h1>Testy <strong>test</strong>!</h1>'
+    expect(html).to match '<h1 id="testy-test">Testy <strong>test</strong>!</h1>'
     expect(html).to match(%r{<li>a list</li>})
     expect(html).to match(%r{<pre><code>.*some code\n</code></pre>})
     expect(html).to match(%r{<table>[\S\s]*<td>WAVE</td>[\S\s]*</table>})
     expect(html).to match(%r{<img src="/images/user/user_spanhalf\.png"})
   end
 
-  it 'converts markdown via a attr access helper method' do
+  it 'converts markdown (inline: false)' do
     html = CustomRender.render_markdown(markdown_fixture, inline: false)
 
-    expect(html).to match '<h1>Testy <strong>test</strong>!</h1>'
+    expect(html).to match '<h1 id="testy-test">Testy <strong>test</strong>!</h1>'
     expect(html).to match(%r{<li>a list</li>})
     expect(html).to match(%r{<pre><code>.*some code\n</code></pre>})
     expect(html).to match(%r{<table>[\S\s]*<td>WAVE</td>[\S\s]*</table>})
     expect(html).to match(%r{<img src="/images/user/user_spanhalf\.png"})
   end
 
-  it 'converts markdown via a attr access helper method and can strip block tags' do
+  it 'converts markdown (inline: true), strips block tags' do
     html = CustomRender.render_markdown(markdown_fixture, inline: true)
 
     expect(html).to_not match '<h1>Testy <strong>test</strong>!</h1>'
@@ -64,13 +64,26 @@ describe 'rendering markdown' do
 
   context 'values are sanitized' do
     it 'removes script tags' do
-      malicious = '<script src="https://www.whatever.org />'
-      html = CustomRender.render_model_markdown(malicious, inline: false)
-      expect(html).to be_empty
+      malicious = '<script src="https://www.whatever.org" />'
+      html = CustomRender.render_markdown(malicious, inline: false)
+      expect(html).to be_blank
     end
+
     it 'removes script blocks' do
       malicious = '<script>console.log("i iz l33t hackz0rs")</script>'
-      html = CustomRender.render_model_markdown(malicious, inline: false)
+      html = CustomRender.render_markdown(malicious, inline: false)
+      expect(html).to be_blank
+    end
+
+    it 'removes script tags (inline)' do
+      malicious = '<script src="https://www.whatever.org" />'
+      html = CustomRender.render_markdown(malicious, inline: true)
+      expect(html).to be_empty
+    end
+
+    it 'removes script blocks (inline)' do
+      malicious = '<script>console.log("i iz l33t hackz0rs")</script>'
+      html = CustomRender.render_markdown(malicious, inline: true)
       expect(html).to be_empty
     end
   end

--- a/spec/lib/modules/custom_render_spec.rb
+++ b/spec/lib/modules/custom_render_spec.rb
@@ -38,7 +38,7 @@ describe 'rendering markdown' do
   end
 
   it 'converts markdown via a attr access helper method' do
-    html = CustomRender.render_model_markdown(markdown_fixture, inline: false)
+    html = CustomRender.render_markdown(markdown_fixture, inline: false)
 
     expect(html).to match '<h1>Testy <strong>test</strong>!</h1>'
     expect(html).to match(%r{<li>a list</li>})
@@ -48,7 +48,7 @@ describe 'rendering markdown' do
   end
 
   it 'converts markdown via a attr access helper method and can strip block tags' do
-    html = CustomRender.render_model_markdown(markdown_fixture, inline: true)
+    html = CustomRender.render_markdown(markdown_fixture, inline: true)
 
     expect(html).to_not match '<h1>Testy <strong>test</strong>!</h1>'
     expect(html).to match 'Testy <strong>test</strong>!'

--- a/spec/lib/modules/filter/query_spec.rb
+++ b/spec/lib/modules/filter/query_spec.rb
@@ -20,7 +20,7 @@ describe Filter::Query do
   def create_filter(params)
     Filter::Query.new(
       params,
-      nil,
+      AudioRecording.all,
       AudioRecording,
       AudioRecording.filter_settings
     )

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -28,7 +28,7 @@ describe Project, type: :model do
 
   it 'generates html for description' do
     md = "# Header\r\n [a link](https://github.com)."
-    html = "<h1>Header</h1>\n<p><a href=\"https://github.com\">a link</a>.</p>\n"
+    html = "<h1 id=\"header\">Header</h1>\n<p><a href=\"https://github.com\">a link</a>.</p>\n"
     project_html = FactoryBot.create(:project, description: md)
 
     expect(project_html.description).to eq(md)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -108,11 +108,11 @@ describe Site, type: :model do
 
   it 'generates html for description' do
     md = "# Header\r\n [a link](https://github.com)."
-    html = "<h1>Header</h1>\n<p><a href=\"https://github.com\">a link</a>.</p>\n"
-    project_html = FactoryBot.create(:site, description: md)
+    html = "<h1 id=\"header\">Header</h1>\n<p><a href=\"https://github.com\">a link</a>.</p>\n"
+    site_html = FactoryBot.create(:site, description: md)
 
-    expect(project_html.description).to eq(md)
-    expect(project_html.description_html).to eq(html)
+    expect(site_html.description).to eq(md)
+    expect(site_html.description_html).to eq(html)
   end
 
   it 'should error on invalid timezone' do

--- a/spec/requests/permissions/analysis_jobs_spec.rb
+++ b/spec/requests/permissions/analysis_jobs_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'Analysis Job permissions' do
+  create_entire_hierarchy
+
+  before do
+    # can only delete an analysis job if it is suspended or completed
+    analysis_job.update_column(:overall_status, :completed)
+  end
+
+  given_the_route '/analysis_jobs' do
+    {
+      id: analysis_job.id
+    }
+  end
+  using_the_factory :analysis_job_with_valid_saved_search, model_name: :analysis_job
+  for_lists_expects do |user, _action|
+    case user
+    when :admin
+      AnalysisJob.all
+    when :owner, :reader, :writer
+      analysis_job
+    else
+      []
+    end
+  end
+  when_updating_send_only :name, :description
+
+  the_user :admin, can_do: everything
+
+  # Analysis jobs are tied to the user that created them.
+  # In this case the writer user made the job. They can do most things
+  the_users :writer, can_do: everything, and_cannot_do: nothing
+
+  # the reader and owner
+  # they can read/create any job as long as they have access to a project included in the job,
+  # but can't change ones they don't own
+  the_users :reader, :owner, can_do: (reading + creation), and_cannot_do: mutation
+
+  # No access doesn't have access to any audio, so can't create a job and
+  # can't read current job
+  the_user :no_access, can_do: listing, and_cannot_do: not_listing
+
+  the_user :harvester, can_do: nothing, and_cannot_do: everything
+
+  the_user :anonymous, can_do: listing, and_cannot_do: not_listing, fails_with: :unauthorized
+
+  the_user :invalid, can_do: nothing, and_cannot_do: everything, fails_with: :unauthorized
+end

--- a/spec/requests/sites_spec.rb
+++ b/spec/requests/sites_spec.rb
@@ -20,4 +20,59 @@ describe 'Sites' do
       }))
     end
   end
+
+  context 'project associations' do
+    example 'cannot create an orphan a site' do
+      body = {
+        site: {
+          name: 'testy test site'
+        }
+      }
+
+      post '/sites', params: body, headers: api_request_headers(owner_token, send_body: true), as: :json
+
+      expect_error(400, 'Site testy test site () is not in any projects.')
+    end
+
+    example 'can create an a site that belongs to multiple projects' do
+      second_project = create(:project)
+      body = {
+        site: {
+          name: 'testy test site',
+          project_ids: [project.id, second_project.id]
+        }
+      }
+
+      post '/sites', params: body, headers: api_request_headers(owner_token, send_body: true), as: :json
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(api_result).to include({
+          data: hash_including({
+            project_ids: [project.id, second_project.id]
+          })
+        })
+      end
+    end
+
+    example 'update a site so that it belongs to multiple projects' do
+      second_project = create(:project)
+      body = {
+        site: {
+          project_ids: [project.id, second_project.id]
+        }
+      }
+
+      patch "/sites/#{site.id}", params: body, headers: api_request_headers(owner_token, send_body: true), as: :json
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(api_result).to include({
+          data: hash_including({
+            project_ids: [project.id, second_project.id]
+          })
+        })
+      end
+    end
+  end
 end

--- a/spec/routing/sites_routing_spec.rb
+++ b/spec/routing/sites_routing_spec.rb
@@ -17,10 +17,18 @@ describe SitesController, type: :routing do
 
     # used by client
     it { expect(get('projects/1/sites')).to route_to('sites#index', project_id: '1', format: 'json') }
-    it { expect(get('sites/1')).to route_to('sites#show_shallow', id: '1', format: 'json') }
     it { expect(get('projects/1/sites/1')).to route_to('sites#show', id: '1', project_id: '1') }
 
     it { expect(get('sites/filter')).to route_to('sites#filter', format: 'json') }
+    it { expect(post('sites/filter')).to route_to('sites#filter', format: 'json') }
+
+    # shallow
+    it { expect(get('sites')).to route_to('sites#index', format: 'json') }
+    it { expect(post('sites')).to route_to('sites#create', format: 'json') }
+    it { expect(get('sites/new')).to route_to('sites#new', format: 'json') }
+    it { expect(put('sites/1')).to route_to('sites#update', format: 'json', id: '1') }
+    it { expect(patch('sites/1')).to route_to('sites#update', format: 'json', id: '1') }
+    it { expect(delete('sites/1')).to route_to('sites#destroy', format: 'json', id: '1') }
     it { expect(post('sites/filter')).to route_to('sites#filter', format: 'json') }
   end
 end

--- a/spec/routing/sites_routing_spec.rb
+++ b/spec/routing/sites_routing_spec.rb
@@ -19,9 +19,6 @@ describe SitesController, type: :routing do
     it { expect(get('projects/1/sites')).to route_to('sites#index', project_id: '1', format: 'json') }
     it { expect(get('projects/1/sites/1')).to route_to('sites#show', id: '1', project_id: '1') }
 
-    it { expect(get('sites/filter')).to route_to('sites#filter', format: 'json') }
-    it { expect(post('sites/filter')).to route_to('sites#filter', format: 'json') }
-
     # shallow
     it { expect(get('sites')).to route_to('sites#index', format: 'json') }
     it { expect(post('sites')).to route_to('sites#create', format: 'json') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,19 +86,23 @@ RSpec.configure do |config|
   #config.include FactoryBot::Syntax::Methods
 
   # redirect puts into a text file
-  original_stderr = $stderr
-  original_stdout = $stdout
+  if defined?(Debugger)
+    puts '$stdout and $stderr will NOT be redirected'
+  else
+    original_stderr = $stderr
+    original_stdout = $stdout
 
-  config.before(:suite) do
-    # Redirect stderr and stdout
-    puts '$stdout and $stderr redirected to log files in ./logs/rspec_*.txt'
-    $stderr = File.new(File.join(File.dirname(__FILE__), '..', 'log', 'rspec_stderr.test.log'), 'w')
-    $stdout = File.new(File.join(File.dirname(__FILE__), '..', 'log', 'rspec_stdout.test.log'), 'w')
-  end
+    config.before(:suite) do
+      # Redirect stderr and stdout
+      puts '$stdout and $stderr redirected to log files in ./logs/rspec_*.txt'
+      $stderr = File.new(File.join(File.dirname(__FILE__), '..', 'log', 'rspec_stderr.test.log'), 'w')
+      $stdout = File.new(File.join(File.dirname(__FILE__), '..', 'log', 'rspec_stdout.test.log'), 'w')
+    end
 
-  config.after(:suite) do
-    $stderr = original_stderr
-    $stdout = original_stdout
+    config.after(:suite) do
+      $stderr = original_stderr
+      $stdout = original_stdout
+    end
   end
 
   # These two settings work together to allow you to limit a spec run

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -101,6 +101,10 @@ RSpec.configure do |config|
               }
             }
           },
+          permission_levels: {
+            type: 'string',
+            enum: ['Owner', 'Writer', 'Reader', nil]
+          },
           meta: {
             type: 'object'
           },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -55,9 +55,54 @@ RSpec.configure do |config|
           }
         },
         schemas: {
+          id: {
+            type: 'integer',
+            minimum: 0,
+            readOnly: true
+          },
+          nullableId: {
+            anyOf: [
+              {
+                type: 'integer',
+                minimum: 0,
+                readOnly: true
+              },
+              {
+                type: 'null'
+              }
+            ]
+          },
+          timezone_information: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  identifier_alt: { type: ['string', 'null'] },
+                  identifier: { type: 'string' },
+                  friendly_identifier: { type: 'string' },
+                  utc_offset: { type: 'string' },
+                  utc_total_offset: { type: 'integer' }
+                }
+              },
+              {
+                type: 'null'
+              }
+            ]
+          },
+          image_urls: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                size: { type: 'string' },
+                url: { type: 'string', format: 'URI' },
+                width: { type: 'integer' },
+                height: { type: 'integer' }
+              }
+            }
+          },
           meta: {
             type: 'object'
-
           },
           meta_error: {
             type: 'object',
@@ -98,7 +143,13 @@ RSpec.configure do |config|
             },
             required: ['meta', 'data']
           },
-          project: Project.schema
+          project: Project.schema,
+          analysis_job: AnalysisJob.schema,
+          bookmark: Bookmark.schema,
+          dataset: Dataset.schema,
+          saved_search: SavedSearch.schema,
+          script: Script.schema,
+          site: Site.schema
         }
       }
     }

--- a/spec/unit/modules/renders_markdown_spec.rb
+++ b/spec/unit/modules/renders_markdown_spec.rb
@@ -14,11 +14,11 @@ describe RendersMarkdown do
   end
 
   subject do
-    class TempModel < ApplicationRecord
+    class TempModelMarkdownTest < ApplicationRecord
       renders_markdown_for :some_long_text
     end
 
-    return TempModel.new
+    return TempModelMarkdownTest.new
   end
 
   describe 'dynamic attribute' do

--- a/spec/unit/modules/renders_markdown_spec.rb
+++ b/spec/unit/modules/renders_markdown_spec.rb
@@ -38,7 +38,7 @@ describe RendersMarkdown do
   describe 'render methods' do
     example 'rendering markdown' do
       subject.some_long_text = '# **hello**'
-      expect(subject.render_markdown_for(:some_long_text)).to eq("<h1><strong>hello</strong></h1>\n")
+      expect(subject.render_markdown_for(:some_long_text)).to eq("<h1 id=\"hello\"><strong>hello</strong></h1>\n")
     end
 
     example 'rendering markdown tagline' do
@@ -76,7 +76,7 @@ describe RendersMarkdown do
     example 'rendering markdown for api' do
       subject.some_long_text = '# **hello**'
       expect(subject.render_markdown_for_api_for(:some_long_text)).to eq({
-        some_long_text_html: "<h1><strong>hello</strong></h1>\n",
+        some_long_text_html: "<h1 id=\"hello\"><strong>hello</strong></h1>\n",
         some_long_text_html_tagline: '<strong>hello</strong>'
       })
     end

--- a/spec/unit/modules/renders_markdown_spec.rb
+++ b/spec/unit/modules/renders_markdown_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe RendersMarkdown do
+  before(:all) do
+    ActiveRecord::Base.connection.drop_table :temp_models, if_exists: true
+    connection = ActiveRecord::Base.connection
+    connection.create_table :temp_models do |t|
+      t.column :some_long_text, :string
+    end
+  end
+
+  after(:all) do
+    ActiveRecord::Base.connection.drop_table :temp_models
+  end
+
+  subject do
+    class TempModel < ApplicationRecord
+      renders_markdown_for :some_long_text
+    end
+
+    return TempModel.new
+  end
+
+  describe 'dynamic attribute' do
+    it 'defines a dynamic attribute with the `renders_markdown_for` call' do
+      expect(subject).to respond_to(:some_long_text_html)
+    end
+
+    it 'is really just a proxy for the generic method' do
+      instance = subject
+
+      expect(instance).to receive(:render_markdown_for).once
+
+      instance.some_long_text_html
+    end
+  end
+
+  describe 'render methods' do
+    example 'rendering markdown' do
+      subject.some_long_text = '# **hello**'
+      expect(subject.render_markdown_for(:some_long_text)).to eq("<h1><strong>hello</strong></h1>\n")
+    end
+
+    example 'rendering markdown tagline' do
+      # 'seeds' is the 20th word - the default truncation point
+      # text also tests whether html tags are split during truncation
+      subject.some_long_text = <<~MARKDOWN
+        # **Hello darkness**, my old friend
+        I've come to talk with you again
+        Because a vision softly creeping
+        _Left its seeds while I was sleeping_
+        And the vision that was planted in my brain
+        Still remains
+        Within the sound of silence
+      MARKDOWN
+      expect(
+        subject.render_markdown_tagline_for(:some_long_text)
+      ).to eq('<strong>Hello darkness</strong>, my old friend I’ve come to talk with you again Because a vision softly creeping <em>Left its seeds...</em>')
+    end
+
+    example 'rendering markdown tagline (different word length)' do
+      subject.some_long_text = <<~MARKDOWN
+        # In restless dreams I walked _alone_
+        Narrow streets of cobblestone
+        ’Neath the halo of a street lamp
+        I turned my collar to the cold and damp
+        When my eyes were stabbed by the flash of a neon light
+        That split the night
+        And touched the sound of silence
+      MARKDOWN
+      expect(
+        subject.render_markdown_tagline_for(:some_long_text, words: 11)
+      ).to eq('In restless dreams I walked <em>alone</em> Narrow streets of cobblestone ’Neath...')
+    end
+
+    example 'rendering markdown for api' do
+      subject.some_long_text = '# **hello**'
+      expect(subject.render_markdown_for_api_for(:some_long_text)).to eq({
+        some_long_text_html: "<h1><strong>hello</strong></h1>\n",
+        some_long_text_html_tagline: '<strong>hello</strong>'
+      })
+    end
+  end
+end

--- a/spec/unit/modules/renders_markdown_spec.rb
+++ b/spec/unit/modules/renders_markdown_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 describe RendersMarkdown do
   before(:all) do
-    ActiveRecord::Base.connection.drop_table :temp_models, if_exists: true
+    ActiveRecord::Base.connection.drop_table :temp_model_markdown_tests, if_exists: true
     connection = ActiveRecord::Base.connection
-    connection.create_table :temp_models do |t|
+    connection.create_table :temp_model_markdown_tests do |t|
       t.column :some_long_text, :string
     end
   end
 
   after(:all) do
-    ActiveRecord::Base.connection.drop_table :temp_models
+    ActiveRecord::Base.connection.drop_table :temp_model_markdown_tests
   end
 
   subject do

--- a/spec/unit/modules/time_zone_attribute_spec.rb
+++ b/spec/unit/modules/time_zone_attribute_spec.rb
@@ -43,7 +43,7 @@ describe TimeZoneAttribute do
   end
 
   subject do
-    class TempModel < ApplicationRecord
+    class TempModelTimezoneTest < ApplicationRecord
       include TimeZoneAttribute
     end
   end

--- a/spec/unit/modules/time_zone_attribute_spec.rb
+++ b/spec/unit/modules/time_zone_attribute_spec.rb
@@ -30,16 +30,16 @@ describe TimeZoneAttribute do
   ].freeze
 
   before(:all) do
-    ActiveRecord::Base.connection.drop_table :temp_models, if_exists: true
+    ActiveRecord::Base.connection.drop_table :temp_model_timezone_tests, if_exists: true
     connection = ActiveRecord::Base.connection
-    connection.create_table :temp_models do |t|
+    connection.create_table :temp_model_timezone_tests do |t|
       t.column :tzinfo_tz, :string, null: true, limit: 255
       t.column :rails_tz, :string, null: true, limit: 255
     end
   end
 
   after(:all) do
-    ActiveRecord::Base.connection.drop_table :temp_models
+    ActiveRecord::Base.connection.drop_table :temp_model_timezone_tests
   end
 
   subject do
@@ -54,7 +54,7 @@ describe TimeZoneAttribute do
         it 'handles restoring bad values from the database' do
           # arrange
           rails_tz_db_string = rails_tz.nil? ? 'null' : "'#{rails_tz}'"
-          insert_sql = "INSERT INTO temp_models (tzinfo_tz, rails_tz) VALUES ('#{tzinfo_tz}',#{rails_tz_db_string})"
+          insert_sql = "INSERT INTO temp_model_timezone_tests (tzinfo_tz, rails_tz) VALUES ('#{tzinfo_tz}',#{rails_tz_db_string})"
           ActiveRecord::Base.connection.execute insert_sql
 
           # act
@@ -67,7 +67,7 @@ describe TimeZoneAttribute do
 
           # act
           loaded.save!
-          results = ActiveRecord::Base.connection.exec_query('SELECT * FROM temp_models LIMIT 1')
+          results = ActiveRecord::Base.connection.exec_query('SELECT * FROM temp_model_timezone_tests LIMIT 1')
 
           # assert
           expect(results.rows.first[1..]).to match([expected, expected_rails_tz])

--- a/spec/views/markdown_view_spec.rb
+++ b/spec/views/markdown_view_spec.rb
@@ -32,7 +32,7 @@ describe 'rendering markdown partials', type: :view do
     stub_template 'public/_markdown_test.html.md' => markdown_fixture
     render partial: 'public/markdown_test'
 
-    expect(rendered).to match(%r{<h1>Test!</h1>})
+    expect(rendered).to match(%r{<h1 id="test">Test!</h1>})
     expect(rendered).to match(%r{<li>a list</li>})
     expect(rendered).to match(/<code>2/)
     expect(rendered).to match "#{@user.user_name}\n<\/code>"

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -41,10 +41,17 @@ paths:
                   id: 1
                   description: project description 2
                   name: gen_project2
+                  notes: note number 2
+                  updater_id: 1
                   creator_id: 3
+                  deleted_at: 
+                  deleter_id: 
+                  created_at: '2020-08-27T15:07:15.914+01:00'
+                  updated_at: '2020-08-27T15:07:16.766+01:00'
                   site_ids:
                   - 1
                   description_html: "<p>project description 2</p>\n"
+                  description_html_tagline: project description 2
               schema:
                 allOf:
                 - "$ref": "#/components/schemas/standard_response"
@@ -89,10 +96,17 @@ paths:
                   id: 2
                   name: gen_project3
                   description: project description 3
-                  creator_id: 7
+                  notes: note number 3
+                  creator_id: 8
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:16.832+01:00'
+                  updated_at: '2020-08-27T15:07:16.832+01:00'
                   site_ids:
                   - 2
                   description_html: "<p>project description 3</p>\n"
+                  description_html_tagline: project description 3
               schema:
                 allOf:
                 - "$ref": "#/components/schemas/standard_response"
@@ -157,10 +171,17 @@ paths:
                   id: 4
                   description: project description 6
                   name: gen_project6
-                  creator_id: 15
+                  notes: note number 6
+                  updater_id: 1
+                  creator_id: 16
+                  deleted_at: 
+                  deleter_id: 
+                  created_at: '2020-08-27T15:07:17.343+01:00'
+                  updated_at: '2020-08-27T15:07:17.560+01:00'
                   site_ids:
                   - 4
                   description_html: "<p>project description 6</p>\n"
+                  description_html_tagline: project description 6
               schema:
                 allOf:
                 - "$ref": "#/components/schemas/standard_response"
@@ -211,10 +232,17 @@ paths:
                 - id: 5
                   name: gen_project7
                   description: project description 7
-                  creator_id: 19
+                  notes: note number 7
+                  creator_id: 21
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:17.622+01:00'
+                  updated_at: '2020-08-27T15:07:17.622+01:00'
                   site_ids:
                   - 5
                   description_html: "<p>project description 7</p>\n"
+                  description_html_tagline: project description 7
               schema:
                 allOf:
                 - "$ref": "#/components/schemas/standard_response"
@@ -262,10 +290,17 @@ paths:
                 - id: 6
                   name: gen_project8
                   description: project description 8
-                  creator_id: 23
+                  notes: note number 8
+                  creator_id: 25
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:17.944+01:00'
+                  updated_at: '2020-08-27T15:07:17.944+01:00'
                   site_ids:
                   - 6
                   description_html: "<p>project description 8</p>\n"
+                  description_html_tagline: project description 8
               schema:
                 allOf:
                 - "$ref": "#/components/schemas/standard_response"
@@ -301,9 +336,16 @@ paths:
                   id: 8
                   name: gen_project10
                   description: project description 10
+                  notes: note number 10
                   creator_id: 1
+                  updater_id: 1
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:18.367+01:00'
+                  updated_at: '2020-08-27T15:07:18.367+01:00'
                   site_ids: []
                   description_html: "<p>project description 10</p>\n"
+                  description_html_tagline: project description 10
               schema:
                 allOf:
                 - "$ref": "#/components/schemas/standard_response"
@@ -343,7 +385,2350 @@ paths:
                   id: 
                   name: 
                   description: 
+                  notes: 
                   creator_id: 
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: 
+                  updated_at: 
+  "/scripts":
+    get:
+      summary: list scripts
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - scripts
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: name
+                    direction: asc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/scripts?direction=asc&items=25&order_by=name&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 9
+                  name: script name 9
+                  description: script description 9
+                  analysis_identifier: script machine identifier 9
+                  version: 0.09
+                  group_id: 9
+                  creator_id: 1
+                  created_at: '2020-08-27T15:07:18.732+01:00'
+                  executable_settings: executable settings 9
+                  executable_settings_media_type: text/plain
+                  analysis_action_params:
+                    file_executable: "./AnalysisPrograms/AnalysisPrograms.exe"
+                    copy_paths:
+                    - "./programs/AnalysisPrograms/Logs/log.txt"
+                    sub_folders: []
+                    custom_setting: 9
+                  is_last_version: true
+                  is_first_version: true
+                  description_html: "<p>script description 9</p>\n"
+                  description_html_tagline: script description 9
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/script"
+  "/scripts/{id}":
+    get:
+      summary: show script
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - scripts
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 10
+                  name: script name 10
+                  description: script description 10
+                  analysis_identifier: script machine identifier 10
+                  version: 0.1
+                  group_id: 10
+                  creator_id: 1
+                  created_at: '2020-08-27T15:07:18.983+01:00'
+                  executable_settings: executable settings 10
+                  executable_settings_media_type: text/plain
+                  analysis_action_params:
+                    file_executable: "./AnalysisPrograms/AnalysisPrograms.exe"
+                    copy_paths:
+                    - "./programs/AnalysisPrograms/Logs/log.txt"
+                    sub_folders: []
+                    custom_setting: 10
+                  is_last_version: true
+                  is_first_version: true
+                  description_html: "<p>script description 10</p>\n"
+                  description_html_tagline: script description 10
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/script"
+  "/scripts/filter":
+    post:
+      summary: filter script
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - scripts
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: name
+                    direction: asc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/scripts/filter?direction=asc&items=25&order_by=name&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 11
+                  name: script name 11
+                  description: script description 11
+                  analysis_identifier: script machine identifier 11
+                  version: 0.11
+                  group_id: 11
+                  creator_id: 1
+                  created_at: '2020-08-27T15:07:19.224+01:00'
+                  executable_settings: executable settings 11
+                  executable_settings_media_type: text/plain
+                  analysis_action_params:
+                    file_executable: "./AnalysisPrograms/AnalysisPrograms.exe"
+                    copy_paths:
+                    - "./programs/AnalysisPrograms/Logs/log.txt"
+                    sub_folders: []
+                    custom_setting: 11
+                  is_last_version: true
+                  is_first_version: true
+                  description_html: "<p>script description 11</p>\n"
+                  description_html_tagline: script description 11
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/script"
+  "/sites":
+    post:
+      summary: create site
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 201
+                  message: Created
+                data:
+                  id: 13
+                  name: site name 13
+                  notes: note number 13
+                  creator_id: 1
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:19.626+01:00'
+                  updated_at: '2020-08-27T15:07:19.626+01:00'
+                  description: site description 13
+                  project_ids: []
+                  location_obfuscated: true
+                  custom_latitude: 
+                  custom_longitude: 
+                  timezone_information: 
+                  image_urls:
+                  - size: extralarge
+                    url: "/images/site/site_span4.png"
+                    width: 300
+                    height: 300
+                  - size: large
+                    url: "/images/site/site_span3.png"
+                    width: 220
+                    height: 220
+                  - size: medium
+                    url: "/images/site/site_span2.png"
+                    width: 140
+                    height: 140
+                  - size: small
+                    url: "/images/site/site_span1.png"
+                    width: 60
+                    height: 60
+                  - size: tiny
+                    url: "/images/site/site_spanhalf.png"
+                    width: 30
+                    height: 30
+                  description_html: "<p>site description 13</p>\n"
+                  description_html_tagline: site description 13
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/site"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/site"
+    get:
+      summary: list sites
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: name
+                    direction: asc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/sites?direction=asc&items=25&order_by=name&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 14
+                  name: site name 14
+                  notes: note number 14
+                  creator_id: 55
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:19.723+01:00'
+                  updated_at: '2020-08-27T15:07:19.723+01:00'
+                  description: site description 14
+                  project_ids:
+                  - 14
+                  location_obfuscated: false
+                  custom_latitude: -49.179023
+                  custom_longitude: 43.082595
+                  timezone_information: 
+                  image_urls:
+                  - size: extralarge
+                    url: "/images/site/site_span4.png"
+                    width: 300
+                    height: 300
+                  - size: large
+                    url: "/images/site/site_span3.png"
+                    width: 220
+                    height: 220
+                  - size: medium
+                    url: "/images/site/site_span2.png"
+                    width: 140
+                    height: 140
+                  - size: small
+                    url: "/images/site/site_span1.png"
+                    width: 60
+                    height: 60
+                  - size: tiny
+                    url: "/images/site/site_spanhalf.png"
+                    width: 30
+                    height: 30
+                  description_html: "<p>site description 14</p>\n"
+                  description_html_tagline: site description 14
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/site"
+  "/sites/filter":
+    post:
+      summary: filter site
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: name
+                    direction: asc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/sites/filter?direction=asc&items=25&order_by=name&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 15
+                  name: site name 15
+                  notes: note number 15
+                  creator_id: 59
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:19.964+01:00'
+                  updated_at: '2020-08-27T15:07:19.964+01:00'
+                  description: site description 15
+                  project_ids:
+                  - 15
+                  location_obfuscated: false
+                  custom_latitude: -36.842571
+                  custom_longitude: 42.286205
+                  timezone_information: 
+                  image_urls:
+                  - size: extralarge
+                    url: "/images/site/site_span4.png"
+                    width: 300
+                    height: 300
+                  - size: large
+                    url: "/images/site/site_span3.png"
+                    width: 220
+                    height: 220
+                  - size: medium
+                    url: "/images/site/site_span2.png"
+                    width: 140
+                    height: 140
+                  - size: small
+                    url: "/images/site/site_span1.png"
+                    width: 60
+                    height: 60
+                  - size: tiny
+                    url: "/images/site/site_spanhalf.png"
+                    width: 30
+                    height: 30
+                  description_html: "<p>site description 15</p>\n"
+                  description_html_tagline: site description 15
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/site"
+  "/sites/{id}":
+    delete:
+      summary: delete site
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '204':
+          description: successful
+          content:
+            application/json:
+              example: 
+    put:
+      summary: update site
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 17
+                  name: site name 18
+                  description: site description 18
+                  notes: note number 18
+                  updater_id: 1
+                  creator_id: 67
+                  deleted_at: 
+                  deleter_id: 
+                  created_at: '2020-08-27T15:07:20.441+01:00'
+                  updated_at: '2020-08-27T15:07:20.615+01:00'
+                  project_ids:
+                  - 17
+                  location_obfuscated: false
+                  custom_latitude: 42.017445
+                  custom_longitude: -60.299422
+                  timezone_information: 
+                  image_urls:
+                  - size: extralarge
+                    url: "/images/site/site_span4.png"
+                    width: 300
+                    height: 300
+                  - size: large
+                    url: "/images/site/site_span3.png"
+                    width: 220
+                    height: 220
+                  - size: medium
+                    url: "/images/site/site_span2.png"
+                    width: 140
+                    height: 140
+                  - size: small
+                    url: "/images/site/site_span1.png"
+                    width: 60
+                    height: 60
+                  - size: tiny
+                    url: "/images/site/site_spanhalf.png"
+                    width: 30
+                    height: 30
+                  description_html: "<p>site description 18</p>\n"
+                  description_html_tagline: site description 18
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/site"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/site"
+    get:
+      summary: show site
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 18
+                  name: site name 19
+                  notes: note number 19
+                  creator_id: 72
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:20.750+01:00'
+                  updated_at: '2020-08-27T15:07:20.750+01:00'
+                  description: site description 19
+                  project_ids:
+                  - 18
+                  location_obfuscated: false
+                  custom_latitude: 55.101294
+                  custom_longitude: 104.375337
+                  timezone_information: 
+                  image_urls:
+                  - size: extralarge
+                    url: "/images/site/site_span4.png"
+                    width: 300
+                    height: 300
+                  - size: large
+                    url: "/images/site/site_span3.png"
+                    width: 220
+                    height: 220
+                  - size: medium
+                    url: "/images/site/site_span2.png"
+                    width: 140
+                    height: 140
+                  - size: small
+                    url: "/images/site/site_span1.png"
+                    width: 60
+                    height: 60
+                  - size: tiny
+                    url: "/images/site/site_spanhalf.png"
+                    width: 30
+                    height: 30
+                  description_html: "<p>site description 19</p>\n"
+                  description_html_tagline: site description 19
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/site"
+    patch:
+      summary: update site
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 19
+                  name: site name 21
+                  description: site description 21
+                  notes: note number 21
+                  updater_id: 1
+                  creator_id: 76
+                  deleted_at: 
+                  deleter_id: 
+                  created_at: '2020-08-27T15:07:20.978+01:00'
+                  updated_at: '2020-08-27T15:07:21.154+01:00'
+                  project_ids:
+                  - 19
+                  location_obfuscated: false
+                  custom_latitude: -37.25948
+                  custom_longitude: -144.76369
+                  timezone_information: 
+                  image_urls:
+                  - size: extralarge
+                    url: "/images/site/site_span4.png"
+                    width: 300
+                    height: 300
+                  - size: large
+                    url: "/images/site/site_span3.png"
+                    width: 220
+                    height: 220
+                  - size: medium
+                    url: "/images/site/site_span2.png"
+                    width: 140
+                    height: 140
+                  - size: small
+                    url: "/images/site/site_span1.png"
+                    width: 60
+                    height: 60
+                  - size: tiny
+                    url: "/images/site/site_spanhalf.png"
+                    width: 30
+                    height: 30
+                  description_html: "<p>site description 21</p>\n"
+                  description_html_tagline: site description 21
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/site"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/site"
+  "/sites/new":
+    get:
+      summary: new site
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - sites
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 
+                  name: 
+                  notes: 
+                  creator_id: 
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: 
+                  updated_at: 
+                  description: 
+                  longitude: 
+                  latitude: 
+                  image: 
+                  tzinfo_tz: 
+                  rails_tz: 
+  "/bookmarks":
+    post:
+      summary: create bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 201
+                  message: Created
+                data:
+                  id: 21
+                  audio_recording_id: 21
+                  offset_seconds: 4.0
+                  name: name 21
+                  creator_id: 1
+                  updater_id: 
+                  created_at: '2020-08-27T15:07:21.719+01:00'
+                  updated_at: '2020-08-27T15:07:21.719+01:00'
+                  description: description 21
+                  category: category 21
+                  description_html: "<p>description 21</p>\n"
+                  description_html_tagline: description 21
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/bookmark"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/bookmark"
+    get:
+      summary: list bookmarks
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: created_at
+                    direction: desc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/bookmarks?direction=desc&items=25&order_by=created_at&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 22
+                  audio_recording_id: 22
+                  offset_seconds: 4.0
+                  name: name 22
+                  creator_id: 1
+                  updater_id: 
+                  created_at: '2020-08-27T15:07:21.842+01:00'
+                  updated_at: '2020-08-27T15:07:21.842+01:00'
+                  description: description 22
+                  category: category 22
+                  description_html: "<p>description 22</p>\n"
+                  description_html_tagline: description 22
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/bookmark"
+  "/bookmarks/new":
+    get:
+      summary: new bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 
+                  audio_recording_id: 
+                  offset_seconds: 
+                  name: 
+                  creator_id: 
+                  updater_id: 
+                  created_at: 
+                  updated_at: 
+                  description: 
+                  category: 
+  "/bookmarks/filter":
+    post:
+      summary: filter bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: created_at
+                    direction: desc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/bookmarks/filter?direction=desc&items=25&order_by=created_at&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 24
+                  audio_recording_id: 24
+                  offset_seconds: 4.0
+                  name: name 24
+                  creator_id: 1
+                  updater_id: 
+                  created_at: '2020-08-27T15:07:22.310+01:00'
+                  updated_at: '2020-08-27T15:07:22.310+01:00'
+                  description: description 24
+                  category: category 24
+                  description_html: "<p>description 24</p>\n"
+                  description_html_tagline: description 24
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/bookmark"
+  "/bookmarks/{id}":
+    put:
+      summary: update bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 25
+                  audio_recording_id: 26
+                  name: name 26
+                  description: description 26
+                  offset_seconds: 4.0
+                  category: category 26
+                  updater_id: 1
+                  creator_id: 1
+                  created_at: '2020-08-27T15:07:22.552+01:00'
+                  updated_at: '2020-08-27T15:07:22.724+01:00'
+                  description_html: "<p>description 26</p>\n"
+                  description_html_tagline: description 26
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/bookmark"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/bookmark"
+    patch:
+      summary: update bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 26
+                  audio_recording_id: 28
+                  name: name 28
+                  description: description 28
+                  offset_seconds: 4.0
+                  category: category 28
+                  updater_id: 1
+                  creator_id: 1
+                  created_at: '2020-08-27T15:07:22.894+01:00'
+                  updated_at: '2020-08-27T15:07:23.073+01:00'
+                  description_html: "<p>description 28</p>\n"
+                  description_html_tagline: description 28
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/bookmark"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/bookmark"
+    delete:
+      summary: delete bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '204':
+          description: successful
+          content:
+            application/json:
+              example: 
+    get:
+      summary: show bookmark
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - bookmarks
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 28
+                  audio_recording_id: 30
+                  offset_seconds: 4.0
+                  name: name 30
+                  creator_id: 1
+                  updater_id: 
+                  created_at: '2020-08-27T15:07:23.421+01:00'
+                  updated_at: '2020-08-27T15:07:23.421+01:00'
+                  description: description 30
+                  category: category 30
+                  description_html: "<p>description 30</p>\n"
+                  description_html_tagline: description 30
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/bookmark"
+  "/saved_searches/new":
+    get:
+      summary: new saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 
+                  name: 
+                  description: 
+                  stored_query: 
+                  creator_id: 
+                  created_at: 
+                  deleter_id: 
+                  deleted_at: 
+  "/saved_searches/filter":
+    post:
+      summary: filter saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: created_at
+                    direction: desc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/saved_searches/filter?direction=desc&items=25&order_by=created_at&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 29
+                  name: saved search name 29
+                  description: saved search description 29
+                  stored_query:
+                    uuid:
+                      eq: blah blah
+                  creator_id: 134
+                  created_at: '2020-08-27T15:07:23.896+01:00'
+                  deleter_id: 
+                  deleted_at: 
+                  project_ids:
+                  - 30
+                  analysis_job_ids:
+                  - 29
+                  description_html: "<p>saved search description 29</p>\n"
+                  description_html_tagline: saved search description 29
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/saved_search"
+  "/saved_searches/{id}":
+    put:
+      summary: can't update saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`.<br />
+        Users that can't: `Harvester`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '404':
+          description: not found
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 404
+                  message: Not Found
+                  error:
+                    details: Could not find the requested page.
+                    info:
+                      original_route: saved_searches/30
+                      original_http_method: PUT
+                data: 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/saved_search"
+    delete:
+      summary: delete saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '204':
+          description: successful
+          content:
+            application/json:
+              example: 
+    patch:
+      summary: can't update saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`.<br />
+        Users that can't: `Harvester`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '404':
+          description: not found
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 404
+                  message: Not Found
+                  error:
+                    details: Could not find the requested page.
+                    info:
+                      original_route: saved_searches/32
+                      original_http_method: PATCH
+                data: 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/saved_search"
+    get:
+      summary: show saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 33
+                  name: saved search name 35
+                  description: saved search description 35
+                  stored_query:
+                    uuid:
+                      eq: blah blah
+                  creator_id: 152
+                  created_at: '2020-08-27T15:07:24.864+01:00'
+                  deleter_id: 
+                  deleted_at: 
+                  project_ids:
+                  - 34
+                  analysis_job_ids:
+                  - 33
+                  description_html: "<p>saved search description 35</p>\n"
+                  description_html_tagline: saved search description 35
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/saved_search"
+  "/saved_searches":
+    get:
+      summary: list saved_searches
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: created_at
+                    direction: desc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/saved_searches?direction=desc&items=25&order_by=created_at&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 34
+                  name: saved search name 36
+                  description: saved search description 36
+                  stored_query:
+                    uuid:
+                      eq: blah blah
+                  creator_id: 156
+                  created_at: '2020-08-27T15:07:25.093+01:00'
+                  deleter_id: 
+                  deleted_at: 
+                  project_ids:
+                  - 35
+                  analysis_job_ids:
+                  - 34
+                  description_html: "<p>saved search description 36</p>\n"
+                  description_html_tagline: saved search description 36
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/saved_search"
+    post:
+      summary: create saved_search
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - saved_searches
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 201
+                  message: Created
+                data:
+                  id: 36
+                  name: saved search name 38
+                  description: saved search description 38
+                  stored_query:
+                    uuid:
+                      eq: blah blah
+                  creator_id: 1
+                  created_at: '2020-08-27T15:07:25.521+01:00'
+                  deleter_id: 
+                  deleted_at: 
+                  project_ids: []
+                  analysis_job_ids: []
+                  description_html: "<p>saved search description 38</p>\n"
+                  description_html_tagline: saved search description 38
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/saved_search"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/saved_search"
+  "/analysis_jobs":
+    get:
+      summary: list analysis_jobs
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: updated_at
+                    direction: desc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/analysis_jobs?direction=desc&items=25&order_by=updated_at&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 36
+                  name: job name 36
+                  annotation_name: 
+                  custom_settings: custom settings 36
+                  script_id: 36
+                  creator_id: 165
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:25.710+01:00'
+                  updated_at: '2020-08-27T15:07:25.710+01:00'
+                  description: job description 36
+                  saved_search_id: 37
+                  started_at: '2020-08-27T15:07:25.705+01:00'
+                  overall_status: new
+                  overall_status_modified_at: '2020-08-27T15:07:25.705+01:00'
+                  overall_progress:
+                    new: 0
+                    queued: 0
+                    working: 0
+                    successful: 0
+                    failed: 0
+                    timed_out: 0
+                    cancelling: 0
+                    cancelled: 0
+                    total: 0
+                  overall_progress_modified_at: '2020-08-27T15:07:25.706+01:00'
+                  overall_count: 0
+                  overall_duration_seconds: 0.0
+                  overall_data_length_bytes: 0
+                  description_html: "<p>job description 36</p>\n"
+                  description_html_tagline: job description 36
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/analysis_job"
+    post:
+      summary: create analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 201
+                  message: Created
+                data:
+                  id: 38
+                  name: job name 38
+                  annotation_name: 
+                  custom_settings: custom settings 38
+                  script_id: 38
+                  creator_id: 1
+                  updater_id: 1
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:26.285+01:00'
+                  updated_at: '2020-08-27T15:07:26.323+01:00'
+                  description: job description 38
+                  saved_search_id: 39
+                  started_at: '2020-08-27T15:07:26.301+01:00'
+                  overall_status: completed
+                  overall_status_modified_at: '2020-08-27T15:07:26.318+01:00'
+                  overall_progress:
+                    new: 0
+                    queued: 0
+                    working: 0
+                    successful: 0
+                    failed: 0
+                    timed_out: 0
+                    cancelling: 0
+                    cancelled: 0
+                    total: 0
+                  overall_progress_modified_at: '2020-08-27T15:07:26.319+01:00'
+                  overall_count: 0
+                  overall_duration_seconds: 0.0
+                  overall_data_length_bytes: 0
+                  description_html: "<p>job description 38</p>\n"
+                  description_html_tagline: job description 38
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/analysis_job"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/analysis_job"
+  "/analysis_jobs/{id}":
+    delete:
+      summary: delete analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '204':
+          description: successful
+          content:
+            application/json:
+              example: 
+    get:
+      summary: show analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 40
+                  name: job name 40
+                  annotation_name: 
+                  custom_settings: custom settings 40
+                  script_id: 40
+                  creator_id: 180
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:26.760+01:00'
+                  updated_at: '2020-08-27T15:07:26.760+01:00'
+                  description: job description 40
+                  saved_search_id: 41
+                  started_at: '2020-08-27T15:07:26.754+01:00'
+                  overall_status: completed
+                  overall_status_modified_at: '2020-08-27T15:07:26.755+01:00'
+                  overall_progress:
+                    new: 0
+                    queued: 0
+                    working: 0
+                    successful: 0
+                    failed: 0
+                    timed_out: 0
+                    cancelling: 0
+                    cancelled: 0
+                    total: 0
+                  overall_progress_modified_at: '2020-08-27T15:07:26.756+01:00'
+                  overall_count: 0
+                  overall_duration_seconds: 0.0
+                  overall_data_length_bytes: 0
+                  description_html: "<p>job description 40</p>\n"
+                  description_html_tagline: job description 40
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/analysis_job"
+    patch:
+      summary: update analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 41
+                  name: job name 42
+                  annotation_name: 
+                  custom_settings: custom settings 41
+                  script_id: 41
+                  creator_id: 184
+                  updater_id: 1
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:27.006+01:00'
+                  updated_at: '2020-08-27T15:07:27.160+01:00'
+                  description: job description 42
+                  saved_search_id: 42
+                  started_at: '2020-08-27T15:07:27.000+01:00'
+                  overall_status: completed
+                  overall_status_modified_at: '2020-08-27T15:07:27.000+01:00'
+                  overall_progress:
+                    new: 0
+                    queued: 0
+                    working: 0
+                    successful: 0
+                    failed: 0
+                    timed_out: 0
+                    cancelling: 0
+                    cancelled: 0
+                    total: 0
+                  overall_progress_modified_at: '2020-08-27T15:07:27.002+01:00'
+                  overall_count: 0
+                  overall_duration_seconds: 0.0
+                  overall_data_length_bytes: 0
+                  description_html: "<p>job description 42</p>\n"
+                  description_html_tagline: job description 42
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/analysis_job"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/analysis_job"
+    put:
+      summary: update analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 42
+                  name: job name 44
+                  annotation_name: 
+                  custom_settings: custom settings 43
+                  script_id: 43
+                  creator_id: 191
+                  updater_id: 1
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:27.321+01:00'
+                  updated_at: '2020-08-27T15:07:27.440+01:00'
+                  description: job description 44
+                  saved_search_id: 44
+                  started_at: '2020-08-27T15:07:27.310+01:00'
+                  overall_status: completed
+                  overall_status_modified_at: '2020-08-27T15:07:27.311+01:00'
+                  overall_progress:
+                    new: 0
+                    queued: 0
+                    working: 0
+                    successful: 0
+                    failed: 0
+                    timed_out: 0
+                    cancelling: 0
+                    cancelled: 0
+                    total: 0
+                  overall_progress_modified_at: '2020-08-27T15:07:27.314+01:00'
+                  overall_count: 0
+                  overall_duration_seconds: 0.0
+                  overall_data_length_bytes: 0
+                  description_html: "<p>job description 44</p>\n"
+                  description_html_tagline: job description 44
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/analysis_job"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/analysis_job"
+  "/analysis_jobs/new":
+    get:
+      summary: new analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 
+                  name: 
+                  annotation_name: 
+                  custom_settings: 
+                  script_id: 
+                  creator_id: 
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: 
+                  updated_at: 
+                  description: 
+                  saved_search_id: 
+                  started_at: 
+                  overall_status: before_save
+                  overall_status_modified_at: 
+                  overall_progress: 
+                  overall_progress_modified_at: 
+                  overall_count: 
+                  overall_duration_seconds: 
+                  overall_data_length_bytes: 0
+  "/analysis_jobs/filter":
+    post:
+      summary: filter analysis_job
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - analysis_jobs
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: updated_at
+                    direction: desc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 1
+                    max_page: 1
+                    current: http://localhost:3000/analysis_jobs/filter?direction=desc&items=25&order_by=updated_at&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 44
+                  name: job name 46
+                  annotation_name: 
+                  custom_settings: custom settings 46
+                  script_id: 46
+                  creator_id: 202
+                  updater_id: 
+                  deleter_id: 
+                  deleted_at: 
+                  created_at: '2020-08-27T15:07:27.852+01:00'
+                  updated_at: '2020-08-27T15:07:27.852+01:00'
+                  description: job description 46
+                  saved_search_id: 47
+                  started_at: '2020-08-27T15:07:27.846+01:00'
+                  overall_status: new
+                  overall_status_modified_at: '2020-08-27T15:07:27.846+01:00'
+                  overall_progress:
+                    new: 0
+                    queued: 0
+                    working: 0
+                    successful: 0
+                    failed: 0
+                    timed_out: 0
+                    cancelling: 0
+                    cancelled: 0
+                    total: 0
+                  overall_progress_modified_at: '2020-08-27T15:07:27.848+01:00'
+                  overall_count: 0
+                  overall_duration_seconds: 0.0
+                  overall_data_length_bytes: 0
+                  description_html: "<p>job description 46</p>\n"
+                  description_html_tagline: job description 46
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/analysis_job"
+  "/datasets":
+    get:
+      summary: list datasets
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: name
+                    direction: asc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 2
+                    max_page: 1
+                    current: http://localhost:3000/datasets?direction=asc&items=25&order_by=name&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 1
+                  creator_id: 1
+                  updater_id: 
+                  name: default
+                  description: The default dataset
+                  created_at: '2020-08-27T15:07:15.838+01:00'
+                  updated_at: '2020-08-27T15:07:15.838+01:00'
+                  description_html: "<p>The default dataset</p>\n"
+                  description_html_tagline: The default dataset
+                - id: 45
+                  creator_id: 205
+                  updater_id: 
+                  name: gen_dataset_name44
+                  description: dataset description 44
+                  created_at: '2020-08-27T15:07:28.149+01:00'
+                  updated_at: '2020-08-27T15:07:28.149+01:00'
+                  description_html: "<p>dataset description 44</p>\n"
+                  description_html_tagline: dataset description 44
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/dataset"
+    post:
+      summary: create dataset
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`.<br />
+        Users that can't: `Harvester`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '201':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 201
+                  message: Created
+                data:
+                  id: 47
+                  creator_id: 1
+                  updater_id: 
+                  name: gen_dataset_name46
+                  description: dataset description 46
+                  created_at: '2020-08-27T15:07:28.461+01:00'
+                  updated_at: '2020-08-27T15:07:28.461+01:00'
+                  description_html: "<p>dataset description 46</p>\n"
+                  description_html_tagline: dataset description 46
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/dataset"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/dataset"
+  "/datasets/{id}":
+    get:
+      summary: show dataset
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 48
+                  creator_id: 214
+                  updater_id: 
+                  name: gen_dataset_name47
+                  description: dataset description 47
+                  created_at: '2020-08-27T15:07:28.671+01:00'
+                  updated_at: '2020-08-27T15:07:28.671+01:00'
+                  description_html: "<p>dataset description 47</p>\n"
+                  description_html_tagline: dataset description 47
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/dataset"
+    patch:
+      summary: update dataset
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 49
+                  description: dataset description 49
+                  name: gen_dataset_name49
+                  updater_id: 1
+                  creator_id: 218
+                  created_at: '2020-08-27T15:07:28.927+01:00'
+                  updated_at: '2020-08-27T15:07:29.003+01:00'
+                  description_html: "<p>dataset description 49</p>\n"
+                  description_html_tagline: dataset description 49
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/dataset"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/dataset"
+    put:
+      summary: update dataset
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 50
+                  description: dataset description 51
+                  name: gen_dataset_name51
+                  updater_id: 1
+                  creator_id: 223
+                  created_at: '2020-08-27T15:07:29.181+01:00'
+                  updated_at: '2020-08-27T15:07:29.233+01:00'
+                  description_html: "<p>dataset description 51</p>\n"
+                  description_html_tagline: dataset description 51
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      "$ref": "#/components/schemas/dataset"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/dataset"
+    delete:
+      summary: can't delete a dataset
+      security:
+      - basic_auth_with_token: []
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`.<br />
+        Users that can't: `Harvester`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '404':
+          description: not found
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 404
+                  message: Not Found
+                  error:
+                    details: Could not find the requested page.
+                    info:
+                      original_route: datasets/51
+                      original_http_method: DELETE
+                data: 
+  "/datasets/new":
+    get:
+      summary: new dataset
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                data:
+                  id: 
+                  creator_id: 
+                  updater_id: 
+                  name: 
+                  description: 
+                  created_at: 
+                  updated_at: 
+  "/datasets/filter":
+    post:
+      summary: filter dataset
+      security:
+      - basic_auth_with_token: []
+      parameters: []
+      tags:
+      - datasets
+      description: |2
+
+        Users that can invoke this route: `Admin`, `owner user`, `writer`, `reader`, `no_access`, `anyone`.<br />
+        Users that can't: `Harvester`.
+
+        Note: accessing a list/index/filter endpoint may return no results due to project permissions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                meta:
+                  status: 200
+                  message: OK
+                  sorting:
+                    order_by: name
+                    direction: asc
+                  paging:
+                    page: 1
+                    items: 25
+                    total: 2
+                    max_page: 1
+                    current: http://localhost:3000/datasets/filter?direction=asc&items=25&order_by=name&page=1
+                    previous: 
+                    next: 
+                data:
+                - id: 1
+                  creator_id: 1
+                  updater_id: 
+                  name: default
+                  description: The default dataset
+                  created_at: '2020-08-27T15:07:15.838+01:00'
+                  updated_at: '2020-08-27T15:07:15.838+01:00'
+                  description_html: "<p>The default dataset</p>\n"
+                  description_html_tagline: The default dataset
+                - id: 53
+                  creator_id: 236
+                  updater_id: 
+                  name: gen_dataset_name54
+                  description: dataset description 54
+                  created_at: '2020-08-27T15:07:29.902+01:00'
+                  updated_at: '2020-08-27T15:07:29.902+01:00'
+                  description_html: "<p>dataset description 54</p>\n"
+                  description_html_tagline: dataset description 54
+              schema:
+                allOf:
+                - "$ref": "#/components/schemas/standard_response"
+                - type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        "$ref": "#/components/schemas/dataset"
 servers:
 - url: https://{defaultHost}
   variables:
@@ -359,6 +2744,47 @@ components:
       name: auth_token
       in: query_string
   schemas:
+    id:
+      type: integer
+      minimum: 0
+      readOnly: true
+    nullableId:
+      anyOf:
+      - type: integer
+        minimum: 0
+        readOnly: true
+      - type: 'null'
+    timezone_information:
+      anyOf:
+      - type: object
+        properties:
+          identifier_alt:
+            type:
+            - string
+            - 'null'
+          identifier:
+            type: string
+          friendly_identifier:
+            type: string
+          utc_offset:
+            type: string
+          utc_total_offset:
+            type: integer
+      - type: 'null'
+    image_urls:
+      type: array
+      items:
+        type: object
+        properties:
+          size:
+            type: string
+          url:
+            type: string
+            format: URI
+          width:
+            type: integer
+          height:
+            type: integer
     meta:
       type: object
     meta_error:
@@ -399,24 +2825,480 @@ components:
       additionalProperties: false
       properties:
         id:
-          type: integer
+          "$ref": "#/components/schemas/id"
           readOnly: true
         name:
           type: string
         description:
-          type: string
+          type:
+          - string
+          - 'null'
         description_html:
-          type: string
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
           readOnly: true
         notes:
-          type: object
+          type: string
         creator_id:
-          type: integer
+          "$ref": "#/components/schemas/id"
           readOnly: true
         updater_id:
-          type: integer
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        deleter_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        updated_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        deleted_at:
+          type:
+          - 'null'
+          - date
           readOnly: true
         site_ids:
           type: array
           items:
             type: integer
+      required:
+      - id
+      - name
+      - description
+      - description_html
+      - description_html_tagline
+      - notes
+      - creator_id
+      - created_at
+      - updater_id
+      - updated_at
+      - deleter_id
+      - deleted_at
+      - site_ids
+    analysis_job:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        name:
+          type: string
+        annotation_name:
+          type:
+          - string
+          - 'null'
+        description:
+          type:
+          - string
+          - 'null'
+        description_html:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        custom_settings:
+          type: string
+        script_id:
+          "$ref": "#/components/schemas/id"
+        saved_search_id:
+          "$ref": "#/components/schemas/id"
+        started_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        overall_status:
+          type: string
+          enum:
+          - before_save
+          - new
+          - preparing
+          - processing
+          - completed
+          - suspended
+          readOnly: true
+        overall_status_modified_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        overall_progress:
+          type: object
+          readOnly: true
+        overall_progress_modified_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        overall_count:
+          type: integer
+          readOnly: true
+        overall_duration_seconds:
+          type: number
+          readOnly: true
+        overall_data_length_bytes:
+          type: integer
+          readOnly: true
+        creator_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        updater_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        deleter_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        updated_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        deleted_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+      required:
+      - id
+      - name
+      - description
+      - description_html
+      - description_html_tagline
+      - custom_settings
+      - script_id
+      - saved_search_id
+      - started_at
+      - overall_status
+      - overall_status_modified_at
+      - overall_progress
+      - overall_progress_modified_at
+      - overall_count
+      - overall_duration_seconds
+      - overall_data_length_bytes
+    bookmark:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        audio_recording_id:
+          "$ref": "#/components/schemas/id"
+        name:
+          type: string
+        category:
+          type: string
+        offset_seconds:
+          type: number
+        description:
+          type:
+          - string
+          - 'null'
+        description_html:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        creator_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        updater_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        updated_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+      required:
+      - id
+      - audio_recording_id
+      - name
+      - category
+      - offset_seconds
+      - description
+      - description_html
+      - description_html_tagline
+      - creator_id
+      - created_at
+      - updater_id
+      - updated_at
+    dataset:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        name:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        description_html:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        creator_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        updater_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        updated_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+      required:
+      - id
+      - name
+      - description
+      - created_at
+      - creator_id
+      - updated_at
+      - updater_id
+    saved_search:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        analysis_job_ids:
+          type: array
+          items:
+            "$ref": "#/components/schemas/id"
+        project_ids:
+          type: array
+          items:
+            "$ref": "#/components/schemas/id"
+        name:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        description_html:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        stored_query:
+          type: object
+        creator_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        deleter_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        deleted_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+      required:
+      - id
+      - name
+      - description
+      - description_html
+      - description_html_tagline
+      - stored_query
+      - creator_id
+      - created_at
+      - deleter_id
+      - deleted_at
+    script:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        group_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        name:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        description_html:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        analysis_identifier:
+          type: string
+        executable_settings:
+          type: string
+        executable_settings_media_type:
+          type: string
+        version:
+          type: number
+        creator_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        is_last_version:
+          type: boolean
+          readOnly: true
+        is_first_version:
+          type: boolean
+          readOnly: true
+        analysis_action_params:
+          type: object
+      required:
+      - id
+      - group_id
+      - name
+      - description
+      - analysis_identifier
+      - executable_settings_media_type
+      - version
+      - created_at
+      - creator_id
+      - is_last_version
+      - is_first_version
+      - analysis_action_params
+    site:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        name:
+          type: string
+        description:
+          type:
+          - string
+          - 'null'
+        description_html:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        description_html_tagline:
+          type:
+          - string
+          - 'null'
+          readOnly: true
+        creator_id:
+          "$ref": "#/components/schemas/id"
+          readOnly: true
+        updater_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        deleter_id:
+          "$ref": "#/components/schemas/nullableId"
+          readOnly: true
+        created_at:
+          type: date
+          readOnly: true
+        updated_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        deleted_at:
+          type:
+          - 'null'
+          - date
+          readOnly: true
+        notes:
+          type: string
+        project_ids:
+          type: array
+          items:
+            type: integer
+        location_obfuscated:
+          type: boolean
+        custom_latitude:
+          type:
+          - number
+          - 'null'
+          minimum: -90
+          maximum: 90
+        custom_longitude:
+          type:
+          - number
+          - 'null'
+          minimum: -180
+          maximum: 180
+        timezone_information:
+          "$ref": "#/components/schemas/timezone_information"
+        image_urls:
+          "$ref": "#/components/schemas/image_urls"
+      required:
+      - id
+      - name
+      - description
+      - description_html
+      - description_html_tagline
+      - creator_id
+      - created_at
+      - updater_id
+      - updated_at
+      - deleter_id
+      - deleted_at
+      - notes
+      - project_ids
+      - location_obfuscated
+      - custom_latitude
+      - custom_longitude
+      - timezone_information
+      - image_urls


### PR DESCRIPTION
# Standardizes description markdown conversion in API

Fixes #487

Also adds a bunch of tests. To ensure the description fields are tested and generated we needed to add each class to our new testing framework. This meant adding API tests for every model afected.

Also fixes #406. Fixes #425.


## Changes

- standard description html/markdown outputs
- taglines now with all descriptions
- updated api tests for all affected models
- updated swagger docs for all affected endpoints
- updated metadata output for projects and sites

## Problems

API (and permission) specs in the new format are still in the process of being written - hence the large amount of churn.

At the time of PR creation there are a few tests failinf

## Visual Changes

N/A

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
