### PR TITLE
Adds regions and active storage

### DIFF
--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# Controller for Regions
+class RegionsController < ApplicationController
+  include Api::ControllerHelper
+
+  # GET /regions
+  # GET /projects/:project_id/regions
+  def index
+    do_authorize_class
+    get_project_if_exists
+    do_authorize_instance(:show, @project) unless @project.nil?
+
+    respond_to do |format|
+      #format.html # index.html.erb
+      format.json do
+        @regions, opts = Settings.api_response.response_advanced(
+          api_filter_params,
+          list_permissions,
+          Region,
+          Region.filter_settings
+        )
+        respond_index(opts)
+      end
+    end
+  end
+
+  # GET /regions/:id
+  # GET /projects/:project_id/regions/:id
+  def show
+    do_load_resource
+    get_project_if_exists
+    do_authorize_instance
+
+    respond_show
+  end
+
+  # GET /regions/new
+  # GET /projects/:project_id/regions/new
+  def new
+    do_new_resource
+    get_project_if_exists
+    do_set_attributes
+    do_authorize_instance
+
+    respond_show
+  end
+
+  # POST /regions
+  # POST /projects/:project_id/regions
+  def create
+    do_new_resource
+    do_set_attributes(region_params)
+    get_project_if_exists
+    do_authorize_instance
+
+    if @region.save
+      if @project.nil?
+        respond_create_success(shallow_region_path(@region))
+      else
+        respond_create_success(project_region_path(@project, @region))
+      end
+    else
+      respond_change_fail
+    end
+  end
+
+  # PUT|PATCH /regions/:id
+  # PUT|PATCH /projects/:project_id/regions/:id
+  def update
+    do_load_resource
+    get_project_if_exists
+    do_authorize_instance
+
+    @original_region_name = @region.name
+
+    if @region.update(region_params)
+      respond_show
+    else
+      respond_change_fail
+    end
+  end
+
+  # DELETE /regions/:id
+  # DELETE /projects/:project_id/regions/:id
+  def destroy
+    do_load_resource
+    get_project_if_exists
+    do_authorize_instance
+
+    @region.destroy
+    add_archived_at_header(@region)
+
+    respond_destroy
+  end
+
+  # GET|POST /regions/filter
+  # GET|POST /projects/:project_id/regions/filter
+  def filter
+    do_authorize_class
+    get_project_if_exists
+    do_authorize_instance(:show, @project) unless @project.nil?
+
+    filter_response, opts = Settings.api_response.response_advanced(
+      api_filter_params,
+      list_permissions,
+      Region,
+      Region.filter_settings
+    )
+    respond_filter(filter_response, opts)
+  end
+
+  def get_project_if_exists
+    return unless params.key?(:project_id)
+
+    @project = Project.find(params[:project_id])
+    @region.project = @project if defined?(@region) && defined?(@project)
+  end
+
+  def list_permissions
+    if @project.nil?
+      Access::ByPermission.regions(current_user)
+    else
+      Access::ByPermission.regions(current_user, project_id: @project.id)
+    end
+  end
+
+  def region_params
+    sanitize_associative_array(:tag, :notes)
+
+    params.require(:region).permit(:name, :description, :notes, :project_id, notes: {})
+  end
+end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -239,7 +239,9 @@ class SitesController < ApplicationController
   end
 
   def site_params
-    params.require(:site).permit(:name, :latitude, :longitude, :description, :image, :notes, :tzinfo_tz, project_ids: [])
+    params.require(:site).permit(
+      :name, :latitude, :longitude, :description, :image, :notes, :tzinfo_tz, :region_id, project_ids: []
+    )
   end
 
   def site_show_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -87,6 +87,7 @@ class Ability
 
       to_project(user, is_guest)
       to_permission(user)
+      to_region(user, is_guest)
       to_site(user, is_guest)
       to_audio_recording(user, is_guest)
       to_audio_event(user, is_guest)
@@ -223,6 +224,32 @@ class Ability
       check_model(permission)
       Access::Core.can?(user, :owner, permission.project)
     end
