### PR TITLE
Fixes stats page and adds stats endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,19 @@ AllCops:
     - '**/*.rb'
   TargetRubyVersion: 3.1
   NewCops: enable
+# Bug in rubocop-rspec config merge: https://github.com/rubocop/rubocop-rspec/pull/1163
+# RSpec:
+#   inherit_mode:
+#     override:
+#       - Merge
+#   Language:
+#     ExampleGroups:
+#       # rswag example group aliases
+#       - path
+#       - get
+#       - push
+#       - post
+#       - delete
 
 # Customized options
 Lint/DeprecatedOpenSSLConstant:

--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :server do
   gem 'pg'
 
   # extensions to arel https://github.com/Faveod/arel-extensions
-  # in particular, we use `cast`
+  # in particular, we use `cast`, and `coalesce`
   gem 'arel_extensions'
 
   # MODELS

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -20,6 +20,8 @@ class StatsController < ApiController
 
   def self.fetch_stats(current_user)
     online_window = 2.hours.ago
+    recent_window = 1.month.ago
+    recent_limit = 10
     {
       summary: {
         users_online: User.recently_seen(online_window).count,
@@ -27,17 +29,17 @@ class StatsController < ApiController
         online_window_start: online_window,
         annotations_total: AudioEvent.count,
         annotations_total_duration: AudioEvent.total_duration_seconds,
-        annotations_recent: AudioEvent.recent_within(1.month.ago).count,
+        annotations_recent: AudioEvent.recent_within(recent_window).count,
         audio_recording_total: AudioRecording.count,
-        audio_recording_recent: AudioRecording.created_within(1.month.ago).count,
+        audio_recording_recent: AudioRecording.created_within(recent_window).count,
         audio_recording_total_duration: AudioRecording.total_duration_seconds,
         audio_recording_total_size: AudioRecording.total_data_bytes.to_i,
         tags_total: Tag.count,
         tags_applied_total: Tagging.count
       },
       recent: {
-        audio_recordings: Access::ByPermission.audio_recordings(current_user).most_recent(10),
-        audio_events: Access::ByPermission.audio_events(current_user).most_recent(10)
+        audio_recordings: Access::ByPermission.audio_recordings(current_user).most_recent(recent_limit),
+        audio_events: Access::ByPermission.audio_events(current_user).most_recent(recent_limit)
       }
     }
   end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Controller for the stats endpoint
+class StatsController < ApiController
+  skip_authorization_check only: [:index]
+
+  # GET /stats
+  # only returns json
+  def index
+    result = StatsController.fetch_stats(current_user)
+
+    # Simplify the response, by mutation. Show only ids from active record models.
+    result[:recent].transform_values! do |query|
+      query.pluck(:id)
+    end
+
+    built_response = Settings.api_response.build(:ok, result)
+    render json: built_response, status: :ok, layout: false
+  end
+
+  def self.fetch_stats(current_user)
+    online_window = 2.hours.ago
+    {
+      summary: {
+        users_online: User.recently_seen(online_window).count,
+        users_total: User.count,
+        online_window_start: online_window,
+        annotations_total: AudioEvent.count,
+        annotations_total_duration: AudioEvent.total_duration_seconds,
+        annotations_recent: AudioEvent.recent_within(1.month.ago).count,
+        audio_recording_total: AudioRecording.count,
+        audio_recording_recent: AudioRecording.created_within(1.month.ago).count,
+        audio_recording_total_duration: AudioRecording.total_duration_seconds,
+        audio_recording_total_size: AudioRecording.total_data_bytes.to_i,
+        tags_total: Tag.count,
+        tags_applied_total: Tagging.count
+      },
+      recent: {
+        audio_recordings: Access::ByPermission.audio_recordings(current_user).most_recent(10),
+        audio_events: Access::ByPermission.audio_events(current_user).most_recent(10)
+      }
+    }
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+# Base record for all models
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   include AlphabeticalPaginatorQuery
   include RendersMarkdown
+  include TimestampHelpers
 end

--- a/app/modules/timestamp_helpers.rb
+++ b/app/modules/timestamp_helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Extension methods for ActiveRecord models with timestamps
+module TimestampHelpers
+  extend ActiveSupport::Concern
+  include ActiveRecord::Timestamp
+
+  # only define method if the attributes needed exist
+  # https://github.com/rails/rails/blob/v6.1.3.2/activerecord/lib/active_record/timestamp.rb
+
+  included do |_base|
+    next unless record_timestamps
+
+    # translates to:
+    # COALESCE(XXX.updated_at, XXX.created_at)
+    def self.arel_updated_or_created
+      if respond_to?(:updated_at)
+        arel_table[:updated_at].coalesce(arel_table[:created_at])
+      else
+        arel_table[:created_at]
+      end
+    end
+
+    scope :most_recent, ->(limit) { order(arel_updated_or_created.desc).limit(limit) }
+    scope :created_within, ->(time) { where(arel_table[:created_at] > time) }
+    scope :recent_within, ->(time) { where(arel_updated_or_created > time) }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -704,6 +704,7 @@ Rails.application.routes.draw do
   # site status API
   get '/status/' => 'status#index', defaults: { format: 'json' }
   get '/website_status/' => 'public#website_status'
+  get '/stats/' => 'stats#index', defaults: { format: 'json' }
 
   # feedback and contact forms
   get '/contact_us' => 'public#new_contact_us'

--- a/spec/api/stats_spec.rb
+++ b/spec/api/stats_spec.rb
@@ -2,8 +2,7 @@
 
 require 'swagger_helper'
 
