### PR TITLE
User changes - contactable opt-in

### DIFF
--- a/app/controllers/user_accounts_controller.rb
+++ b/app/controllers/user_accounts_controller.rb
@@ -105,8 +105,8 @@ ELSE last_sign_in_at END DESC')
     do_authorize_instance
 
     @user_projects = Access::ByPermission.projects(@user).includes(:creator).references(:creator)
-                                         .order('projects.name ASC')
-                                         .page(paging_params[:page].blank? ? 1 : paging_params[:page])
+      .order('projects.name ASC')
+      .page((paging_params[:page].presence || 1))
     respond_to do |format|
       format.html
     end
@@ -118,8 +118,8 @@ ELSE last_sign_in_at END DESC')
     do_authorize_instance
 
     @user_sites = Access::ByPermission.sites(@user).includes(:creator, :projects).references(:creator, :project)
-                                      .order('sites.name ASC')
-                                      .page(paging_params[:page].blank? ? 1 : paging_params[:page])
+      .order('sites.name ASC')
+      .page((paging_params[:page].presence || 1))
 
     respond_to do |format|
       format.html
@@ -132,8 +132,8 @@ ELSE last_sign_in_at END DESC')
     do_authorize_instance
 
     @user_bookmarks = Access::ByUserModified.bookmarks(@user)
-                                            .order('bookmarks.updated_at DESC')
-                                            .page(paging_params[:page].blank? ? 1 : paging_params[:page])
+      .order('bookmarks.updated_at DESC')
+      .page((paging_params[:page].presence || 1))
     respond_to do |format|
       format.html
     end
@@ -145,8 +145,8 @@ ELSE last_sign_in_at END DESC')
     do_authorize_instance
 
     @user_audio_event_comments = Access::ByUserModified.audio_event_comments(@user)
-                                                       .order('audio_event_comments.updated_at DESC')
-                                                       .page(paging_params[:page].blank? ? 1 : paging_params[:page])
+      .order('audio_event_comments.updated_at DESC')
+      .page((paging_params[:page].presence || 1))
     respond_to do |format|
       format.html
     end
@@ -160,8 +160,8 @@ ELSE last_sign_in_at END DESC')
     @user_annotations = Access::ByUserModified.audio_events(@user).includes(audio_recording: [:site]).references(
       :audio_recordings, :sites
     )
-                                              .order('audio_events.updated_at DESC')
-                                              .page(paging_params[:page].blank? ? 1 : paging_params[:page])
+      .order('audio_events.updated_at DESC')
+      .page((paging_params[:page].presence || 1))
     respond_to do |format|
       format.html
     end
@@ -173,11 +173,11 @@ ELSE last_sign_in_at END DESC')
     do_authorize_instance
 
     @user_saved_searches = Access::ByUserModified.saved_searches(@user)
-                                                 .order('saved_searches.created_at DESC')
-                                                 .paginate(
-                                                   page: paging_params[:page].blank? ? 1 : paging_params[:page],
-                                                   per_page: 30
-                                                 )
+      .order('saved_searches.created_at DESC')
+      .paginate(
+        page: paging_params[:page].presence || 1,
+        per_page: 30
+      )
     respond_to do |format|
       format.html
     end
@@ -189,11 +189,11 @@ ELSE last_sign_in_at END DESC')
     do_authorize_instance
 
     @user_analysis_jobs = Access::ByUserModified.analysis_jobs(@user)
-                                                .order('analysis_jobs.updated_at DESC')
-                                                .paginate(
-                                                  page: paging_params[:page].blank? ? 1 : paging_params[:page],
-                                                  per_page: 30
-                                                )
+      .order('analysis_jobs.updated_at DESC')
+      .paginate(
+        page: paging_params[:page].presence || 1,
+        per_page: 30
+      )
     respond_to do |format|
       format.html
     end
@@ -223,7 +223,7 @@ ELSE last_sign_in_at END DESC')
     params.require(:user).permit(
       :user_name, :email, :password, :password_confirmation, :remember_me,
       :roles, :roles_mask, :preferences,
-      :image, :login
+      :image, :login, :contactable
     )
   end
 
@@ -231,7 +231,7 @@ ELSE last_sign_in_at END DESC')
     params.require(:user).permit(
       :id, :user_name, :email, :tzinfo_tz,
       :password, :password_confirmation,
-      :roles_mask, :image
+      :roles_mask, :image, :contactable
     )
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -667,7 +667,7 @@ class Ability
     can [:index, :filter], SavedSearch
   end
 
-  def to_provenance(_user, is_guest)
+  def to_provenance(_user, _is_guest)
     # other actions are admin only
 
     # available to any user, including guest