+  end
+
+  def to_region(user, _is_guest)
+    # POST      /projects/:project_id/regions                         regions#create
+    # GET       /projects/:project_id/regions/new                     regions#new
+    # GET       /projects/:project_id/regions/:id                     regions#show
+    # PATCH|PUT /projects/:project_id/regions/:id                     regions#update
+    # DELETE    /projects/:project_id/regions/:id                     regions#destroy
+    # GET       /projects/:project_id/regions                         regions#index {:format=>"json"}
+    # GET|POST  /regions/filter                                       regions#filter {:format=>"json"}
+    # and all of the above again with the shallow route
+
+    # any user, including guest, with reader permissions on project can #show a region and access #new
+    can [:show], Region do |region|
+      check_model(region)
+      Access::Core.can_any?(user, :reader, region.project)
+    end
+
+    # only owner can access these actions.
+    can [:create, :update, :destroy], Region do |region|
+      check_model(region)
+      Access::Core.can_any?(user, :owner, region.project)
+    end
+
+    # available to any user, including guest
+    can [:index, :filter, :new], Region
   end
 
   def to_site(user, _is_guest)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,7 @@ class Project < ApplicationRecord
   has_many :writers, -> { joins(:permissions).where({ permissions: { level: 'writer' } }).distinct }, through: :permissions, source: :user
   has_many :owners, -> { joins(:permissions).where({ permissions: { level: 'owner' } }).distinct }, through: :permissions, source: :user
   has_and_belongs_to_many :sites, -> { distinct }
+  has_many :regions, inverse_of: :project
   has_and_belongs_to_many :saved_searches, inverse_of: :projects
   has_many :analysis_jobs, through: :saved_searches
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class Region < ApplicationRecord
+  # ensures that creator_id, updater_id, deleter_id are set
+  include UserChange
+
+  # relations
+  has_many :sites, inverse_of: :region
+
+  belongs_to :project, inverse_of: :regions
+  belongs_to :creator, class_name: 'User', foreign_key: :creator_id, inverse_of: :created_regions
+  belongs_to :updater, class_name: 'User', foreign_key: :updater_id, inverse_of: :updated_regions, optional: true
+  belongs_to :deleter, class_name: 'User', foreign_key: :deleter_id, inverse_of: :deleted_regions, optional: true
+
+  # add deleted_at and deleter_id
+  acts_as_paranoid
+  validates_as_paranoid
+
+  # attribute validations
+  validates :name, presence: true, length: { minimum: 2 }
+
+  def self.filter_settings
+    common_fields = [:id, :name, :description, :notes, :creator_id, :created_at, :updater_id, :updated_at, :deleter_id, :deleted_at, :project_id]
+    {
+      valid_fields: common_fields,
+      render_fields: common_fields,
+      text_fields: [:name, :description],
+      custom_fields: lambda { |item, _user|
+        extra_fields = {
+          site_ids: item.sites.pluck(:id).flatten,
+          **item.render_markdown_for_api_for(:description)
+        }
+        [item, extra_fields]
+      },
+      new_spec_fields: lambda { |_user|
+        {
+          name: nil,
+          description: nil,
+          notes: nil,
+          project_id: nil
+        }
+      },
+      controller: :regions,
+      action: :filter,
+      defaults: {
+        order_by: :name,
+        direction: :asc
+      },
+      valid_associations: [
+        {
+          join: Project,
+          on: Region.arel_table[:project_id].eq(Project.arel_table[:id]),
+          available: true
+        },
+        {
+          join: Site,
+          on: Region.arel_table[:id].eq(Site.arel_table[:id]),
+          available: true
+        }
+      ]
+    }
+  end
+
+  def self.schema
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { '$ref' => '#/components/schemas/id', readOnly: true },
+        name: { type: 'string' },
+        **Api::Schema.rendered_markdown(:description),
+        **Api::Schema.all_user_stamps,
+        notes: { type: 'object' },
+        project_id: { '$ref' => '#/components/schemas/id' },
+        site_ids: { type: 'array', items: { '$ref' => '#/components/schemas/id' } }
+      },
+      required: [
+        :id,
+        :name,
+        :notes,
+        :project_id,
+        :description,
+        :description_html,
+        :description_html_tagline,
+        :creator_id,
+        :created_at,
+        :updater_id,
+        :updated_at,
+        :deleter_id,
+        :deleted_at,
+        :site_ids
+      ]
+    }.freeze
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,10 @@ class User < ApplicationRecord
   has_many :updated_projects, class_name: 'Project', foreign_key: :updater_id, inverse_of: :updater
   has_many :deleted_projects, class_name: 'Project', foreign_key: :deleter_id, inverse_of: :deleter
 
