### PR TITLE
Make harvester more resilient to bad paths

### DIFF
--- a/baw-server.code-workspace
+++ b/baw-server.code-workspace
@@ -140,6 +140,7 @@
       "Railtie",
       "rakefile",
       "rdebug",
+      "readables",
       "realdirpath",
       "realpath",
       "recaptcha",

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -24,6 +24,11 @@ module Fixtures
     '/sub_dir_1/BLENDED.Tile_20160727T124536Z_3.2.png' =>	100_993
   }.freeze
 
+  # A filename with some non-printable characters in it.
+  # https://github.com/QutEcoacoustics/baw-server/issues/702
+  # @return [String]
+  MIXED_ENCODING_FILENAME = "20231205T\xe2\x80\x8f\xe2\x80\x8e140158_TURTNEST22_n1_m1.wav"
+
   # @return [Pathname]
   def self.zip_fixture
     ensure_exists FILES_PATH / 'compressed.zip'

--- a/spec/lib/gems/baw_workers/jobs/harvest/edge_cases/mixed_encoding_filenames_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/harvest/edge_cases/mixed_encoding_filenames_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe BawWorkers::Jobs::Harvest::HarvestJob, :clean_by_truncation do
+  include_context 'shared_test_helpers'
+
+  prepare_users
+  prepare_project
+  prepare_region
+  prepare_site
+
+  prepare_harvest_with_mappings do
+    [
+      BawWorkers::Jobs::Harvest::Mapping.new(
+        path: '',
+        site_id: site.id,
+        utc_offset: nil,
+        recursive: false
+      )
+    ]
+  end
+
+  pause_all_jobs
+
+  before do
+    clear_original_audio
+    clear_harvester_to_do
+  end
+
+  describe 'special characters in filenames' do
+    it 'works with filenames that have non-printable characters' do
+      paths = copy_fixture_to_harvest_directory(
+        Fixtures.audio_file_mono,
+        harvest,
+        target_name: Fixtures::MIXED_ENCODING_FILENAME
+      )
+
+      BawWorkers::Jobs::Harvest::HarvestJob.enqueue_file(harvest, paths.harvester_relative_path, should_harvest: true)
+
+      perform_jobs(count: 1)
+
+      expect_jobs_to_be(completed: 1, of_class: BawWorkers::Jobs::Harvest::HarvestJob)
+
+      item = HarvestItem.first
+
+      # so in this case extra characters are stuck in between the datestamp
+      # so the harvest should not be exceptional
+      # but the file should not he harvested and should record validation errors
+      aggregate_failures do
+        expect(item).to be_failed
+        expect(item.info.to_h[:validations]).to eq [
+          # and also a more helpful validation about the encoding
+          {
+            name: :invalid_filename_characters,
+            status: :fixable,
+            message: 'Filename has invalid characters. Remove problem characters where indicated `20231205T��140158_TURTNEST22_n1_m1.wav`'
+          }
+        ]
+      end
+    end
+
+    it 'works for files that have invalid UTF-8 byte sequences in them' do
+      paths = copy_fixture_to_harvest_directory(
+        Fixtures.audio_file_mono,
+        harvest
+      )
+
+      bad_name = "\xC2.wav"
+
+      # have to rename here because Pathname is a nanny and won't let you create files with invalid UTF-8 sequences
+      File.rename(
+        paths.absolute_path.to_s,
+        "#{harvest.upload_directory}/#{bad_name}"
+      )
+
+      BawWorkers::Jobs::Harvest::HarvestJob.enqueue_file(
+        harvest,
+        paths.harvester_relative_path.to_s.gsub(Fixtures.audio_file_mono.basename.to_s, bad_name),
+        should_harvest: true
+      )
+
+      perform_jobs(count: 1)
+
+      expect_jobs_to_be(completed: 1, of_class: BawWorkers::Jobs::Harvest::HarvestJob)
+
+      item = HarvestItem.first
+
+      # in this case the file is actually renamed before the harvest job starts
+      expect(item.path).to match(/�.wav/)
+
+      # so in this case extra characters are stuck in between the datestamp
+      # so the harvest should not be exceptional
+      # but the file should not he harvested and should record validation errors
+      aggregate_failures do
+        expect(item).to be_failed
+        expect(item.info.to_h[:validations]).to eq [
+          # and also a more helpful validation about the encoding
+          {
+            name: :invalid_filename_characters,
+            status: :fixable,
+            message: 'Filename has invalid characters. Remove problem characters where indicated `�.wav`'
+          }
+        ]
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -263,6 +263,7 @@ RSpec.configure do |config|
   require "#{RSPEC_ROOT}/support/shared_context/logger_spy"
 
   require_relative 'support/matchers/be_same_file_as'
+  require_relative 'support/matchers/string_to_have_encoding'
 
   # change the default creation strategy
   # Previous versions of factory bot would ensure associations used the :create

--- a/spec/support/matchers/string_to_have_encoding.rb
+++ b/spec/support/matchers/string_to_have_encoding.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :string_to_have_encoding do |expected_encoding|
+  match do |actual|
+    actual.is_a?(String) && actual.encoding == expected_encoding
+  end
+
+  failure_message do |actual|
+    next "expected `#{actual}` to be a String but was a #{actual.class}" unless actual.is_a?(String)
+
+    "expected that `#{actual}` would have encoding `#{expected_encoding}` but was `#{actual.encoding}`"
+  end
+
+  failure_message_when_negated do |actual|
+    next "expected `#{actual}` to be a String but was a #{actual.class}" unless actual.is_a?(String)
+
+    "expected that `#{actual}` would not have encoding `#{expected_encoding}` but was `#{actual.encoding}`"
+  end
+
+  description do
+    "have encoding #{expected_encoding}"
+  end
+end


### PR DESCRIPTION
The harvester now rejects files that have control characters in their filename or invalid utf-8 sequences.

Program runner is also more resilient to parsing invalid characters.

Fixes #702
