### PR TITLE
Add nullable license field to Projects model

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -189,7 +189,7 @@ ORDER BY project_count ASC, s.name ASC")
   def project_params
     check_for_allow_audio_upload(params.require(:project)).permit(
       :description, :image, :name, :notes, :urn, :allow_original_download,
-      :allow_audio_upload
+      :allow_audio_upload, :license
     )
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,7 @@
 #  image_file_name         :string
 #  image_file_size         :bigint
 #  image_updated_at        :datetime
+#  license                 :text
 #  name                    :string           not null
 #  notes                   :text
 #  urn                     :string
@@ -78,9 +79,11 @@ class Project < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   #validates :urn, uniqueness: {case_sensitive: false}, allow_blank: true, allow_nil: true
   validates_format_of :urn, with: %r{\Aurn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]+\z},
-    message: 'urn %{value} is not valid, must be in format urn:<name>:<path>', allow_blank: true, allow_nil: true
+    message: 'urn %<value>s is not valid, must be in format urn:<name>:<path>', allow_blank: true, allow_nil: true
   validates_attachment_content_type :image, content_type: %r{\Aimage/(jpg|jpeg|pjpeg|png|x-png|gif)\z},
-    message: 'file type %{value} is not allowed (only jpeg/png/gif images)'
+    message: 'file type %<value>s is not allowed (only jpeg/png/gif images)'
+
+  validates :license, length: { minimum: 1 }, allow_nil: true
 
   # ensure allow original download is a permission level.
   # Do not add predicates to Project ( #reader?, #writer?, #owner? do not make sense when attached directly to Project).
@@ -99,7 +102,8 @@ class Project < ApplicationRecord
                      :updater_id,
                      :updated_at,
                      :deleter_id,
-                     :deleted_at],
+                     :deleted_at,
+                     :license],
       render_fields: [:id, :name, :description, :creator_id,
                       :created_at,
                       :updater_id,
@@ -108,7 +112,8 @@ class Project < ApplicationRecord
                       :deleted_at,
                       :notes,
                       :allow_original_download,
-                      :allow_audio_upload],
+                      :allow_audio_upload,
+                      :license],
       text_fields: [:name, :description],
       custom_fields: lambda { |item, user|
                        # do a query for the attributes that may not be in the projection
@@ -212,7 +217,8 @@ class Project < ApplicationRecord
         image_urls: Api::Schema.image_urls,
         access_level: Api::Schema.permission_levels,
         allow_original_download: Api::Schema.permission_levels,
-        allow_audio_upload: { type: 'boolean' }
+        allow_audio_upload: { type: 'boolean' },
+        license: { type: ['string', 'null'] }
       },
       required: [
         :id,
@@ -231,7 +237,8 @@ class Project < ApplicationRecord
         :site_ids,
         :region_ids,
         :image_urls,
-        :allow_original_download
+        :allow_original_download,
+        :license
       ]
     }.freeze
   end

--- a/db/migrate/20240110141130_add_license_to_projects.rb
+++ b/db/migrate/20240110141130_add_license_to_projects.rb
@@ -1,0 +1,5 @@
+class AddLicenseToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :license, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1161,7 +1161,8 @@ CREATE TABLE public.projects (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     allow_original_download character varying,
-    allow_audio_upload boolean DEFAULT false
+    allow_audio_upload boolean DEFAULT false,
+    license text
 );
 
 
@@ -3696,6 +3697,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220704043031'),
 ('20220808062341'),
 ('20220825042333'),
-('20220930062323');
+('20220930062323'),
+('20240110141130');
 
 

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -13,6 +13,7 @@
 #  image_file_name         :string
 #  image_file_size         :bigint
 #  image_updated_at        :datetime
+#  license                 :text
 #  name                    :string           not null
 #  notes                   :text
 #  urn                     :string
@@ -42,6 +43,7 @@ FactoryBot.define do
     sequence(:urn) { |n| "urn:project:example.org/project/#{n}" }
     sequence(:notes) { |n| "note number #{n}" }
     allow_audio_upload { false }
+    license { 'CC-BY-4.0' }
 
     creator
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,6 +13,7 @@
 #  image_file_name         :string
 #  image_file_size         :bigint
 #  image_updated_at        :datetime
+#  license                 :text
 #  name                    :string           not null
 #  notes                   :text
 #  urn                     :string
@@ -72,6 +73,10 @@ describe Project, type: :model do
 
     expect(project_html.description).to eq(md)
     expect(project_html.description_html).to eq(html)
+  end
+
+  it 'validates license is not an empty string' do
+    expect(build(:project, license: '')).not_to be_valid
   end
 
   # this should pass, but the paperclip implementation of validate_attachment_content_type is buggy.

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -82,6 +82,25 @@ describe 'Projects' do
       expect(response.body).to match 'projects/new'
     end
 
+    it 'allows creating a project without a license' do
+      body = { project: { name: 'test123' } }
+      post '/projects', params: body, **api_with_body_headers(reader_token)
+
+      expect_success
+      expect(api_data).to match(hash_including({
+        name: 'test123',
+        license: nil
+      }))
+    end
+
+    it 'does not allow creating a project with an empty string license' do
+      body = { project: { name: 'test123', license: '' } }
+      post '/projects', params: body, **api_with_body_headers(reader_token)
+
+      expect_error(:unprocessable_entity, 'Record could not be saved',
+        { license: ['is too short (minimum is 1 character)'] })
+    end
+
     # can't test empty body with multipart/form-data content type
     # because middleware errors when trying to parse it
   end
@@ -171,6 +190,4 @@ describe 'Projects' do
       }))
     end
   end
-
-
 end


### PR DESCRIPTION
# Add nullable license field to Projects model

Given that projects can be publically available for viewing, users have commonly associated usage rights and licensing information with the projects. However, with existing API capabilities, this information is usually encoded in the `description` field.

The addition of a specific `license` attribute on projects will allow uses to either: Reference an SPDX license code or insert a custom license as free form text.

## Changes

- Adds a license filed to project models

## Issues

Fixes: #289 

## Problems

None

## Visual Changes

None

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