+  has_many :created_regions, class_name: 'Region', foreign_key: :creator_id, inverse_of: :creator
+  has_many :updated_regions, class_name: 'Region', foreign_key: :updater_id, inverse_of: :updater
+  has_many :deleted_regions, class_name: 'Region', foreign_key: :deleter_id, inverse_of: :deleter
+
   has_many :created_scripts, class_name: 'Script', foreign_key: :creator_id, inverse_of: :creator
 
   has_many :created_sites, class_name: 'Site', foreign_key: :creator_id, inverse_of: :creator

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.active_storage.service = :local
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,4 +101,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_storage.service = :local
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -92,4 +92,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_storage.service = :local
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,8 +62,9 @@ Rails.application.configure do
   # Paperclip default location in tmp, so it can be cleared after test suite is run
   Paperclip::Attachment.default_options[:path] = ':rails_root/tmp/paperclip:url'
 
-
   config.after_initialize do
   end
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_storage.service = :local
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,11 +139,9 @@ Rails.application.routes.draw do
   # audio_recording_uploader: /projects/:project_id/sites/:site_id/audio_recordings/check_uploader/:uploader_id
   # audio_recording_update_status: /audio_recordings/:id/update_status
 
-  # endpoints used by client:
-  # see:  https://github.com/QutBioacoustics/baw-client/blob/master/src/baw.paths.nobuild.js#L3
-
   # placed above related resource so it does not conflict with (resource)/:id => (resource)#show
   match 'projects/filter' => 'projects#filter', via: [:get, :post], defaults: { format: 'json' }
+  match 'projects/:project_id/regions/filter' => 'regions#filter', via: [:get, :post], defaults: { format: 'json' }
   match 'projects/:project_id/sites/filter' => 'sites#filter', via: [:get, :post], defaults: { format: 'json' }
 
   # routes for projects and nested resources
@@ -175,6 +173,9 @@ Rails.application.routes.draw do
     end
     # API project sites list
     resources :sites, only: [:index], defaults: { format: 'json' }
+
+    # API only: regions
+    resources :regions, except: [:edit], defaults: { format: 'json' }
   end
 
   # placed above related resource so it does not conflict with (resource)/:id => (resource)#show
@@ -259,11 +260,14 @@ Rails.application.routes.draw do
 
   # path for orphaned sites
   get 'sites/orphans' => 'sites#orphans'
-  post 'sites/orphans/filter' => 'sites#orphans'
+  match 'sites/orphans/filter' => 'sites#orphans', via: [:get, :post], defaults: { format: 'json' }
 
   # shallow path to sites
 
   resources :sites, except: [:edit], defaults: { format: 'json' }, as: 'shallow_site'
+
+  match 'regions/filter' => 'regions#filter', via: [:get, :post], defaults: { format: 'json' }
+  resources :regions, except: [:edit], defaults: { format: 'json' }, as: 'shallow_region'
 
   match 'datasets/:dataset_id/progress_events/audio_recordings/:audio_recording_id/start/:start_time_seconds/end/:end_time_seconds' =>
     'progress_events#create_by_dataset_item_params',

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,3 @@
+local:
+  service: Disk
+  root: <%= Rails.root / 'public' / 'system' / 'active_storage' %>