-# the cms service is provided by a third party, hence its API
-# varies from our common format.
+# the stats service does not return a model, and has no C-UD, only -R-- (Read).
 describe 'stats', type: :request do
   let(:skip_automatic_description) { true }
 

--- a/spec/api/stats_spec.rb
+++ b/spec/api/stats_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+# the cms service is provided by a third party, hence its API
+# varies from our common format.
+describe 'stats', type: :request do
+  let(:skip_automatic_description) { true }
+
+  path '/stats' do
+    get 'Gets stats' do
+      tags 'stats'
+      produces 'application/json'
+      response '200', 'stats retrieved' do
+        schema schema allOf: [
+          { '$ref' => '#/components/schemas/standard_response' },
+          {
+            type: 'object',
+            properties: {
+              data: { '$ref' => '#/components/schemas/stats' }
+            }
+          }
+        ]
+
+        run_test! do
+          expect_json_response
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/permissions/stats_spec.rb
+++ b/spec/requests/permissions/stats_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe 'Stats permissions' do
+  create_entire_hierarchy
+
+  given_the_route '/stats' do
+    {}
+  end
+
+  send_create_body do
+    [{}, :json]
+  end
+
+  send_update_body do
+    [{}, :json]
+  end
+
+  custom_index = {
+    path: '',
+    verb: :get,
+    expect: lambda { |_user, _action|
+              expect(api_response).to include({
+                summary: a_hash
+              })
+            },
+    action: :index
+  }
+
+  ensures :admin, :owner, :writer, :reader, :no_access, :harvester, :anonymous, :invalid,
+          can: [custom_index],
+          cannot: [:create, :update, :destroy],
+          fails_with: :not_found
+end

--- a/spec/requests/permissions/status_spec.rb
+++ b/spec/requests/permissions/status_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe 'Status permissions' do
+  create_entire_hierarchy
+
+  given_the_route '/status' do
+    {}
+  end
+
+  send_create_body do
+    [{}, :json]
+  end
+
+  send_update_body do
+    [{}, :json]
+  end
+
+  custom_index = {
+    path: '',
+    verb: :get,
+    expect: lambda { |_user, _action|
+              expect(api_response).to include({
+                status: 'good'
+              })
+            },
+    action: :index
+  }
+
+  ensures :admin, :owner, :writer, :reader, :no_access, :harvester, :anonymous, :invalid,
+          can: [custom_index],
+          cannot: [:create, :update, :destroy],
+          fails_with: :not_found
+end

--- a/spec/requests/stats_spec.rb
+++ b/spec/requests/stats_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe '/stats' do
+  create_audio_recordings_hierarchy
+  prepare_audio_event
+  prepare_tag
+  prepare_audio_events_tags
+  prepare_dataset
+  create_anon_hierarchy
+  let!(:reference_event) { FactoryBot.create(:audio_event, is_reference: true) }
+
+  it 'can fetch stats' do
+    get '/stats'
+
+    expect_success
+    expect(api_data).to match({
+      summary: {
+        users_online: 0,
+        users_total: 10,
+        online_window_start: an_instance_of(String),
+        annotations_total: 2,
+        annotations_total_duration: 2.0,
+        annotations_recent: 2,
+        audio_recording_total: 3,
+        audio_recording_recent: 3,
+        audio_recording_total_duration: 180_000.0,
+        audio_recording_total_size: 11_400,
+        tags_total: 1,
+        tags_applied_total: 1
+      },
+      recent: {
+        audio_recordings: [2],
+        audio_events: [reference_event.id]
+      }
+    })
+  end
+end

--- a/spec/routing/stats_routing_spec.rb
+++ b/spec/routing/stats_routing_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe StatsController, type: :routing do
+  it { expect(get('/stats')).to route_to('stats#index', format: 'json') }
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-
-
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
@@ -191,6 +189,43 @@ RSpec.configure do |config|
                     full_path: { type: 'string', format: 'uri-reference' }
                   },
                   additionalProperties: false
+                }
+              }
+            },
+            additionalProperties: false
+          },
+          stats: {
+            type: 'object',
+            required: [:summary, :recent],
+            properties: {
+              summary: {
+                type: 'object',
+                properties: {
+                  users_online: { type: 'integer' },
+                  users_total: { type: 'integer' },
+                  online_window_start: { type: 'string', format: 'date-time', readOnly: true },
+                  annotations_total: { type: 'integer' },
+                  annotations_total_duration: { type: 'number' },
+                  annotations_recent: { type: 'integer' },
+                  audio_recording_total: { type: 'integer' },
+                  audio_recording_recent: { type: 'integer' },
+                  audio_recording_total_duration: { type: 'number' },
+                  audio_recording_total_size: { type: 'integer' },
+                  tags_total: { type: 'integer' },
+                  tags_applied_total: { type: 'integer' }
+                }
+              },
+              recent: {
+                type: 'object',
+                properties: {
+                  audio_recordings: {
+                    type: 'array',
+                    items: { '$ref' => '#/components/schemas/id' }
+                  },
+                  audio_events: {
+                    type: 'array',
+                    items: { '$ref' => '#/components/schemas/id' }
+                  }
                 }
               }
             },


### PR DESCRIPTION
# Fixes stats page and adds stats endpoint

Fixes #523,  Closes #413

## Changes

Factored stats out into it's own controller for neatness.

Had to maintain backwards compatibility with old website_status view, but it should be easy enough to rip that out later.

Added some generic scopes to any model that implements the timestamps protocol.

Removed all raw SQL from the stats queries.

## Problems

N/A

## Visual Changes

N/A

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
