### PR TITLE
Adds original download capability

### DIFF
--- a/app/models/audio_recording.rb
+++ b/app/models/audio_recording.rb
@@ -365,6 +365,17 @@ class AudioRecording < ApplicationRecord
           value: arel_recorded_end_date
         }
       ],
+      capabilities: {
+        original_download: {
+          #can_list: ->(klass) { Current.ability.can?(:original, klass) },
+          can_item: ->(item) { Current.ability.can?(:original, item) },
+          details: lambda { |can, _item, _klass|
+                     unless can
+                       'You do not have permission to download the original audio recording. Check your access level or the original download settings for this project'
+                     end
+                   }
+        }
+      },
       valid_associations: [
         {
           join: AudioEvent,

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -3,5 +3,13 @@
 # New in Rails 5.2, the "current" concept.
 # https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html#method-c-attribute
 class Current < ActiveSupport::CurrentAttributes
+  # @!attribute [rw] user
+  #   @return [User]
   attribute :user
+  # @!attribute [rw] ability
+  #   @return [Ability]
+  attribute :ability
+
+  # @!parse
+  #   extend self
 end

--- a/app/modules/api/controller_helper.rb
+++ b/app/modules/api/controller_helper.rb
@@ -66,6 +66,9 @@ module Api
       items = get_resource_plural.map { |item|
         Settings.api_response.prepare(item, current_user, opts)
       }
+
+      Settings.api_response.add_capabilities!(opts, resource_class)
+
       built_response = Settings.api_response.build(:ok, items, opts)
       render json: built_response, status: :ok, layout: false
     end
@@ -76,7 +79,10 @@ module Api
 
       item = Settings.api_response.prepare(item_resource, current_user)
 
-      built_response = Settings.api_response.build(:ok, item)
+      opts = {}
+      Settings.api_response.add_capabilities!(opts, resource_class, item_resource)
+
+      built_response = Settings.api_response.build(:ok, item, opts)
       render json: built_response, status: :ok, layout: false
     end
 
@@ -85,7 +91,11 @@ module Api
 
       item = Settings.api_response.prepare_new(item_resource, current_user)
 
-      built_response = Settings.api_response.build(:ok, item)
+      opts = {}
+      # Can't think of a valid context for this currently
+      #Settings.api_response.add_capabilities!(opts, resource_class, item_resource)
+
+      built_response = Settings.api_response.build(:ok, item, opts)
       render json: built_response, status: :ok, layout: false
     end
 
@@ -94,7 +104,11 @@ module Api
 
       item = Settings.api_response.prepare(item_resource, current_user)
 
-      built_response = Settings.api_response.build(:created, item)
+      opts = {}
+
+      Settings.api_response.add_capabilities!(opts, resource_class, item_resource)
+
+      built_response = Settings.api_response.build(:created, item, opts)
       render json: built_response, status: :created, location: location.blank? ? item_resource : location, layout: false
     end
 
@@ -131,6 +145,8 @@ module Api
         Settings.api_response.prepare(item, current_user, opts)
       }
 
+      Settings.api_response.add_capabilities!(opts, resource_class)
+
       built_response = Settings.api_response.build(:ok, items, opts)
       render json: built_response, status: :ok, content_type: 'application/json', layout: false
     end
@@ -150,7 +166,7 @@ module Api
 
       # choose a subset of response to format as a request filter
       # data is discarded here
-      filter = filter_response[:meta].except(:status, :message, :paging)
+      filter = filter_response[:meta].except(:status, :message, :paging, :capabilities)
       if !opts[:page].blank? && !opts[:items].blank?
         filter[:paging] = {
           items: opts[:items]

--- a/app/modules/api/schema.rb
+++ b/app/modules/api/schema.rb
@@ -107,6 +107,25 @@ module Api
               enum: ['Owner', 'Writer', 'Reader', nil]
             },
             meta: {
+              properties: {
+                capabilities: {
+                  type: 'object',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      can: {
+                        type: ['null', 'boolean']
+                      },
+                      details: {
+                        type: 'string'
+                      }
+                    },
+                    required: [
+                      'can'
+                    ]
+                  }
+                }
+              },
               type: 'object'
             },
             meta_error: {

--- a/app/modules/filter/query.rb
+++ b/app/modules/filter/query.rb
@@ -15,7 +15,7 @@ module Filter
       :valid_fields, :text_fields, :filter_settings,
       :parameters, :filter, :projection, :qsp_text_filter,
       :qsp_generic_filters, :paging, :sorting, :build,
-      :custom_fields2
+      :custom_fields2, :capabilities
 
     # Convert a json POST body to an arel query.
     # @param [Hash] parameters
@@ -50,6 +50,7 @@ module Filter
       @default_sort_order = filter_settings[:defaults][:order_by]
       @default_sort_direction = filter_settings[:defaults][:direction]
       @custom_fields2 = filter_settings[:custom_fields2] || {}
+      @capabilities = filter_settings[:capabilities] || {}
 
       @build = Build.new(@table, filter_settings)
 

--- a/app/modules/filter/validate.rb
+++ b/app/modules/filter/validate.rb
@@ -413,6 +413,20 @@ module Filter
         end
       end
 
+      if value.include?(:capabilities)
+        validate_hash(value[:capabilities])
+        value[:capabilities].values do |capability|
+          validate_hash(capability)
+          validate_hash_key(capability, :can_list, [NilClass, Proc])
+          validate_hash_key(capability, :can_item, [NilClass, Proc])
+          validate_closure(capability[:can_list], [:klass]) if capability[:can_list]
+          validate_closure(capability[:can_item], [:item]) if capability[:can_list]
+
+          validate_hash_key(capability, :details, [Proc])
+          validate_closure(capability[:details], [:can, item, klass]) if capability[:details]
+        end
+      end
+
       validate_closure(value[:custom_fields], [:item, :user]) if value.include?(:custom_fields)
 
       if value.include?(:custom_fields2)

--- a/app/modules/set_current.rb
+++ b/app/modules/set_current.rb
@@ -6,11 +6,16 @@ module SetCurrent
 
   included do
     before_action :set_current_user
+    before_action :set_current_ability
   end
 
   private
 
   def set_current_user
     Current.user = current_user
+  end
+
+  def set_current_ability
+    Current.ability = current_ability unless current_user.nil?
   end
 end

--- a/spec/acceptance/datasets_spec.rb
+++ b/spec/acceptance/datasets_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 require 'rspec_api_documentation/dsl'
 require 'helpers/acceptance_spec_helper'
 
@@ -26,10 +25,10 @@ resource 'Datasets' do
   # Create post parameters from factory
   let(:post_attributes) { FactoryBot.attributes_for(:dataset, name: 'New Dataset name') }
 
-  # note about harvester
+  # NOTE: about harvester
   # Harvester can access filter and index, but nothing else
   # This is because no permissions have been blacklisted in by_permission.rb
-  # and no permissions have been whitelisted for harvester in ability.rb
+  # and no permissions have been allowed for harvester in ability.rb
 
   ################################
   # INDEX
@@ -43,7 +42,8 @@ resource 'Datasets' do
       :get,
       'INDEX (as admin)',
       :ok,
-      { response_body_content: ['The default dataset', 'gen_dataset'], expected_json_path: 'data/0/name', data_item_count: 2 }
+      { response_body_content: ['The default dataset', 'gen_dataset'], expected_json_path: 'data/0/name',
+        data_item_count: 2 }
     )
   end
 