--- a/db/migrate/20200831130746_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200831130746_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20200901011916_create_regions.rb
+++ b/db/migrate/20200901011916_create_regions.rb
@@ -1,0 +1,28 @@
+class CreateRegions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :regions do |t|
+      t.string :name
+      t.text :description
+      t.jsonb :notes
+
+      t.integer :project_id, null: false
+
+      t.integer :creator_id
+      t.integer :updater_id
+      t.integer :deleter_id
+
+      t.timestamps null: true
+      t.datetime :deleted_at
+    end
+
+    change_table :sites do |t|
+      t.integer :region_id, null: true
+    end
+
+    add_foreign_key :regions, :projects
+    add_foreign_key :regions, :users, column: :creator_id
+    add_foreign_key :regions, :users, column: :updater_id
+    add_foreign_key :regions, :users, column: :deleter_id
+    add_foreign_key :sites, :regions
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -644,6 +644,44 @@ CREATE TABLE public.questions_studies (
 
 
 --
+-- Name: regions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.regions (
+    id bigint NOT NULL,
+    name character varying,
+    description text,
+    notes jsonb,
+    project_id integer NOT NULL,
+    creator_id integer,
+    updater_id integer,
+    deleter_id integer,
+    created_at timestamp(6) without time zone,
+    updated_at timestamp(6) without time zone,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: regions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.regions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: regions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.regions_id_seq OWNED BY public.regions.id;
+
+
+--
 -- Name: responses; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -783,7 +821,8 @@ CREATE TABLE public.sites (
     updated_at timestamp without time zone,
     description text,
     tzinfo_tz character varying(255),
-    rails_tz character varying(255)
+    rails_tz character varying(255),
+    region_id integer
 );
 
 
@@ -1074,6 +1113,13 @@ ALTER TABLE ONLY public.questions ALTER COLUMN id SET DEFAULT nextval('public.qu
 
 
 --
+-- Name: regions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.regions ALTER COLUMN id SET DEFAULT nextval('public.regions_id_seq'::regclass);
+
+
+--
 -- Name: responses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1255,6 +1301,14 @@ ALTER TABLE ONLY public.projects
 
 ALTER TABLE ONLY public.questions
     ADD CONSTRAINT questions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: regions regions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.regions
+    ADD CONSTRAINT regions_pkey PRIMARY KEY (id);
 
 
 --
@@ -2167,11 +2221,35 @@ ALTER TABLE ONLY public.analysis_jobs_items
 
 
 --
+-- Name: sites fk_rails_8829b783ca; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sites
+    ADD CONSTRAINT fk_rails_8829b783ca FOREIGN KEY (region_id) REFERENCES public.regions(id);
+
+
+--
+-- Name: regions fk_rails_a2bcbc219c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.regions
+    ADD CONSTRAINT fk_rails_a2bcbc219c FOREIGN KEY (deleter_id) REFERENCES public.users(id);
+
+
+--
 -- Name: responses fk_rails_a7a3c29a3c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.responses
     ADD CONSTRAINT fk_rails_a7a3c29a3c FOREIGN KEY (creator_id) REFERENCES public.users(id);
+
+
+--
+-- Name: regions fk_rails_a93b9e488e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.regions
+    ADD CONSTRAINT fk_rails_a93b9e488e FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
 --
@@ -2220,6 +2298,22 @@ ALTER TABLE ONLY public.dataset_items
 
 ALTER TABLE ONLY public.progress_events
     ADD CONSTRAINT fk_rails_cf446a18ca FOREIGN KEY (creator_id) REFERENCES public.users(id);
+
+
+--
+-- Name: regions fk_rails_e89672d43e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.regions
+    ADD CONSTRAINT fk_rails_e89672d43e FOREIGN KEY (creator_id) REFERENCES public.users(id);
+
+
+--
+-- Name: regions fk_rails_f67676d1b2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.regions
+    ADD CONSTRAINT fk_rails_f67676d1b2 FOREIGN KEY (updater_id) REFERENCES public.users(id);
 
 
 --
@@ -2452,6 +2546,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200625025540'),
 ('20200625040615'),
 ('20200714005247'),
-('20200831130746');
+('20200831130746'),
+('20200901011916');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -34,6 +34,74 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.active_storage_attachments (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    record_type character varying NOT NULL,
+    record_id bigint NOT NULL,
+    blob_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: active_storage_attachments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.active_storage_attachments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: active_storage_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.active_storage_attachments_id_seq OWNED BY public.active_storage_attachments.id;
+
+
+--
+-- Name: active_storage_blobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.active_storage_blobs (
+    id bigint NOT NULL,
+    key character varying NOT NULL,
+    filename character varying NOT NULL,
+    content_type character varying,
+    metadata text,
+    byte_size bigint NOT NULL,
+    checksum character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: active_storage_blobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.active_storage_blobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: active_storage_blobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.active_storage_blobs_id_seq OWNED BY public.active_storage_blobs.id;
+
+
+--
 -- Name: analysis_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -901,6 +969,20 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
+-- Name: active_storage_attachments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('public.active_storage_attachments_id_seq'::regclass);
+
+
+--
+-- Name: active_storage_blobs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('public.active_storage_blobs_id_seq'::regclass);
+
+
+--
 -- Name: analysis_jobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1045,6 +1127,22 @@ ALTER TABLE ONLY public.tags ALTER COLUMN id SET DEFAULT nextval('public.tags_id
 --
 
 ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_storage_attachments
+    ADD CONSTRAINT active_storage_attachments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: active_storage_blobs active_storage_blobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_storage_blobs
+    ADD CONSTRAINT active_storage_blobs_pkey PRIMARY KEY (id);
 
 
 --
@@ -1284,6 +1382,27 @@ CREATE UNIQUE INDEX bookmarks_name_creator_id_uidx ON public.bookmarks USING btr
 --
 
 CREATE INDEX dataset_items_idx ON public.dataset_items USING btree (start_time_seconds, end_time_seconds);
+
+
+--
+-- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_active_storage_attachments_on_blob_id ON public.active_storage_attachments USING btree (blob_id);
+
+
+--
+-- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON public.active_storage_attachments USING btree (record_type, record_id, name, blob_id);
+
+
+--
+-- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON public.active_storage_blobs USING btree (key);
 
 
 --
@@ -2072,6 +2191,14 @@ ALTER TABLE ONLY public.datasets
 
 
 --
+-- Name: active_storage_attachments fk_rails_c3b3935057; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_storage_attachments
+    ADD CONSTRAINT fk_rails_c3b3935057 FOREIGN KEY (blob_id) REFERENCES public.active_storage_blobs(id);
+
+
+--
 -- Name: questions_studies fk_rails_c7ae81b3ab; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2324,6 +2451,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200612004608'),
 ('20200625025540'),
 ('20200625040615'),
-('20200714005247');
+('20200714005247'),
+('20200831130746');
 
 

--- a/spec/api/regions_spec.rb
+++ b/spec/api/regions_spec.rb
@@ -1,0 +1,191 @@
+require 'swagger_helper'
+
+describe 'regions', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Region
+  which_has_schema ref(:region)
+
+  path '/regions/filter' do
+    post('filter region') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/regions' do
+    get('list regions') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create region') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/regions/new' do
+    get('new region') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/regions/{id}' do
+    with_id_route_parameter
+    let(:id) { region.id }
+
+    get('show region') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(region)
+        end
+      end
+    end
+
+    patch('update region') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(region)
+        end
+      end
+    end
+
+    put('update region') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(region)
+        end
+      end
+    end
+
+    delete('delete region') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end
+
+describe 'regions (nested)', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+  for_model Region
+  which_has_schema ref(:region)
+
+  let(:project_id) { project.id }
+  with_route_parameter(:project_id)
+
+  path '/projects/{project_id}/regions/filter' do
+    post('filter region') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+  end
+
+  path '/projects/{project_id}/regions' do
+    get('list regions') do
+      response(200, 'successful') do
+        schema_for_many
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+    end
+
+    post('create region') do
+      model_sent_as_parameter_in_body
+      response(201, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test!
+      end
+    end
+  end
+
+  path '/projects/{project_id}/regions/new' do
+    get('new region') do
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+  end
+
+  path '/projects/{project_id}/regions/{id}' do
+    with_route_parameter(:project_id)
+    with_id_route_parameter
+    let(:id) { region.id }
+
+    get('show region') do
+      response(200, 'successful') do
+        schema_for_single
+        run_test! do
+          expect_id_matches(region)
+        end
+      end
+    end
+
+    patch('update region') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(region)
+        end
+      end
+    end
+
+    put('update region') do
+      model_sent_as_parameter_in_body
+      response(200, 'successful') do
+        schema_for_single
+        auto_send_model
+        run_test! do
+          expect_id_matches(region)
+        end
+      end
+    end
+
+    delete('delete region') do
+      response(204, 'successful') do
+        schema nil
+        run_test! do
+          expect_empty_body
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/region_factory.rb
+++ b/spec/factories/region_factory.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :region do
+    sequence(:name) { |n| "region name #{n}" }
+    sequence(:description) { |n| "site **description** #{n}" }
+    sequence(:notes) { |n| { "region_note_#{n}" => n } }
+
+    project
+
+    creator
+  end
+end

--- a/spec/helpers/creation.rb
+++ b/spec/helpers/creation.rb
@@ -15,6 +15,7 @@ module Creation
       prepare_tag
       prepare_script
 
+      prepare_region
       prepare_site
 
       prepare_audio_recording
@@ -205,8 +206,12 @@ module Creation
       }
     end
 
+    def prepare_region
+      let!(:region) { Common.create_region(owner_user, project) }
+    end
+
     def prepare_site
-      let!(:site) { Common.create_site(owner_user, project) }
+      let!(:site) { Common.create_site(owner_user, project, region: region) }
     end
 
     def prepare_permission_owner
@@ -334,9 +339,14 @@ module Creation
         FactoryBot.create(:project, creator: creator)
       end
 
-      def create_site(creator, project)
+      def create_region(creator, project)
+        FactoryBot.create(:region, creator: creator, project: project)
+      end
+
+      def create_site(creator, project, region: nil)
         site = FactoryBot.create(:site, :with_lat_long, creator: creator)
         site.projects << project
+        site.region = region unless region.nil?
         site.save!
         site
       end

--- a/spec/helpers/creation.rb
+++ b/spec/helpers/creation.rb
@@ -95,6 +95,7 @@ module Creation
       prepare_permission_writer
       prepare_permission_reader
 
+      prepare_region
       prepare_site
 
       prepare_audio_recording

--- a/spec/helpers/factory_bot_helpers.rb
+++ b/spec/helpers/factory_bot_helpers.rb
@@ -8,11 +8,11 @@ module Baw
     # The schema parameter must be a hash of a json-schema-style structure.
     # @param factory - the name of a factory to use instead of model_name
     # @param subset - an array of properties to keep, further filtering on the schema's writeable properties
-    def body_attributes_for(model_name, factory: nil, subset: nil)
+    def body_attributes_for(model_name, factory: nil, subset: nil, factory_args: {})
       schema = model_name.to_s.classify.constantize.schema if schema.nil?
       # was using attributes_for here but it doesn't include associations!
       # full = attributes_for(model_name)
-      full = build(factory || model_name).attributes.symbolize_keys
+      full = build(factory || model_name, **factory_args).attributes.symbolize_keys
       writeable = schema[:properties]
                   .reject { |_key, value| value[:readOnly] }
                   .keys

--- a/spec/helpers/permissions_helper.rb
+++ b/spec/helpers/permissions_helper.rb
@@ -4,15 +4,16 @@ module PermissionsGroupHelpers
   STANDARD_ACTIONS = Set[:index, :show, :create, :update, :destroy, :filter, :new].freeze
   STANDARD_USERS = Set[:admin, :harvester, :owner, :writer, :reader, :no_access, :invalid, :anonymous].freeze
 
-  mattr_accessor :registered_users, :route, :route_params, :factory, :model_name, :expected_list_items_callback, :update_attrs_subset
+  mattr_accessor :registered_users, :route, :route_params, :factory, :factory_args, :model_name, :expected_list_items_callback, :update_attrs_subset
 
   def given_the_route(route, &route_params)
     self.route = route
     self.route_params = route_params
   end
 
-  def using_the_factory(factory, model_name: factory)
+  def using_the_factory(factory, model_name: factory, factory_args: nil)
     self.factory = factory
+    self.factory_args = factory_args
     self.model_name = model_name
   end
 
@@ -72,6 +73,7 @@ module PermissionsGroupHelpers
         user: user,
         actions: actions,
         factory: factory,
+        factory_args: factory_args,
         model_name: model_name,
         expected_list_items_callback: expected_list_items_callback,
         update_attrs_subset: update_attrs_subset
@@ -198,6 +200,14 @@ RSpec.shared_examples :permissions_for do |options|
     options[:factory]
   }
 
+  let(:factory_args) {
+    if options[:factory_args].nil?
+      {}
+    else
+      instance_exec(&options[:factory_args])
+    end
+  }
+
   let(:model_name) {
     options[:model_name]
   }
@@ -233,10 +243,10 @@ RSpec.shared_examples :permissions_for do |options|
     # some endpoints require a valid body is included
     case action
     when :create
-      body = body_attributes_for(model_name, factory: factory)
+      body = body_attributes_for(model_name, factory: factory, factory_args: factory_args)
       as = :json
     when :update
-      body = body_attributes_for(model_name, factory: factory, subset: update_attrs_subset)
+      body = body_attributes_for(model_name, factory: factory, subset: update_attrs_subset, factory_args: factory_args)
       as = :json
     else
       body = nil

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,6 +8,7 @@ describe Project, type: :model do
   end
 
   it { is_expected.to have_many :permissions }
+  it { is_expected.to have_many :regions }
   it { is_expected.to have_and_belong_to_many :sites }
 
   it { is_expected.to belong_to(:creator).with_foreign_key(:creator_id) }

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Region, type: :model do
+  it 'has a valid factory' do
+    expect(FactoryBot.create(:region)).to be_valid
+  end
+  it 'is invalid without a name' do
+    expect(FactoryBot.build(:region, name: nil)).not_to be_valid
+  end
+  it 'requires a name with at least two characters' do
+    s = FactoryBot.build(:region, name: 's')
+    expect(s).not_to be_valid
+    expect(s.valid?).to be_falsey
+    expect(s.errors[:name].size).to eq(1)
+  end
+
+  it { is_expected.to belong_to(:project) }
+  it { is_expected.to have_many(:sites) }
+  it { is_expected.to belong_to(:creator).with_foreign_key(:creator_id) }
+  it { is_expected.to belong_to(:updater).with_foreign_key(:updater_id).optional }
+  it { is_expected.to belong_to(:deleter).with_foreign_key(:deleter_id).optional }
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -93,7 +93,7 @@ describe Site, type: :model do
     }
   end
   it { is_expected.to have_and_belong_to_many :projects }
-
+  it { is_expected.to belong_to(:region).optional }
   it { is_expected.to belong_to(:creator).with_foreign_key(:creator_id) }
   it { is_expected.to belong_to(:updater).with_foreign_key(:updater_id).optional }
   it { is_expected.to belong_to(:deleter).with_foreign_key(:deleter_id).optional }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,6 +34,10 @@ describe User, type: :model do
     expect(User.new).to be_a_kind_of(TimeZoneAttribute)
   end
 
+  it { is_expected.to have_many(:created_regions) }
+  it { is_expected.to have_many(:updated_regions) }
+  it { is_expected.to have_many(:deleted_regions) }
+
   #pending "add some examples to (or delete) #{__FILE__}"
 
   # this should pass, but the paperclip implementation of validate_attachment_content_type is buggy.

--- a/spec/requests/permissions/regions_spec.rb
+++ b/spec/requests/permissions/regions_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe 'Region permissions' do
+  create_entire_hierarchy
+
+  given_the_route '/regions' do
+    {
+      id: region.id
+    }
+  end
+  using_the_factory :region, factory_args: -> { { project_id: project.id } }
+  for_lists_expects do |user, _action|
+    case user
+    when :admin
+      Region.all
+    when :owner, :reader, :writer
+      region
+    else
+      []
+    end
+  end
+
+  the_users :admin, :owner, can_do: everything
+  the_users :writer, :reader, can_do: reading, and_cannot_do: writing
+
+  the_user :no_access, can_do: listing, and_cannot_do: not_listing
+
+  the_user :harvester, can_do: nothing, and_cannot_do: everything
+
+  the_user :anonymous, can_do: listing, and_cannot_do: not_listing, fails_with: :unauthorized
+
+  the_user :invalid, can_do: nothing, and_cannot_do: everything, fails_with: :unauthorized
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -153,7 +153,8 @@ RSpec.configure do |config|
           dataset: Dataset.schema,
           saved_search: SavedSearch.schema,
           script: Script.schema,
-          site: Site.schema
+          site: Site.schema,
+          region: Region.schema
         }
       }
     }

--- a/spec/unit/active_storage.rb
+++ b/spec/unit/active_storage.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Active storage' do
+  it 'should have an active storage configuration' do
+    expect(Rails.configuration.active_storage).to_not be_nil
+  end
+
+  it 'should be using disk' do
+    expect(Rails.configuration.active_storage.service).to be(:local)
+  end
+
+  it 'should be using disk' do
+    expect(ActiveStorage::Blob.service).to be_a_kind_of(ActiveStorage::Service::DiskService)
+  end
+end


### PR DESCRIPTION
# Adds regions …

Closes #383

In an ideal world our 'sites' table would be named 'points' and if we had sites they would represent an area/region of study where several sensors were deployed as points.

However, we do have a concept of a point named with the term 'site'. Correcting this mistake is prohibitively expensive.

Instead we know introduce the concept of a region. A region is an area of study, usually small, where a group of related sensors are deployed as 'sites'. A region as introduced here is consistent with the ecological definition of a site.

We also desperately wanted to avoid changing the hierarchy in the app - especially with all the complexities involved with sites<->projects. So this means it is optional for a site to belong to a region.

This idea was previously named site_groups because really all this region concept is a logical grouping of sites.

## Changes

Adding a new table, model, and nested/shallow API only endpoints

## Problems

- No image attachment yet


## Visual Changes

N/A

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
