### PR TITLE
Fixes Current.ability

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,6 +15,12 @@ class SessionsController < Devise::SessionsController
   # remove Devise's default destroy response
   skip_before_action :verify_signed_out_user
 
+  # skip caching current_ability in Current.ability
+  # Not sure what he issue here is, but I think the set_current_ability callback
+  # happens before the rest of the callbacks in this controller. Once current_ability
+  # is called it's value is cached and the callbacks in this controller fail
+  skip_before_action :set_current_ability
+
   # don't check auth for new and create (since this is how to sign in to the api)
   check_authorization except: [:new, :create]
 
@@ -114,7 +120,8 @@ class SessionsController < Devise::SessionsController
   private
 
   def response_wrapper(status_symbol, data, error_details = nil, error_links = [])
-    built_response = Settings.api_response.build(status_symbol, data, { error_details: error_details, error_links: error_links })
+    built_response = Settings.api_response.build(status_symbol, data,
+      { error_details: error_details, error_links: error_links })
     render json: built_response, status: status_symbol, layout: false
   end
 end

--- a/app/modules/set_current.rb
+++ b/app/modules/set_current.rb
@@ -16,6 +16,6 @@ module SetCurrent
   end
 
   def set_current_ability
-    Current.ability = current_ability unless current_user.nil?
+    Current.ability = current_ability
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -246,7 +246,7 @@ describe ApplicationController, type: :controller do
       response = get :index_ability
       expect(Current.ability).to be_an_instance_of(Ability)
 
-      # if you're signed in you cannot download an original recording
+      # if you're not signed in you cannot download an original recording
       expect(Current.ability.can?(:original, audio_recording)).to eq false
 
       expect(response.body).to eq('Ability')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -188,4 +188,68 @@ describe ApplicationController, type: :controller do
       it_behaves_like 'sanitization', :nested
     end
   end
+
+  describe 'Current' do
+    create_entire_hierarchy
+
+    controller(ApplicationController) do
+      skip_authorization_check
+
+      def index_ability
+        render plain: Current.ability&.class&.name
+      end
+
+      def index_user
+        render(plain: Current.user&.user_name)
+      end
+    end
+
+    before do
+      routes.draw do
+        get 'index_user' => 'anonymous#index_user'
+        get 'index_ability' => 'anonymous#index_ability'
+      end
+
+      project.allow_original_download = :reader
+      project.save!
+    end
+
+    it 'inherits from the application controller' do
+      expect(controller).to be_a_kind_of(ApplicationController)
+    end
+
+    it 'sets Current.user when a user session is supplied' do
+      request.env['HTTP_AUTHORIZATION'] = reader_token
+      response = get :index_user
+      expect(Current.user).to eq reader_user
+      expect(response.body).to eq(reader_user.user_name)
+    end
+
+    it 'sets Current.user to nil when there is no user session' do
+      response = get :index_user
+      expect(Current.user).to be_nil
+      expect(response.body).to eq('')
+    end
+
+    it 'sets Current.ability when a user session is supplied' do
+      request.env['HTTP_AUTHORIZATION'] = reader_token
+      response = get :index_ability
+      expect(Current.ability).to be_an_instance_of(Ability)
+
+      # if you're signed in you can download an original recording
+      expect(Current.ability.can?(:original, audio_recording)).to eq true
+
+      expect(response.body).to eq('Ability')
+    end
+
+    it 'sets Current.ability even when a user session is not supplied' do
+      response = get :index_ability
+      expect(Current.ability).to be_an_instance_of(Ability)
+
+      # if you're signed in you cannot download an original recording
+      expect(Current.ability.can?(:original, audio_recording)).to eq false
+
+      expect(response.body).to eq('Ability')
+    end
+  end
 end


### PR DESCRIPTION
# Fixes Current.ability

I had assumed that current_ability would not be set to a useful value when current_user was nil. Actually though, CanCanCan does provide a useful ability instance even when a user is nil and I should not have not set Current.ability when current_user was nil.

Fixes #553

## Changes

Adds more tests for the current class and also fixes aforementioned bug.

## Problems

N/A

## Visual Changes

N/A

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
