### PR TITLE
macos dev compatability

### DIFF
--- a/.rerun
+++ b/.rerun
@@ -5,4 +5,3 @@
 --name "baw-workers"
 --background
 --clear
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     command: >-
-      rerun -- bin/baw-workers baw:worker:run
+      ./provision/rerun.sh ${HOMEBREW_PREFIX} bin/baw-workers baw:worker:run
     depends_on:
       - db
       - redis
@@ -153,14 +153,14 @@ services:
   scheduler:
     <<: *worker
     command: >-
-      rerun -- bin/baw-workers baw:worker:run_scheduler
+      ./provision/rerun.sh ${HOMEBREW_PREFIX} bin/baw-workers baw:worker:run_scheduler
   scheduler_test:
     <<: *worker_test
     # Note: we disable recurring jobs by default on our test scheduler
     # because extra enqueued jobs while other tests are running would break
     # so many things.
     command: >-
-      rerun -- bin/baw-workers baw:worker:run_scheduler
+      ./provision/rerun.sh ${HOMEBREW_PREFIX} bin/baw-workers baw:worker:run_scheduler
     environment:
       RAILS_ENV: test
 

--- a/provision/dev_setup.sh
+++ b/provision/dev_setup.sh
@@ -13,16 +13,16 @@ USERNAME=baw_web
 /bin/cp /etc/skel/.bashrc "/home/$USERNAME/.bashrc"
 chown $USERNAME "/home/$USERNAME/.bashrc"
 
-SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-    && mkdir -p /commandhistory \
-    && chmod 777 /commandhistory \
-    && touch /commandhistory/.bash_history \
-    && chown -R $USERNAME /commandhistory \
-    && echo $SNIPPET >> "/home/$USERNAME/.bashrc"
+SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" &&
+    mkdir -p /commandhistory &&
+    chmod 777 /commandhistory &&
+    touch /commandhistory/.bash_history &&
+    chown -R $USERNAME /commandhistory &&
+    echo $SNIPPET >>"/home/$USERNAME/.bashrc"
 
 mkdir -p /home/$USERNAME/.vscode-server/extensions \
-        /home/$USERNAME/.vscode-server-insiders/extensions \
-    && chown -R $USERNAME \
+    /home/$USERNAME/.vscode-server-insiders/extensions &&
+    chown -R $USERNAME \
         /home/$USERNAME/.vscode-server \
         /home/$USERNAME/.vscode-server-insiders
 

--- a/provision/rerun.sh
+++ b/provision/rerun.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# first arg expected to be ostype variable
+# rest of args is command to run to pass on to rerun
+if [[ $1 =~ .*homebrew ]]; then
+    echo -e "\n== Running rerun with force polling ==\n"
+    rerun --force-polling -- "${@:2}"
+else
+    rerun -- "${@:2}"
+fi


### PR DESCRIPTION
adds rerun provision script for supporting polling on docker desktop on mac because inotify not supported. 
bash lint auto-fixes. 
log truncation changes. 
wildcard bug fix for when no log files. 
change array exec syntax to comply with linter advice.