@@ -55,7 +55,8 @@ resource 'Datasets' do
       :get,
       'INDEX (as reader user)',
       :ok,
-      { response_body_content: ['The default dataset', 'gen_dataset'], expected_json_path: 'data/0/name', data_item_count: 2 }
+      { response_body_content: ['The default dataset', 'gen_dataset'], expected_json_path: 'data/0/name',
+        data_item_count: 2 }
     )
   end
 

--- a/spec/acceptance/media/media_original_spec.rb
+++ b/spec/acceptance/media/media_original_spec.rb
@@ -44,9 +44,6 @@ resource 'Media/original' do
   # ORIGINAL
   ################################
   describe 'original audio download' do
-    let(:start_offset) { nil }
-    let(:end_offset) { nil }
-
     before do
       # the standard media route only allows short recordings, purposely mock a long duration to make sure long
       # original recordings succeed.
@@ -79,7 +76,7 @@ resource 'Media/original' do
       let(:authentication_token) { reader_token }
 
       standard_request_options(:get, 'ORIGINAL (as reader)', :forbidden,
-                               { expected_json_path: get_json_error_path(:permissions) })
+        { expected_json_path: get_json_error_path(:permissions) })
     end
 
     get '/audio_recordings/:audio_recording_id/original' do
@@ -88,7 +85,7 @@ resource 'Media/original' do
       let(:authentication_token) { writer_token }
 
       standard_request_options(:get, 'ORIGINAL (as writer)', :forbidden,
-                               { expected_json_path: get_json_error_path(:permissions) })
+        { expected_json_path: get_json_error_path(:permissions) })
     end
 
     get '/audio_recordings/:audio_recording_id/original' do