@@ -722,7 +722,7 @@ class Ability
     # normal users edit their profile using devise/registrations#edit
 
     # users can only view their own:
-    can [:projects, :sites, :bookmarks, :audio_events, :audio_event_comments], User, id: user.id
+    can [:projects, :sites, :bookmarks, :audio_events, :audio_event_comments, :update], User, id: user.id
 
     # users get their own account and preferences from these actions
     can [:my_account, :modify_preferences], User, id: user.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,38 +4,39 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  authentication_token   :string
-#  confirmation_sent_at   :datetime
-#  confirmation_token     :string
-#  confirmed_at           :datetime
-#  current_sign_in_at     :datetime
-#  current_sign_in_ip     :string
-#  email                  :string           not null
-#  encrypted_password     :string           not null
-#  failed_attempts        :integer          default(0)
-#  image_content_type     :string
-#  image_file_name        :string
-#  image_file_size        :bigint
-#  image_updated_at       :datetime
-#  invitation_token       :string
-#  last_seen_at           :datetime
-#  last_sign_in_at        :datetime
-#  last_sign_in_ip        :string
-#  locked_at              :datetime
-#  preferences            :text
-#  rails_tz               :string(255)
-#  remember_created_at    :datetime
-#  reset_password_sent_at :datetime
-#  reset_password_token   :string
-#  roles_mask             :integer
-#  sign_in_count          :integer          default(0)
-#  tzinfo_tz              :string(255)
-#  unconfirmed_email      :string
-#  unlock_token           :string
-#  user_name              :string           not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  id                                                                              :integer          not null, primary key
+#  authentication_token                                                            :string
+#  confirmation_sent_at                                                            :datetime
+#  confirmation_token                                                              :string
+#  confirmed_at                                                                    :datetime
+#  contactable(Is the user contactable - consent status re: email communications ) :enum             default("unknown"), not null
+#  current_sign_in_at                                                              :datetime
+#  current_sign_in_ip                                                              :string
+#  email                                                                           :string           not null
+#  encrypted_password                                                              :string           not null
+#  failed_attempts                                                                 :integer          default(0)
+#  image_content_type                                                              :string
+#  image_file_name                                                                 :string
+#  image_file_size                                                                 :bigint
+#  image_updated_at                                                                :datetime
+#  invitation_token                                                                :string
+#  last_seen_at                                                                    :datetime
+#  last_sign_in_at                                                                 :datetime
+#  last_sign_in_ip                                                                 :string
+#  locked_at                                                                       :datetime
+#  preferences                                                                     :text
+#  rails_tz                                                                        :string(255)
+#  remember_created_at                                                             :datetime
+#  reset_password_sent_at                                                          :datetime
+#  reset_password_token                                                            :string
+#  roles_mask                                                                      :integer
+#  sign_in_count                                                                   :integer          default(0)
+#  tzinfo_tz                                                                       :string(255)
+#  unconfirmed_email                                                               :string
+#  unlock_token                                                                    :string
+#  user_name                                                                       :string           not null
+#  created_at                                                                      :datetime
+#  updated_at                                                                      :datetime
 #
 # Indexes
 #
@@ -60,6 +61,25 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :trackable, :validatable,
     :confirmable, :lockable, :timeoutable
+
+  # Defines a reusable mapping (CONSENT_ENUM) of consent constants
+  CONSENT_UNASKED = 'unasked'
+  CONSENT_CONSENTED = 'consented'
+  CONSENT_UNCONSENTED = 'unconsented'
+
+  CONSENT_ENUM = {
+    CONSENT_UNASKED => CONSENT_UNASKED,
+    CONSENT_CONSENTED => CONSENT_CONSENTED,
+    CONSENT_UNCONSENTED => CONSENT_UNCONSENTED
+  }.freeze
+
+  # enum :consent, {
+  #   CONSENT_UNASKED => CONSENT_UNASKED,
+  #   CONSENT_CONSENTED => CONSENT_CONSENTED,
+  #   CONSENT_UNCONSENTED => CONSENT_UNCONSENTED
+  # }, prefix: :consent
+
+  enum :contactable, CONSENT_ENUM, prefix: :contactable, validate: true
 
   # http://www.phase2technology.com/blog/authentication-permissions-and-roles-in-rails-with-devise-cancan-and-role-model/
   include RoleModel
@@ -210,8 +230,8 @@ class User < ApplicationRecord
   def excluded_login
     reserved_user_names = ['admin', 'harvester', 'analysis_runner', 'root', 'superuser', 'administrator', 'admins',
                            'administrators']
