### PR TITLE
Fix stale job scheduling

### DIFF
--- a/lib/gems/baw-workers/lib/baw_workers/active_job/recurring.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/active_job/recurring.rb
@@ -11,9 +11,11 @@ module BawWorkers
     # @example
     #   class MyJob < BawWorkers::Jobs::ApplicationJob
     #     queue_as :default
-    #     recurring_at '0 0 * * *' # every day at midnight
-    #     def perform(*args)
-    #       # do something
+    #     recurring_at '0 0 * * *', args: [ 1 ]
+    #
+    #     def perform(an_argument)
+    #       # prints `1` every day at midnight
+    #       puts an_argument
     #     end
     #   end
     #
@@ -32,14 +34,20 @@ module BawWorkers
         # @!attribute [rw] recurring_cron_schedule
         #   @return [string] The cron schedule for this recurring job.
 
+        # @!attribute [rw] recurring_cron_schedule_args
+        #  @return [Array] The arguments the job will be scheduled with
+
         # Sets the cron schedule for this job.
         # @param [String] cron_schedule the cron schedule for this job. This is a 6-star schedule.
+        # @param [Array] args the arguments the job will be scheduled with
         # @raise [ArgumentError] if cron_schedule is not a string
         # @return [void]
-        def recurring_at(cron_schedule)
+        def recurring_at(cron_schedule, args: [])
           raise ArgumentError, 'cron_schedule must be a string' unless cron_schedule.is_a?(String)
+          raise ArgumentError, 'args must be an array' unless args.is_a?(Array)
 
           self.recurring_cron_schedule = cron_schedule
+          self.recurring_cron_schedule_args = args
         end
 
         # override resque-scheduler's default behaviour to adapt it to work with active job.
@@ -54,6 +62,7 @@ module BawWorkers
 
         def __setup_recurring
           class_attribute :recurring_cron_schedule, instance_accessor: false
+          class_attribute :recurring_cron_schedule_args, instance_accessor: false
         end
       end
 

--- a/lib/gems/baw-workers/lib/baw_workers/jobs/analysis/remote_stale_check_job.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/jobs/analysis/remote_stale_check_job.rb
@@ -13,7 +13,7 @@ module BawWorkers
         queue_as Settings.actions.analysis_stale_check.queue
         perform_expects [NilClass, Integer]
 
-        recurring_at Settings.actions.analysis_stale_check.schedule
+        recurring_at Settings.actions.analysis_stale_check.schedule, args: [nil]
 
         # only allow one of these to run at once.
         # constrained resource: don't want two of these running at once otherwise
@@ -29,7 +29,7 @@ module BawWorkers
           push_message(error.message)
         end
 
-        def perform(min_age_seconds = nil)
+        def perform(min_age_seconds)
           # first check if we can contact the remote queue
           failed!('Could not connect to remote queue.') unless batch.remote_connected?
 

--- a/spec/lib/gems/baw_workers/jobs/analysis/remote_stale_check_job_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/analysis/remote_stale_check_job_spec.rb
@@ -13,7 +13,6 @@ describe BawWorkers::Jobs::Analysis::RemoteStaleCheckJob do
   )
 
   pause_all_jobs
-
   submit_pbs_jobs_as_held
 
   def get_last_status(expected_count)
@@ -21,6 +20,16 @@ describe BawWorkers::Jobs::Analysis::RemoteStaleCheckJob do
       expected_count,
       of_class: BawWorkers::Jobs::Analysis::RemoteStaleCheckJob
     ).max_by(&:time)
+  end
+
+  it 'can be performed later' do
+    BawWorkers::Jobs::Analysis::RemoteStaleCheckJob.perform_later!(nil)
+
+    expect_enqueued_jobs(1, of_class: BawWorkers::Jobs::Analysis::RemoteStaleCheckJob)
+
+    perform_jobs(count: 1)
+
+    expect_performed_jobs(1, of_class: BawWorkers::Jobs::Analysis::RemoteStaleCheckJob)
   end
 
   stepwise 'can resolve stale jobs' do


### PR DESCRIPTION
Our remote stale job was not enqueuing correctly from the scheduler. This is because we had no way to supply arguments to scheduled jobs and my own silly job argument validator could not handle that.

Before:

![Screenshot 2025-01-14 144431](https://github.com/user-attachments/assets/003568f4-0203-45ce-999e-adabf7ba27e9)

After:

![image](https://github.com/user-attachments/assets/2cec5a2c-53cb-4004-a6a8-546c15c51f70)