@@ -97,7 +94,7 @@ resource 'Media/original' do
       let(:authentication_token) { no_access_token }
 
       standard_request_options(:get, 'ORIGINAL (as no access)', :forbidden,
-                               { expected_json_path: get_json_error_path(:permissions) })
+        { expected_json_path: get_json_error_path(:permissions) })
     end
 
     get '/audio_recordings/:audio_recording_id/original' do
@@ -106,7 +103,7 @@ resource 'Media/original' do
       let(:authentication_token) { invalid_token }
 
       standard_request_options(:get, 'ORIGINAL (with invalid token)', :unauthorized,
-                               { expected_json_path: get_json_error_path(:sign_in) })
+        { expected_json_path: get_json_error_path(:sign_in) })
     end
 
     get '/audio_recordings/:audio_recording_id/original' do
@@ -115,7 +112,7 @@ resource 'Media/original' do
       let(:authentication_token) { owner_token }
 
       standard_request_options(:get, 'ORIGINAL (as owner token)', :forbidden,
-                               { expected_json_path: get_json_error_path(:permissions) })
+        { expected_json_path: get_json_error_path(:permissions) })
     end
 
     get '/audio_recordings/:audio_recording_id/original' do

--- a/spec/helpers/capabilities_helper.rb
+++ b/spec/helpers/capabilities_helper.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'helpers/shared_examples/capabilities_for'
+require 'helpers/permissions_helper'
+
+module CapabilitiesHelper
+  module ExampleGroup
+    STANDARD_USERS = PermissionsHelpers::ExampleGroup::STANDARD_USERS
+
+    def self.extended(base)
+      base.define_metadata_state(:capabilities_spec, default: {})
+
+      base.after do
+        logger.info(trace_metadata(:capabilities_spec))
+      end
+    end
+
+    def given_the_route(route, &route_params)
+      spec = get_capabilities_spec
+      spec[:route] = route
+      spec[:route_params] = route_params
+
+      set_capabilities_spec(spec)
+    end
+
+    def has_list_capability(name, can_users:, cannot_users:, unsure_users: [], unauthorized_users: [])
+      spec = get_capabilities_spec
+
+      users = normalize_users(
+        "list: #{name}",
+        can: can_users,
+        cannot: cannot_users,
+        unsure: unsure_users,
+        unauthorized: unauthorized_users
+      )
+
+      users.each do |user, can|
+        it_behaves_like 'capabilities for', {
+          route: spec[:route],
+          route_params: spec[:route_params],
+          user: user,
+          name: name,
+          expected_can: can,
+          actions: [
+            { verb: :get, path: '' },
+            { verb: :get, path: 'filter' }
+          ]
+        }
+      end
+
+      set_capabilities_spec(spec)
+    end
+
+    def has_item_capability(name, can_users:, cannot_users:, unsure_users: [], unauthorized_users: [])
+      spec = get_capabilities_spec
+
+      users = normalize_users(
+        "item: #{name}",
+        can: can_users,
+        cannot: cannot_users,
+        unsure: unsure_users,
+        unauthorized: unauthorized_users
+      )
+
+      users.each do |user, can|
+        it_behaves_like 'capabilities for', {
+          route: spec[:route],
+          route_params: spec[:route_params],
+          user: user,
+          name: name,
+          expected_can: can,
+          actions: [
+            { verb: :get, path: '{id}' }
+          ]
+        }
+      end
+
+      set_capabilities_spec(spec)
+    end
+
+    private
+
+    def validate_no_overlap(name, can:, cannot:, unsure:, unauthorized:)
+      message = "The capability spec for the `:#{name}` capability"
+      # find if there are any overlaps
+      intersection = [can, cannot, unsure, unauthorized]
+                     .combination(2)
+                     .map { |a, b| (a & b).to_a }
+                     .flatten
+      raise "#{message} has overlapping users. The following are duplicates: #{intersection}" if intersection.any?
+    end
+
+    def validate_all_users(name, can:, cannot:, unsure:, unauthorized:)
+      # find if there are any overlaps
+      all = (can + cannot + unsure + unauthorized)
+      missing = STANDARD_USERS - all
+      undefined = all - STANDARD_USERS
+      raise "Not all users tested for #{name}. The following are missing: #{missing.to_a}" unless missing.empty?
+
+      raise "Unknown user tested for #{name}. The following are undefined: #{undefined.to_a}" unless undefined.empty?
+    end
+
+    def normalize_users(name, can:, cannot:, unsure:, unauthorized:)
+      can = Set.new(can)
+      cannot = Set.new(cannot)
+      unsure = Set.new(unsure)
+
+      validate_no_overlap(name, can: can, cannot: cannot, unsure: unsure, unauthorized: unauthorized)
+      validate_all_users(name, can: can, cannot: cannot, unsure: unsure, unauthorized: unauthorized)
+
+      [
+        *can.map { |u| [u, true] },
+        *cannot.map { |u| [u, false] },
+        *unsure.map { |u| [u, nil] },
+        *unauthorized.map { |u| [u, :unauthorized] }
+      ]
+    end
+  end
+end