-    errors.add(:login, 'is reserved') if reserved_user_names.include?(login.downcase)
-    errors.add(:user_name, 'is reserved') if reserved_user_names.include?(user_name.downcase)
+    errors.add(:login, 'is reserved') if reserved_user_names.include?(login&.downcase)
+    errors.add(:user_name, 'is reserved') if reserved_user_names.include?(user_name&.downcase)
   end
 
   # format, uniqueness, and presence are validated by devise
@@ -345,10 +365,11 @@ class User < ApplicationRecord
   end
 
   # Define filter api settings
+  # @return [Hash] filter settings
   def self.filter_settings
     {
-      valid_fields: [:id, :user_name, :roles_mask, :last_seen_at, :created_at, :updated_at],
-      render_fields: [:id, :user_name, :roles_mask],
+      valid_fields: [:id, :user_name, :roles_mask, :last_seen_at, :created_at, :updated_at, :contactable],
+      render_fields: [:id, :user_name, :roles_mask, :contactable],
       text_fields: [:user_name],
       custom_fields: lambda { |item, user|
                        # 'item' is the user being processed, 'user' is the currently logged in user

--- a/db/migrate/20250113012304_add_contactable_to_users.rb
+++ b/db/migrate/20250113012304_add_contactable_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddContactableToUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_enum :consent, ['unasked', 'consented', 'unconsented']
+    add_column :users, :contactable, :enum, enum_type: :consent, default: 'unasked', null: false,
+      comment: 'Is the user contactable - consent status re: email communications '
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -86,6 +86,17 @@ CREATE TYPE public.analysis_jobs_item_transition AS ENUM (
 
 
 --
+-- Name: consent; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.consent AS ENUM (
+    'unasked',
+    'consented',
+    'unconsented'
+);
+
+
+--
 -- Name: dirname(text); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -2004,8 +2015,16 @@ CREATE TABLE public.users (
     preferences text,
     tzinfo_tz character varying(255),
     rails_tz character varying(255),
-    last_seen_at timestamp without time zone
+    last_seen_at timestamp without time zone,
+    contactable public.consent DEFAULT 'unasked'::public.consent NOT NULL
 );
+
+
+--
+-- Name: COLUMN users.contactable; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.contactable IS 'Is the user contactable - consent status re: email communications ';
 
 
 --
@@ -4216,6 +4235,7 @@ ALTER TABLE ONLY public.tags
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250113012304'),
 ('20241106015941'),
 ('20241004055117'),
 ('20240828062256'),

--- a/lib/gems/baw-app/lib/types.rb
+++ b/lib/gems/baw-app/lib/types.rb
@@ -21,8 +21,15 @@ module BawApp
       begin
         p.mkpath
       rescue Errno::EACCES => e
-        Rails.logger.debug { "ERROR: Could not create directory #{p}, #{e}" }
+        # These errors happen before the logger is available, don't use rails logger
+        # rubocop:disable Rails/Output
+        puts "CreatedDirPathname ERROR: Could not create directory #{p}, #{e}"
+        # rubocop:enable Rails/Output
         raise e if BawApp.dev_or_test?
+      rescue StandardError => e
+        # rubocop:disable Rails/Output
+        puts "CreatedDirPathname ERROR:  #{e}"
+        # rubocop:enable Rails/Output
       end
       p
     }

--- a/spec/controllers/user_accounts_controller_spec.rb
+++ b/spec/controllers/user_accounts_controller_spec.rb
@@ -6,7 +6,7 @@ describe UserAccountsController do
   # make sure it can recover from bad input
   describe 'proper timezones data' do
     let(:user_bad_tz) {
-      user = FactoryBot.build(:user, tzinfo_tz: 'Australia - Sydney', rails_tz: 'Sydney')
+      user = build(:user, tzinfo_tz: 'Australia - Sydney', rails_tz: 'Sydney')
       user.save!(validate: false)
       user
     }
@@ -55,7 +55,7 @@ describe UserAccountsController do
 
   describe 'bad timezones data' do
     let(:user_bad_tz) {
-      user = FactoryBot.build(:user, tzinfo_tz: 'person@domain.com', rails_tz: 'person@domain.com')
+      user = build(:user, tzinfo_tz: 'person@domain.com', rails_tz: 'person@domain.com')
       user.save!(validate: false)
       user
     }
@@ -71,7 +71,7 @@ describe UserAccountsController do
         response = get :my_account, params: { format: :json }
         body = JSON.parse(response.body)
 
-        expect(body['timezone_information']).to be(nil)
+        expect(body['timezone_information']).to be_nil
 
         user_good_tz = User.find(user_bad_tz.id)
         new_values = [user_good_tz.tzinfo_tz, user_good_tz.rails_tz]

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,38 +4,39 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  authentication_token   :string
-#  confirmation_sent_at   :datetime
-#  confirmation_token     :string
-#  confirmed_at           :datetime
-#  current_sign_in_at     :datetime
-#  current_sign_in_ip     :string
-#  email                  :string           not null
-#  encrypted_password     :string           not null
-#  failed_attempts        :integer          default(0)
-#  image_content_type     :string
-#  image_file_name        :string
-#  image_file_size        :bigint
-#  image_updated_at       :datetime
-#  invitation_token       :string
-#  last_seen_at           :datetime
-#  last_sign_in_at        :datetime
-#  last_sign_in_ip        :string
-#  locked_at              :datetime
-#  preferences            :text
-#  rails_tz               :string(255)
-#  remember_created_at    :datetime
-#  reset_password_sent_at :datetime
-#  reset_password_token   :string
-#  roles_mask             :integer
-#  sign_in_count          :integer          default(0)
-#  tzinfo_tz              :string(255)
-#  unconfirmed_email      :string
-#  unlock_token           :string
-#  user_name              :string           not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  id                                                                              :integer          not null, primary key
+#  authentication_token                                                            :string
+#  confirmation_sent_at                                                            :datetime
+#  confirmation_token                                                              :string
+#  confirmed_at                                                                    :datetime
+#  contactable(Is the user contactable - consent status re: email communications ) :enum             default("unknown"), not null
+#  current_sign_in_at                                                              :datetime
+#  current_sign_in_ip                                                              :string
+#  email                                                                           :string           not null
+#  encrypted_password                                                              :string           not null
+#  failed_attempts                                                                 :integer          default(0)
+#  image_content_type                                                              :string
+#  image_file_name                                                                 :string
+#  image_file_size                                                                 :bigint
+#  image_updated_at                                                                :datetime
+#  invitation_token                                                                :string
+#  last_seen_at                                                                    :datetime
+#  last_sign_in_at                                                                 :datetime
+#  last_sign_in_ip                                                                 :string
+#  locked_at                                                                       :datetime
+#  preferences                                                                     :text
+#  rails_tz                                                                        :string(255)
+#  remember_created_at                                                             :datetime
+#  reset_password_sent_at                                                          :datetime
+#  reset_password_token                                                            :string
+#  roles_mask                                                                      :integer
+#  sign_in_count                                                                   :integer          default(0)
+#  tzinfo_tz                                                                       :string(255)
+#  unconfirmed_email                                                               :string
+#  unlock_token                                                                    :string
+#  user_name                                                                       :string           not null
+#  created_at                                                                      :datetime
+#  updated_at                                                                      :datetime
 #
 # Indexes
 #
@@ -87,7 +88,7 @@ FactoryBot.define do
 
     trait :avatar_image do
       # this will be slow
-      image { fixture_file_upload(Rails.root.join('public', 'images', 'user', 'user-512.png'), 'image/png') }
+      image { fixture_file_upload(Rails.public_path.join('images/user/user-512.png'), 'image/png') }
     end
 
     factory :confirmed_user, traits: [:confirmed], aliases: [:user, :creator, :updater, :deleter, :uploader, :flagger]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,38 +4,39 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  authentication_token   :string
-#  confirmation_sent_at   :datetime
-#  confirmation_token     :string
-#  confirmed_at           :datetime
-#  current_sign_in_at     :datetime
-#  current_sign_in_ip     :string
-#  email                  :string           not null
-#  encrypted_password     :string           not null
-#  failed_attempts        :integer          default(0)
-#  image_content_type     :string
-#  image_file_name        :string
-#  image_file_size        :bigint
-#  image_updated_at       :datetime
-#  invitation_token       :string
-#  last_seen_at           :datetime
-#  last_sign_in_at        :datetime
-#  last_sign_in_ip        :string
-#  locked_at              :datetime
-#  preferences            :text
-#  rails_tz               :string(255)
-#  remember_created_at    :datetime
-#  reset_password_sent_at :datetime
-#  reset_password_token   :string
-#  roles_mask             :integer
-#  sign_in_count          :integer          default(0)
-#  tzinfo_tz              :string(255)
-#  unconfirmed_email      :string
-#  unlock_token           :string
-#  user_name              :string           not null
-#  created_at             :datetime
-#  updated_at             :datetime
+#  id                                                                              :integer          not null, primary key
+#  authentication_token                                                            :string
+#  confirmation_sent_at                                                            :datetime
+#  confirmation_token                                                              :string
+#  confirmed_at                                                                    :datetime
+#  contactable(Is the user contactable - consent status re: email communications ) :enum             default("unknown"), not null
+#  current_sign_in_at                                                              :datetime
+#  current_sign_in_ip                                                              :string
+#  email                                                                           :string           not null
+#  encrypted_password                                                              :string           not null
+#  failed_attempts                                                                 :integer          default(0)
+#  image_content_type                                                              :string
+#  image_file_name                                                                 :string
+#  image_file_size                                                                 :bigint
+#  image_updated_at                                                                :datetime
+#  invitation_token                                                                :string
+#  last_seen_at                                                                    :datetime
+#  last_sign_in_at                                                                 :datetime
+#  last_sign_in_ip                                                                 :string
+#  locked_at                                                                       :datetime
+#  preferences                                                                     :text
+#  rails_tz                                                                        :string(255)
+#  remember_created_at                                                             :datetime
+#  reset_password_sent_at                                                          :datetime
+#  reset_password_token                                                            :string
+#  roles_mask                                                                      :integer
+#  sign_in_count                                                                   :integer          default(0)
+#  tzinfo_tz                                                                       :string(255)
+#  unconfirmed_email                                                               :string
+#  unlock_token                                                                    :string
+#  user_name                                                                       :string           not null
+#  created_at                                                                      :datetime
+#  updated_at                                                                      :datetime
 #
 # Indexes
 #
@@ -99,7 +100,7 @@ describe User do
     end
 
     KEYS.each { |key|
-      it "will show if #{key} is recent" do
+      it "shows if #{key} is recent" do
         user[key] = 1.day.ago
         user.save!
         expect(User.recently_seen(1.month.ago).to_a).to include(user)
@@ -118,5 +119,28 @@ describe User do
     user = build(:user, user_name: "!aNT's fully s!ck user name 1337;;\n)/)'")
 
     expect(user.safe_user_name).to eq('aNTs-fully-s-ck-user-name-1337')
+  end
+
+  it 'defaults to contactable: unasked' do
+    user = build(:user)
+    expect(user.contactable).to eq('unasked')
+    expect(user).to be_valid
+  end
+
+  it 'allows valid contactable values' do
+    expect(build(:user, contactable: 'consented')).to be_valid
+    expect(build(:user, contactable: 'unconsented')).to be_valid
+  end
+
+  it 'does not allow invalid contactable values' do
+    user = build(:user, contactable: 'donkey')
+    expect(user).not_to be_valid
+  end
+
+  it 'contactable status can be set and checked using scopes' do
+    user = build(:user)
+    user.contactable_consented!
+    expect(user.contactable_consented?).to be true
+    expect(user).to be_valid
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -21,4 +21,41 @@ describe 'Users' do
       }))
     end
   end
+
+  it 'when shown, returns a contactable field' do
+    reader_user.contactable = 'consented'
+    reader_user.save!
+    get "/user_accounts/#{reader_user.id}", **api_headers(reader_token)
+    expect_success
+    expect(api_data).to include(contactable: 'consented')
+  end
+
+  it 'accepts a contactable field' do
+    body = {
+      user: {
+        contactable: 'consented'
+      }
+    }
+    patch "/user_accounts/#{reader_user.id}", params: body, **api_with_body_headers(reader_token)
+    expect_success
+    expect(reader_user.reload.contactable_consented?).to be true
+  end
+
+  it 'rejects an invalid contactable field' do
+    body = {
+      user: {
+        contactable: 'cucumber'
+      }
+    }
+    patch "/user_accounts/#{reader_user.id}", params: body, **api_with_body_headers(reader_token)
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it 'accessing my_account returns a contactable field' do
+    reader_user.contactable = 'unconsented'
+    reader_user.save!
+    get '/my_account', **api_headers(reader_token)
+    expect_success
+    expect(api_data).to include(contactable: 'unconsented')
+  end
 end


### PR DESCRIPTION
# User changes - contactable opt-in

The purpose is to implement a consent status for whether a user can be contacted or not via email (#692)

## Changes

- updates user model, new field `contactable`, enum type
- adds generic consent enum + contactable implementation
- `contactable` added to strong params + self.filter_settings

- user can now :update, in ability.rb

- test cases added on user model + requests

unrelated updates to error handling in lib/gems/baw-app/lib/types.rb

autoformat **only** changes:
- spec/factories/user_factory.rb
- spec/controllers/user_accounts_controller_spec.rb

## Problems

None identified

## Visual Changes

None