--- a/spec/helpers/request_spec_helpers.rb
+++ b/spec/helpers/request_spec_helpers.rb
@@ -193,10 +193,24 @@ module RequestSpecHelpers
       }))
     end
 
-    def expect_has_filter(_filter)
+    def expect_has_filter(filter)
       expect(api_result).to include(meta: hash_including({
-        filter: projection
+        filter: filter
       }))
+    end
+
+    def expect_has_capability(name, can, details = nil)
+      { can: can, details: details } => expected
+
+      expect(api_result).to include(
+        meta: hash_including(
+          {
+            capabilities: hash_including(
+              name => expected
+            )
+          }
+        )
+      )
     end
 
     def expect_success

--- a/spec/helpers/shared_context/api_spec_shared_context.rb
+++ b/spec/helpers/shared_context/api_spec_shared_context.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require "securerandom"
+
+require 'securerandom'
 
 RSpec.shared_context 'with api shared context' do
   # ensure uuid generation is stable
@@ -12,7 +13,7 @@ RSpec.shared_context 'with api shared context' do
     Zonebie.backend.zone = ::ActiveSupport::TimeZone['UTC']
     Timecop.freeze(Time.local(2020, 1, 2, 3, 4, 5.678))
     SecureRandom.singleton_class.send(:alias_method, :old_gen_random, :gen_random)
-    SecureRandom.send(:define_singleton_method,:gen_random) do |n|
+    SecureRandom.send(:define_singleton_method, :gen_random) do |n|
       n = n ? n.to_int : 16
       Array.new(n) { Kernel.rand(256) }.pack('C*')
     end
@@ -56,6 +57,8 @@ RSpec.shared_context 'with api shared context' do
       spec_example.metadata[:response][:content] = json_example
     when %r{text/plain}
       spec_example.metadata[:response][:content] = raw_example
+    when nil
+      logger.warn("Empty response; can't determine content type for example")
     else
       # add no example
       logger.debug("Not adding response example for #{response.content_type}")

--- a/spec/helpers/shared_examples/capabilities_for.rb
+++ b/spec/helpers/shared_examples/capabilities_for.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'capabilities for' do |options|
+  let(:route_params) {
+    # execute the provided block as if it were defined with this let scope
+    instance_exec(&options[:route_params])
+  }
+
+  let(:user_token) {
+    # lookup user token, e.g. reader_token, owner_token, ...
+    send("#{options[:user]}_token".to_sym)
+  }
+
+  def send_request(action, route, route_params)
+    verb = action[:verb]
+    path = action[:path]
+    path = Addressable::Template.new("#{route}/#{path}")
+    url = path.expand(route_params)
+
+    # process is the generic base method for the get, post, put, etc.. methods
+    process(verb, url, **api_headers(user_token))
+  end
+
+  def validate_result(name, expected_can)
+    details = an_instance_of(String).or(eq(nil))
+    expect_has_capability(name, expected_can, details)
+  end
+
+  # add metadata so examples can be filtered
+  can_text = case options[:expected_can]
+             when true then 'can'
+             when false then 'cannot'
+             else 'unsure'
+             end
+  context_name = "#{options[:name]} equivalent to #{can_text}"
+  # again add metadata to allow filtering by action
+  context context_name, { options[:name] => true, :capabilities => true } do
+    options[:actions].each do |action|
+      example "for the `#{options[:user]}` user, #{action}", { options[:user] => true } do
+        # first build and issue request
+        send_request(action, options[:route], route_params)
+
+        aggregate_failures 'Failures:' do
+          expected = options[:expected_can]
+
+          if expected == :unauthorized
+            if response.status == 401
+              expect_error(:unauthorized, nil)
+            else
+              expect_error(:forbidden, nil)
+            end
+          else
+            expect_success
+
+            # only validate results if we expect valid data
+            validate_result(options[:name], expected)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/solargraph.rb
+++ b/spec/helpers/solargraph.rb
@@ -23,6 +23,7 @@ RSpec.describe '', skip: true do
   extend ApiSpecHelpers::ExampleGroup
 
   extend PermissionsHelpers::ExampleGroup
+  extend CapabilitiesHelper::ExampleGroup
 
   include FactoryBotHelpers::Example
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -214,12 +214,17 @@ RSpec.configure do |config|
   config.extend PermissionsHelpers::ExampleGroup, {
     file_path: Regexp.new('/spec/requests/permissions')
   }
+  require_relative 'helpers/capabilities_helper'
+  config.extend CapabilitiesHelper::ExampleGroup, {
+    file_path: Regexp.new('/spec/requests/capabilities')
+  }
 
   require_relative 'helpers/image_helpers'
   require_relative 'helpers/sql_helpers'
 
   require_relative 'helpers/shared_examples/a_route_that_stores_images'
   require_relative 'helpers/shared_examples/permissions_for'
+  require_relative 'helpers/shared_examples/capabilities_for'
   require_relative 'helpers/shared_examples/a_stats_bucket'
 
   require "#{RSPEC_ROOT}/helpers/shared_context/baw_audio_tools_shared"

--- a/spec/requests/capabilities/README.md
+++ b/spec/requests/capabilities/README.md
@@ -1,0 +1,36 @@
+# Capabilities spec
+
+Goals of capabilities specs is to test capabilities only.
+
+- should test capabilities
+- should test capabilities for list and details endpoints
+  - lists: index, filter
+  - details: show, new, edit, update
+- all requests should return successfully
+  - we assume an errored request has already gone past the stage where a capability
+    was useful. I.e. a capability advises a client if an action is possible;
+    if the request has failed, the client has ignored (or was unable to ignore)
+    the advice.
+- should not test for spec adherence
+- should not test functionality
+- should test for various users
+
+
+The specs in this directory use a custom DSL defined by `helpers/capabilities_helper.rb`.
+
+
+## Useful filters
+
+You can use tag filtering on the rspec to only execute certain cases.
+
+For example, to only run examples for the `owner` user:
+
+```
+rspec /requests/permissions -t owner
+```
+
+Or every user except `admin`:
+
+```
+rspec /requests/permissions -t ~admin
+```

--- a/spec/requests/capabilities/audio_recordings_spec.rb
+++ b/spec/requests/capabilities/audio_recordings_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe AudioRecordings, 'capabilities' do
+  create_entire_hierarchy
+
+  given_the_route '/audio_recordings' do
+    {
+      id: audio_recording.id
+    }
+  end
+
+  shared_context 'with allow_original_downloads' do |level, can_users:, cannot_users:, unsure_users:, unauthorized_users:|
+    describe "allow_original_downloads for #{level || '<none>'}" do
+      before do
+        project.allow_original_download = level
+        project.save!
+      end
+
+      has_item_capability :original_download,
+        can_users: can_users,
+        cannot_users: cannot_users,
+        unsure_users: unsure_users,
+        unauthorized_users: unauthorized_users
+    end
+  end
+
+  include_examples 'with allow_original_downloads', nil, {
+    can_users: [:admin],
+    cannot_users: [:owner, :writer, :reader],
+    unsure_users: [],
+    unauthorized_users: [:no_access, :invalid, :anonymous, :harvester]
+  }
+
+  include_examples 'with allow_original_downloads', :reader, {
+    can_users: [:admin, :owner, :writer, :reader],
+    cannot_users: [],
+    unsure_users: [],
+    unauthorized_users: [:no_access, :invalid, :anonymous, :harvester]
+  }
+
+  include_examples 'with allow_original_downloads', :writer, {
+    can_users: [:admin, :owner, :writer],
+    cannot_users: [:reader],
+    unsure_users: [],
+    unauthorized_users: [:no_access, :invalid, :anonymous, :harvester]
+  }
+
+  include_examples 'with allow_original_downloads', :owner, {
+    can_users: [:admin, :owner],
+    cannot_users: [:writer, :reader],
+    unsure_users: [],
+    unauthorized_users: [:no_access, :invalid, :anonymous, :harvester]
+  }
+end

--- a/spec/requests/permissions/projects_spec.rb
+++ b/spec/requests/permissions/projects_spec.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 
 describe 'Project permissions' do
   create_entire_hierarchy
@@ -32,8 +32,8 @@ describe 'Project permissions' do
   the_user :invalid, can_do: nothing, and_cannot_do: everything, fails_with: :unauthorized
 
   context 'with public project creation disabled' do
-    before(:each) do
-      allow(Settings.permissions).to receive(:any_user_can_create_projects) { false }
+    before do
+      allow(Settings.permissions).to receive(:any_user_can_create_projects).and_return(false)
     end
 
     ensures :owner, :writer, :reader, :harvester, cannot: [:create]

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -960,7 +960,7 @@ paths:
                   See https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.1
                   for installation instructions.
 
-                  Version 4.9.0 from http://localhost:3000.
+                  Version 4.9.1 from http://localhost:3000.
 
                 .EXAMPLE
 
@@ -994,8 +994,10 @@ paths:
 
                 $InformationPreference = 'Continue'
                 $ErrorActionPreference = 'Stop'
+                # https://github.com/PowerShell/PowerShell/issues/14348
+                $ProgressPreference = 'SilentlyContinue'
 
-                Write-Information "Acoustic Workbench downloader script version 4.9.0"
+                Write-Information "Acoustic Workbench downloader script version 4.9.1"
 
                 if ($null -eq $target) {
                   $target = $pwd
@@ -1018,7 +1020,7 @@ paths:
 
                 if ($null -eq $filter) {
                   $filter = @'
-                {"sorting":{"order_by":"recorded_date","direction":"desc"},"paging":{"items":25},"projection":{"include":["id","recorded_date","sites.name","site_id","canonical_file_name"]}}
+                {"sorting":{"order_by":"recorded_date","direction":"desc"},"capabilities":{"original_download":{"can_item":{},"details":{}}},"paging":{"items":25},"projection":{"include":["id","recorded_date","sites.name","site_id","canonical_file_name"]}}
                 '@
                 }
                 Write-Information "Filter: $filter"
@@ -1161,7 +1163,7 @@ paths:
                   See https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.1
                   for installation instructions.
 
-                  Version 4.9.0 from http://localhost:3000.
+                  Version 4.9.1 from http://localhost:3000.
 
                 .EXAMPLE
 
@@ -1195,8 +1197,10 @@ paths:
 
                 $InformationPreference = 'Continue'
                 $ErrorActionPreference = 'Stop'
+                # https://github.com/PowerShell/PowerShell/issues/14348
+                $ProgressPreference = 'SilentlyContinue'
 
-                Write-Information "Acoustic Workbench downloader script version 4.9.0"
+                Write-Information "Acoustic Workbench downloader script version 4.9.1"
 
                 if ($null -eq $target) {
                   $target = $pwd
@@ -1219,7 +1223,7 @@ paths:
 
                 if ($null -eq $filter) {
                   $filter = @'
-                {"sorting":{"order_by":"recorded_date","direction":"desc"},"paging":{"items":25},"projection":{"include":["id","recorded_date","sites.name","site_id","canonical_file_name"]}}
+                {"sorting":{"order_by":"recorded_date","direction":"desc"},"capabilities":{"original_download":{"can_item":{},"details":{}}},"paging":{"items":25},"projection":{"include":["id","recorded_date","sites.name","site_id","canonical_file_name"]}}
                 '@
                 }
                 Write-Information "Filter: $filter"
@@ -1364,6 +1368,12 @@ paths:
                     current: http://localhost:3000/audio_recordings?direction=desc&items=25&order_by=recorded_date&page=1
                     previous: 
                     next: 
+                  capabilities:
+                    original_download:
+                      can: 
+                      details: You do not have permission to download the original
+                        audio recording. Check your access level or the original download
+                        settings for this project
                 data:
                 - id: 20
                   uuid: 1eb68505-5f9b-4678-a876-3f0d7de1cfd9
@@ -1427,6 +1437,10 @@ paths:
                 meta:
                   status: 200
                   message: OK
+                  capabilities:
+                    original_download:
+                      can: true
+                      details: 
                 data:
                   id: 21
                   uuid: e046e7be-1a16-4610-9882-e8daebb6576a
@@ -1492,6 +1506,10 @@ paths:
                 meta:
                   status: 200
                   message: OK
+                  capabilities:
+                    original_download:
+                      can: true
+                      details: 
                 data:
                   id: 22
                   uuid: ce43bb99-420c-455a-937a-d42459933bc9
@@ -1552,6 +1570,10 @@ paths:
                 meta:
                   status: 200
                   message: OK
+                  capabilities:
+                    original_download:
+                      can: true
+                      details: 
                 data:
                   id: 23
                   uuid: d05c1bb9-2687-440a-86b4-6ec3c91d88e4
@@ -1658,6 +1680,12 @@ paths:
                     current: http://localhost:3000/audio_recordings/filter?direction=desc&items=25&order_by=recorded_date&page=1
                     previous: 
                     next: 
+                  capabilities:
+                    original_download:
+                      can: 
+                      details: You do not have permission to download the original
+                        audio recording. Check your access level or the original download
+                        settings for this project
                 data:
                 - id: 25
                   uuid: 4f97f45e-080c-4d10-bba7-e52696d9d320
@@ -2588,8 +2616,8 @@ paths:
                   deleter_id: 
                   deleted_at: 
                   region_id: 41
-                  custom_latitude: 84.710449
-                  custom_longitude: 29.079889
+                  custom_latitude: -58.800399
+                  custom_longitude: -105.25982
                   location_obfuscated: false
                   project_ids:
                   - 44
@@ -2672,8 +2700,8 @@ paths:
                   deleter_id: 
                   deleted_at: 
                   region_id: 42
-                  custom_latitude: -14.842749
-                  custom_longitude: -84.341464
+                  custom_latitude: -81.25144
+                  custom_longitude: 179.016037
                   location_obfuscated: false
                   project_ids:
                   - 45
@@ -2792,9 +2820,13 @@ paths:
                 meta:
                   status: 201
                   message: Created
+                  capabilities:
+                    original_download:
+                      can: true
+                      details: 
                 data:
                   id: 44
-                  uuid: 3fb2905b-13aa-45c9-ac89-0b2b78adbb28
+                  uuid: 1290bdb5-cee1-4b3b-b63f-b2905b13aab5
                   recorded_date: '2012-05-09T07:06:59.000Z'
                   site_id: 44
                   duration_seconds: 60000.0
@@ -2812,7 +2844,7 @@ paths:
                   updater_id: 
                   notes:
                     test: note number 44
-                  file_hash: SHA256::44jkovp9n9ngw1reb1c1qlj92r3fwgylwhapa62qimj6mjgg3yvip0mpzki73bp5
+                  file_hash: SHA256::44uhiaijkovp9n9ngw1reb1c1qlj92r3fwgylwhapa62qimj6mjgg3yvip0mpzki
                   uploader_id: 1
                   original_file_name: original name 44.mp3
                   canonical_file_name: 20120509T070659Z_site-name-46_44.mp3
@@ -5639,6 +5671,20 @@ components:
       - Reader
       - 
     meta:
+      properties:
+        capabilities:
+          type: object
+          items:
+            type: object
+            properties:
+              can:
+                type:
+                - 'null'
+                - boolean
+              details:
+                type: string
+            required:
+            - can
       type: object
     meta_error:
       type: object


### PR DESCRIPTION
#Also adds a basic capabilities framework.

Closes #551
Closes #491

Adds a basic capabilities framework, in accordance with https://github.com/QutEcoacoustics/baw-server/wiki/API:-Capabilties

## Changes

- Added a basic capabilities framework
- Added the original download capability for audio recordings

## Problems

The plan was for:

- basic capabilities (get, post, put, patch, delete, etc..) to be included with every resource but that is being left for later
- the spec also defined capabilities as being opt-in which is also not completed here
   - more work than required for MVP
   - also not sure if it is the right choice

## Visual Changes

N/A

## Final Checklist

- [ x Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
