### PR TITLE
Adds a Verification API

### DIFF
--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# VerificationsController
+class VerificationsController < ApplicationController
+  include Api::ControllerHelper
+
+  # GET /verifications
+  # GET /audio_recordings/:audio_recording_id/audio_events/:audio_event_id/verifications
+  def index
+    do_authorize_class
+    get_audio_event
+
+    @verifications, opts = Settings.api_response.response_advanced(
+      api_filter_params,
+      list_permissions,
+      Verification,
+      Verification.filter_settings
+    )
+    respond_index(opts)
+  end
+
+  # GET /verifications/:id
+  # GET /audio_recordings/:audio_recording_id/audio_events/:audio_event_id/verifications/:id
+  def show
+    do_load_resource
+    do_authorize_instance
+
+    respond_show
+  end
+
+  # GET /verifications/new
+  def new
+    do_new_resource
+    get_resource
+    do_set_attributes
+    do_authorize_instance
+
+    respond_new
+  end
+
+  # POST /verifications
+  def create
+    do_new_resource
+    do_set_attributes(verification_params)
+
+    do_authorize_instance
+
+    if @verification.save
+      respond_create_success(shallow_verification_url(@verification))
+    else
+      respond_change_fail
+    end
+  end
+
+  # PUT/PATCH /verifications/:id
+  def update
+    do_load_resource
+    do_authorize_instance
+
+    if @verification.update(verification_update_params)
+      respond_show
+    else
+      respond_change_fail
+    end
+  end
+
+  # Handled in Archivable
+  # DELETE /verifications/:id
+
+  # GET|POST /verifications/filter
+  # GET|POST /audio_recordings/:audio_recording_id/audio_events/:audio_event_id/verifications/filter
+  def filter
+    do_authorize_class
+    get_audio_event
+
+    filter_response, opts = Settings.api_response.response_advanced(
+      api_filter_params,
+      list_permissions,
+      Verification,
+      Verification.filter_settings
+    )
+    respond_filter(filter_response, opts)
+  end
+
+  private
+
+  def verification_params
+    params.require(:verification).permit(
+      :confirmed, :audio_event_id, :tag_id
+    )
+  end
+
+  def verification_update_params
+    params.require(:verification).permit(
+      :confirmed
+    )
+  end
+
+  def get_audio_event #rubocop:disable Naming/AccessorMethodName
+    @audio_event = AudioEvent.find(params[:audio_event_id]) if params&.key?(:audio_event_id)
+  end
+
+  def list_permissions
+    Access::ByPermission.audio_event_verifications(current_user, audio_event: @audio_event)
+  end
+end

--- a/app/models/audio_event.rb
+++ b/app/models/audio_event.rb
@@ -54,6 +54,7 @@ class AudioEvent < ApplicationRecord
   belongs_to :updater, class_name: 'User', inverse_of: :updated_audio_events, optional: true
   belongs_to :deleter, class_name: 'User', inverse_of: :deleted_audio_events, optional: true
   has_many :comments, class_name: 'AudioEventComment', inverse_of: :audio_event, dependent: :delete_all
+  has_many :verifications, inverse_of: :audio_event, dependent: :destroy
 
   # AT 2021: disabled. Nested associations are extremely complex,
   # and as far as we are aware, they are not used anywhere in production

--- a/app/models/audio_event_import_file.rb
+++ b/app/models/audio_event_import_file.rb
@@ -24,7 +24,9 @@
 #
 class AudioEventImportFile < ApplicationRecord
   # associations
-  has_many :audio_events, -> { includes :taggings }, inverse_of: :audio_event_import_file, dependent: :destroy
+  has_many :audio_events, lambda {
+    includes [:taggings, :verifications]
+  }, inverse_of: :audio_event_import_file, dependent: :destroy
 
   belongs_to :audio_event_import, inverse_of: :audio_event_import_files
   belongs_to :analysis_jobs_item, inverse_of: :audio_event_import_files, optional: true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,9 +30,11 @@ class Tag < ApplicationRecord
   extend Enumerize
 
   # relations
-  has_many :taggings, inverse_of: :tag
+  has_many :taggings, inverse_of: :tag, dependent: :destroy
   has_many :audio_events, through: :taggings
   has_many :tag_groups, inverse_of: :tag
+  has_many :verifications, inverse_of: :tag, dependent: :destroy
+
   belongs_to :creator, class_name: 'User', inverse_of: :created_tags
   belongs_to :updater, class_name: 'User', inverse_of: :updated_tags, optional: true
 
@@ -72,7 +74,7 @@ class Tag < ApplicationRecord
   #Tag.joins(:taggings).select('tags.*, count(tag_id) as "tag_count"').group(:tag_id).order(' tag_count desc')
 
   def taxonomic_enforced
-    if type_of_tag == 'common_name' || type_of_tag == 'species_name'
+    if ['common_name', 'species_name'].include?(type_of_tag)
       errors.add(:is_taxonomic, "must be true for #{type_of_tag}") unless is_taxonomic
     elsif is_taxonomic
       errors.add(:is_taxonomic, "must be false for #{type_of_tag}")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -212,6 +212,9 @@ class User < ApplicationRecord
 
   has_one :statistics, class_name: Statistics::UserStatistics.name
 
+  has_many :created_verifications, class_name: 'Verification', foreign_key: :creator_id, inverse_of: :creator
+  has_many :updated_verifications, class_name: 'Verification', foreign_key: :updator_id, inverse_of: :updater
+
   # scopes
   scope :users, -> { where(roles_mask: 2) }
   scope(:recently_seen,

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# A Verification represents a user's confirmation that a tag is correctly
+# applied to an audio event.
+# @see (#AudioEvent) and (#Tag) for more information on these models.
+#
+# == Schema Information
+#
+# Table name: verifications
+#
+#  id             :bigint           not null, primary key
+#  confirmed      :enum             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  audio_event_id :bigint           not null
+#  creator_id     :integer          not null
+#  tag_id         :bigint           not null
+#  updater_id     :integer
+#
+# Indexes
+#
+#  idx_on_audio_event_id_tag_id_creator_id_f944f25f20  (audio_event_id,tag_id,creator_id) UNIQUE
+#  index_verifications_on_audio_event_id               (audio_event_id)
+#  index_verifications_on_tag_id                       (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (audio_event_id => audio_events.id) ON DELETE => cascade
+#  fk_rails_...  (creator_id => users.id)
+#  fk_rails_...  (tag_id => tags.id) ON DELETE => cascade
+#  fk_rails_...  (updater_id => users.id)
+#
+class Verification < ApplicationRecord
+  belongs_to :audio_event, inverse_of: :verifications
+  belongs_to :tag, inverse_of: :verifications
+  belongs_to :creator, class_name: 'User', inverse_of: :created_verifications
+  belongs_to :updater, class_name: 'User', inverse_of: :updated_verifications, optional: true
+
+  # Defines the possible values for confirmation
+  CONFIRMATION_TRUE = 'correct'
+  CONFIRMATION_FALSE = 'incorrect'
+  CONFIRMATION_UNSURE = 'unsure'
+  CONFIRMATION_SKIP = 'skip'
+
+  # @type [Hash{String => String}]
+  CONFIRMATION_ENUM = {
+    CONFIRMATION_TRUE => CONFIRMATION_TRUE,
+    CONFIRMATION_FALSE => CONFIRMATION_FALSE,
+    CONFIRMATION_UNSURE => CONFIRMATION_UNSURE,
+    CONFIRMATION_SKIP => CONFIRMATION_SKIP
+  }.freeze
+
+  # @!method confirmed_true?
+  #   @return [Boolean] true if the verification is confirmed as true
+  # @!method confirmed_true!
+  #   @return [void] sets the verification as confirmed true
+  # @!method confirmed_false?
+  #   @return [Boolean] true if the verification is confirmed as false
+  # @!method confirmed_false!
+  #   @return [void] sets the verification as confirmed false
+  # @!method confirmed_unsure?
+  #   @return [Boolean] true if the verification is marked as unsure
+  # @!method confirmed_unsure!
+  #   @return [void] sets the verification as unsure
+  # @!method confirmed_skip?
+  #   @return [Boolean] true if the verification is marked as skip
+  # @!method confirmed_skip!
+  #   @return [void] sets the verification as skip
+  enum :confirmed, CONFIRMATION_ENUM, prefix: :confirmed, validate: true
+
+  def self.filter_settings
+    fields = [
+      :id, :confirmed, :audio_event_id, :tag_id, :creator_id,
+      :updater_id, :created_at, :updated_at
+    ]
+
+    {
+      valid_fields: fields,
+      render_fields: fields,
+      text_fields: [],
+      new_spec_fields: lambda { |_user|
+        {
+          confirmed: nil,
+          audio_event_id: nil,
+          tag_id: nil
+        }
+      },
+      controller: :verifications,
+      action: :filter,
+      defaults: {
+        order_by: :created_at,
+        direction: :desc
+      },
+      valid_associations: [
+        {
+          join: AudioEvent,
+          on: Verification.arel_table[:audio_event_id].eq(AudioEvent.arel_table[:id]),
+          available: true,
+          associations: [
+            {
+              join: AudioRecording,
+              on: AudioEvent.arel_table[:audio_recording_id].eq(AudioRecording.arel_table[:id]),
+              available: true
+            }
+          ]
+        },
+        {
+          join: Tag,
+          on: Verification.arel_table[:tag_id].eq(Tag.arel_table[:id]),
+          available: true
+        }
+      ]
+    }
+  end
+
+  def self.schema
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: Api::Schema.id,
+        confirmed: {
+          type: 'string',
+          enum: CONFIRMATION_ENUM.values
+        },
+        audio_event_id: Api::Schema.id(read_only: false),
+        tag_id: Api::Schema.id(read_only: false),
+        **Api::Schema.updater_and_creator_user_stamps
+      },
+      required: [
+        :id,
+        :confirmed,
+        :audio_event_id,
+        :tag_id,
+        :creator_id,
+        :created_at,
+        :updater_id,
+        :updated_at
+      ]
+    }.freeze
+  end
+end

--- a/app/modules/access/by_permission.rb
+++ b/app/modules/access/by_permission.rb
@@ -184,6 +184,17 @@ module Access
         end
       end
 
+      # Get all verifications for which this user has these access levels.
+      # @param [User] user
+      # @param [Symbol, Array<Symbol>] levels
+      # @param [AudioEvent] audio_event
+      # @return [ActiveRecord::Relation] verifications
+      def audio_event_verifications(user, levels: Access::Core.levels, audio_event: nil)
+        query = Verification.joins(audio_event: [{ audio_recording: [:site] }])
+        query = query.where(audio_event_id: audio_event.id) if audio_event
+        permission_sites(user, levels, query)
+      end
+
       # Get all saved searches for which this user has these access levels.
       # @param [User] user
       # @param [Symbol, Array<Symbol>] levels

--- a/app/modules/api/controller_helper.rb
+++ b/app/modules/api/controller_helper.rb
@@ -6,7 +6,7 @@ module Api
   module ControllerHelper
     extend ActiveSupport::Concern
 
-    # based on https://codelation.com/blog/rails-restful-api-just-add-water
+    # based on https://codelation.com/restful-rails-api-just-add-water/
     private
 
     # The singular name for the resource class based on the controller

--- a/app/modules/api/schema.rb
+++ b/app/modules/api/schema.rb
@@ -357,7 +357,8 @@ module Api
             audio_event_import: AudioEventImport.schema,
             audio_event_import_file: AudioEventImportFile.schema,
             audio_event: AudioEvent.schema,
-            provenance: Provenance.schema
+            provenance: Provenance.schema,
+            verification: Verification.schema
           },
           parameters: {
             'archived-parameter': archived_parameter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -747,6 +747,7 @@ Rails.application.routes.draw do
       end
       resources :tags, only: [:index], defaults: { format: 'json' }
       resources :taggings, except: [:edit], defaults: { format: 'json' }
+      resources :verifications, only: [:index, :show], defaults: { format: 'json' }, concerns: [:filterable]
     end
   end
 
@@ -759,6 +760,12 @@ Rails.application.routes.draw do
 
   # API tags
   resources :tags, only: [:index, :show, :create, :new], defaults: { format: 'json' }, concerns: [:filterable]
+
+  # API verifications
+  resources :verifications, except: [:edit],
+    as: 'shallow_verifications',
+    defaults: { format: 'json' },
+    concerns: [:filterable]
 
   # API audio_event create
   resources :audio_events, only: [], defaults: { format: 'json' }, concerns: [:filterable] do

--- a/db/migrate/20250120064731_create_verifications.rb
+++ b/db/migrate/20250120064731_create_verifications.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateVerifications < ActiveRecord::Migration[7.2]
+  def change
+    create_enum :confirmation, ['correct', 'incorrect', 'unsure', 'skip']
+
+    create_table :verifications do |t|
+      t.references :audio_event, null: false, foreign_key: { on_delete: :cascade }
+      t.references :tag, null: false, foreign_key: { on_delete: :cascade }
+      t.column :creator_id, :integer, null: false
+      t.column :updater_id, :integer
+      t.column :confirmed, :confirmation, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :verifications, :users, column: :creator_id
+    add_foreign_key :verifications, :users, column: :updater_id
+
+    add_index :verifications, [:audio_event_id, :tag_id, :creator_id], unique: true
+  end
+end

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,15 +1,11 @@
 # Spec
 
-To determine the convention for test types and folders see:
-https://relishapp.com/rspec/rspec-rails/v/4-0/docs/directory-structure
-
-## Factories
-
-Run the `rake factory_bot:lint` task to lint factories.
+Test types and folders are based on the conventional `Rspec` [directory
+structure](https://rspec.info/features/7-0/rspec-rails/directory-structure/).
 
 ## API specs
 
-Specs for the API come in a few forms:
+Specs for the API are organised into different folders, based on separation of concerns:
 
 - those that test permissions
     - modelled as request spec in the `spec/permissions` folder
@@ -20,9 +16,45 @@ Specs for the API come in a few forms:
 - those that document and validate the API
   - in the `/spec/api` folder
 
-API docs test API responses, and validate API request and response
-bodies according to schemas. These are supported by the
-`rswag` gem and should be placed in the `api` folder.
+This separation also facilitates the use of different helpers and configurations
+for each type of test (see the `spec/support` folder).
+
+### Permissions
+
+If the test is related to a permission, i.e. what user is allowed to invoke
+which actions, it should be a permission spec (`spec/permissions`).
+
+When testing permissions, the permissions helper methods will check that every
+case of user and action combination is covered, and fail if not.
+
+### API documentation and validation
+
+If the test is related to the shape of the request or response, it should be an
+api spec, and placed in the `/spec/api` folder. These tests document the API by
+validating the request and response bodies according to the defined schemas[^1],
+supported by the `rswag` gem. They are used to generate Swagger files that can
+be exposed as YAML endpoints.
+
+Note that all api specs are run as  the `admin_user`.
+
+### Requests - Specific functionality
+
+API tests that aren't covered by either the permissions or
+documentation/validation categories (such as complex behaviours) can be a request
+spec (`/spec/requests`).
+
+### Deprecated tests
 
 All tests in `spec/acceptance` are deprecated and should be replaced
 when opportunities arrive.
+
+## Factories
+
+The `factory_bot` gem is used to create test data. Factories are defined in the
+`spec/factories` folder.
+
+Run the `rake factory_bot:lint` task to lint factories.
+
+[^1]: Refer to `app/modules/api/schema.rb` for the OpenAPI schema definitions;
+    model-specific schemas are defined within their respective model classes.
+

--- a/spec/acceptance/user_accounts_spec.rb
+++ b/spec/acceptance/user_accounts_spec.rb
@@ -159,23 +159,21 @@ resource 'Users' do
     standard_request_options(:put, 'UPDATE (as admin, different user)', :ok, { expected_json_path: 'data/user_name' })
   end
 
-  # put '/user_accounts/:id' do
-  #   id_param
-  #   let(:id) { writer_id }
-  #   let(:raw_post) { { user: post_attributes }.to_json }
-  #   let(:authentication_token) { writer_token } # admin only, users edit using devise/registrations#edit
-  #   standard_request_options(:put, 'UPDATE (as writer, same user)', :forbidden,
-  #     { expected_json_path: get_json_error_path(:permissions) })
-  # end
+  put '/user_accounts/:id' do
+    id_param
+    let(:id) { writer_id }
+    let(:raw_post) { { user: post_attributes }.to_json }
+    let(:authentication_token) { writer_token }
+    standard_request_options(:put, 'UPDATE (as writer, same user)', :ok, { expected_json_path: 'data/user_name' })
+  end
 
-  # put '/user_accounts/:id' do
-  #   id_param
-  #   let(:id) { reader_id }
-  #   let(:raw_post) { { user: post_attributes }.to_json }
-  #   let(:authentication_token) { reader_token } # admin only, users edit using devise/registrations#edit
-  #   standard_request_options(:put, 'UPDATE (as reader, same user)', :forbidden,
-  #     { expected_json_path: get_json_error_path(:permissions) })
-  # end
+  put '/user_accounts/:id' do
+    id_param
+    let(:id) { reader_id }
+    let(:raw_post) { { user: post_attributes }.to_json }
+    let(:authentication_token) { reader_token }
+    standard_request_options(:put, 'UPDATE (as reader, same user)', :ok, { expected_json_path: 'data/user_name' })
+  end
 
   # put '/user_accounts/:id' do
   #   id_param

--- a/spec/api/verifications_spec.rb
+++ b/spec/api/verifications_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'verifications' do
+  describe 'shallow', type: :request do
+    create_entire_hierarchy
+
+    sends_json_and_expects_json
+    with_authorization
+    for_model Verification
+    which_has_schema ref(:verification)
+
+    path '/verifications/filter' do
+      post('filter verification') do
+        response(200, 'successful') do
+          schema_for_many
+          run_test! do
+            expect_at_least_one_item
+          end
+        end
+      end
+    end
+
+    path '/verifications' do
+      get('list verifications') do
+        response(200, 'successful') do
+          schema_for_many
+          run_test! do
+            expect_at_least_one_item
+          end
+        end
+      end
+
+      post('create verification') do
+        model_sent_as_parameter_in_body
+        response(201, 'successful') do
+          schema_for_single
+          auto_send_model
+          run_test!
+        end
+      end
+    end
+
+    path '/verifications/new' do
+      get('new verification') do
+        response(200, 'successful') do
+          run_test!
+        end
+      end
+    end
+
+    path '/verifications/{id}' do
+      with_id_route_parameter
+      let(:id) { verification.id }
+
+      get('show verification') do
+        response(200, 'successful') do
+          schema_for_single
+          run_test! do
+            expect_id_matches(verification)
+          end
+        end
+      end
+
+      patch('update verification') do
+        model_sent_as_parameter_in_body
+        response(200, 'successful') do
+          schema_for_single
+          send_model do
+            {
+              'verification' => {
+                confirmed: Verification::CONFIRMATION_FALSE
+              }
+            }
+          end
+          run_test! do
+            expect_id_matches(verification)
+          end
+        end
+      end
+
+      put('update verification') do
+        model_sent_as_parameter_in_body
+        response(200, 'successful') do
+          schema_for_single
+          send_model do
+            {
+              'verification' => {
+                confirmed: Verification::CONFIRMATION_FALSE
+              }
+            }
+          end
+          run_test! do
+            expect_id_matches(verification)
+          end
+        end
+      end
+
+      delete('delete verification') do
+        response(204, 'successful') do
+          schema nil
+          run_test! do
+            expect_empty_body
+          end
+        end
+      end
+    end
+  end
+
+  describe 'nested', type: :request do
+    create_entire_hierarchy
+
+    sends_json_and_expects_json
+    with_authorization
+    for_model Verification
+    which_has_schema ref(:verification)
+
+    let(:audio_recording_id) { audio_recording.id }
+    let(:audio_event_id) { audio_event.id }
+
+    path '/audio_recordings/{audio_recording_id}/audio_events/{audio_event_id}/verifications/filter' do
+      with_route_parameter(:audio_recording_id) { audio_recording_id }
+      with_route_parameter(:audio_event_id) { audio_event_id }
+
+      post('filter verification') do
+        response(200, 'successful') do
+          schema_for_many
+          run_test! do
+            expect_at_least_one_item
+          end
+        end
+      end
+    end
+
+    path '/audio_recordings/{audio_recording_id}/audio_events/{audio_event_id}/verifications' do
+      with_route_parameter(:audio_recording_id) { audio_recording_id }
+      with_route_parameter(:audio_event_id) { audio_event_id }
+
+      get('list verifications') do
+        response(200, 'successful') do
+          schema_for_many
+          run_test! do
+            expect_at_least_one_item
+          end
+        end
+      end
+    end
+
+    path '/audio_recordings/{audio_recording_id}/audio_events/{audio_event_id}/verifications/{id}' do
+      with_route_parameter(:audio_recording_id) { audio_recording_id }
+      with_route_parameter(:audio_event_id) { audio_event_id }
+
+      with_id_route_parameter
+      let(:id) { verification.id }
+
+      get('show verification') do
+        response(200, 'successful') do
+          schema_for_single
+          run_test! do
+            expect_id_matches(verification)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/verification_factory.rb
+++ b/spec/factories/verification_factory.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: verifications
+#
+#  id             :bigint           not null, primary key
+#  confirmed      :enum             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  audio_event_id :bigint           not null
+#  creator_id     :integer          not null
+#  tag_id         :bigint           not null
+#  updater_id     :integer
+#
+# Indexes
+#
+#  idx_on_audio_event_id_tag_id_creator_id_f944f25f20  (audio_event_id,tag_id,creator_id) UNIQUE
+#  index_verifications_on_audio_event_id               (audio_event_id)
+#  index_verifications_on_tag_id                       (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (audio_event_id => audio_events.id) ON DELETE => cascade
+#  fk_rails_...  (creator_id => users.id)
+#  fk_rails_...  (tag_id => tags.id) ON DELETE => cascade
+#  fk_rails_...  (updater_id => users.id)
+#
+FactoryBot.define do
+  factory :verification do
+    creator
+    audio_event
+    tag
+    confirmed { Verification::CONFIRMATION_TRUE }
+  end
+end

--- a/spec/migrations/coerce_timezones_spec.rb
+++ b/spec/migrations/coerce_timezones_spec.rb
@@ -82,7 +82,6 @@ describe CoerceTimezones, :migration do
         SELECT id, tzinfo_tz FROM sites ORDER BY id ASC;
       SQL
     )
-
     # after migration everything should be nice
     aggregate_failures do
       CASES.each_with_index do |example, index|

--- a/spec/models/analysis_jobs_item_spec.rb
+++ b/spec/models/analysis_jobs_item_spec.rb
@@ -97,7 +97,8 @@ describe AnalysisJobsItem do
     audio_event_import_files: {
       audio_events: {
         taggings: nil,
-        comments: nil
+        comments: nil,
+        verifications: nil
       }
     }
   } do

--- a/spec/models/audio_event_import_file_spec.rb
+++ b/spec/models/audio_event_import_file_spec.rb
@@ -113,7 +113,8 @@ describe AudioEventImportFile do
   it_behaves_like 'cascade deletes for', :audio_event_import_file, {
     audio_events: {
       taggings: nil,
-      comments: nil
+      comments: nil,
+      verifications: nil
     }
   } do
     create_entire_hierarchy

--- a/spec/models/audio_event_spec.rb
+++ b/spec/models/audio_event_spec.rb
@@ -510,7 +510,8 @@ describe AudioEvent do
 
   it_behaves_like 'cascade deletes for', :audio_event, {
     taggings: nil,
-    comments: nil
+    comments: nil,
+    verifications: nil
   } do
     create_entire_hierarchy
   end

--- a/spec/models/audio_recording_spec.rb
+++ b/spec/models/audio_recording_spec.rb
@@ -602,7 +602,8 @@ describe AudioRecording do
   it_behaves_like 'cascade deletes for', :audio_recording, {
     audio_events: {
       taggings: nil,
-      comments: nil
+      comments: nil,
+      verifications: nil
     },
     analysis_jobs_items: :audio_event_import_files,
     bookmarks: nil,

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -110,7 +110,8 @@ describe Project do
         audio_recordings: {
           audio_events: {
             taggings: nil,
-            comments: nil
+            comments: nil,
+            verifications: nil
           },
           analysis_jobs_items: :audio_event_import_files,
           bookmarks: nil,

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -54,7 +54,8 @@ describe Region, type: :model do
       audio_recordings: {
         audio_events: {
           taggings: nil,
-          comments: nil
+          comments: nil,
+          verifications: nil
         },
         analysis_jobs_items: :audio_event_import_files,
         bookmarks: nil,

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -262,7 +262,8 @@ describe Site do
     audio_recordings: {
       audio_events: {
         taggings: nil,
-        comments: nil
+        comments: nil,
+        verifications: nil
       },
       analysis_jobs_items: :audio_event_import_files,
       bookmarks: nil,

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -145,4 +145,11 @@ describe Tag do
     t.notes = { comment: 'testing' }
     expect(t).to be_valid
   end
+
+  it_behaves_like 'cascade deletes for', :tag, {
+    verifications: nil,
+    taggings: nil
+  } do
+    create_entire_hierarchy
+  end
 end

--- a/spec/models/verification_spec.rb
+++ b/spec/models/verification_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: verifications
+#
+#  id             :bigint           not null, primary key
+#  confirmed      :enum             not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  audio_event_id :bigint           not null
+#  creator_id     :integer          not null
+#  tag_id         :bigint           not null
+#  updater_id     :integer
+#
+# Indexes
+#
+#  idx_on_audio_event_id_tag_id_creator_id_f944f25f20  (audio_event_id,tag_id,creator_id) UNIQUE
+#  index_verifications_on_audio_event_id               (audio_event_id)
+#  index_verifications_on_tag_id                       (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (audio_event_id => audio_events.id) ON DELETE => cascade
+#  fk_rails_...  (creator_id => users.id)
+#  fk_rails_...  (tag_id => tags.id) ON DELETE => cascade
+#  fk_rails_...  (updater_id => users.id)
+#
+describe Verification do
+  it 'has a valid factory' do
+    v = create(:verification)
+
+    expect(v).to be_valid
+  end
+
+  it { is_expected.to belong_to(:audio_event) }
+  it { is_expected.to belong_to(:tag) }
+  it { is_expected.to belong_to(:creator) }
+  it { is_expected.to belong_to(:updater).optional }
+
+  it 'does not allow nil for confirmed' do
+    expect(build(:verification, confirmed: nil)).not_to be_valid
+  end
+
+  it 'is not valid with an invalid confirmed value' do
+    expect(build(:verification, confirmed: 'this_is_not_valid')).not_to be_valid
+  end
+
+  Verification::CONFIRMATION_ENUM.each_key do |key|
+    it "is valid with confirmed value `#{key}`" do
+      v = build(:verification, confirmed: key)
+      expect(v).to be_valid
+    end
+  end
+
+  it 'allows a user to have multiple verifications for different audio events and tags' do
+    v = create(:verification)
+    expect(build(:verification, creator_id: v.creator_id)).to be_valid
+  end
+end

--- a/spec/permissions/regions_spec.rb
+++ b/spec/permissions/regions_spec.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 
 describe 'Region permissions' do
   create_entire_hierarchy

--- a/spec/permissions/verifications_spec.rb
+++ b/spec/permissions/verifications_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+describe 'Verification permissions' do
+  create_entire_hierarchy
+
+  # Only index and show are available on the nested route
+  # Index is available to all users, show is available to all users with reader
+  # permissions on project
+  given_the_route '/audio_recordings/{audio_recording_id}/audio_events/{audio_event_id}/verifications' do
+    {
+      audio_recording_id: audio_recording.id,
+      audio_event_id: audio_event.id,
+      id: verification.id
+    }
+  end
+
+  using_the_factory :verification, factory_args: lambda {
+    #  creating a new tag to satisfy uniqueness constraint
+    { audio_event_id: audio_event.id, tag_id: create(:tag).id }
+  }
+
+  let(:another_writer) do
+    create(:user, user_name: 'another_writer', skip_creation_email: true).tap do |user|
+      create(:write_permission, creator: owner_user, user: user, project: project)
+    end
+  end
+
+  let(:another_writer_token) { Creation::Common.create_user_token(another_writer) }
+
+  with_custom_user(:another_writer)
+
+  for_lists_expects do |user, _action|
+    case user
+    when :admin
+      Verification.all
+    when :owner, :reader, :writer, :another_writer
+      verification
+    else
+      []
+    end
+  end
+
+  the_users :admin, :reader, :writer, :another_writer, :owner,
+    can_do: Set[:index, :show, :filter],
+    fails_with: :not_found
+
+  the_user :anonymous, can_do: Set[:index, :filter], fails_with: [:not_found, :unauthorized]
+
+  the_user :invalid, can_do: nothing, fails_with: [:not_found, :unauthorized]
+
+  the_user :no_access, can_do: Set[:index, :filter], fails_with: [:not_found, :forbidden]
+
+  the_user :harvester, can_do: nothing, fails_with: [:not_found, :forbidden]
+end
+
+describe 'Verification permissions (shallow)' do
+  create_entire_hierarchy
+
+  given_the_route '/verifications' do
+    {
+      id: verification.id
+    }
+  end
+
+  using_the_factory :verification, factory_args: lambda {
+    #  creating a new tag to satisfy uniqueness constraint
+    { audio_event_id: audio_event.id, tag_id: create(:tag).id }
+  }
+  send_update_body do
+    [{
+      'verification' => {
+        confirmed: Verification::CONFIRMATION_FALSE
+      }
+    }, :json]
+  end
+
+  send_create_body do
+    [{
+      'verification' => {
+        confirmed: Verification::CONFIRMATION_TRUE,
+        audio_event_id: audio_event.id,
+        tag_id: create(:tag).id
+      }
+    }, :json]
+  end
+
+  let(:another_writer) do
+    create(:user, user_name: 'another_writer', skip_creation_email: true).tap do |user|
+      create(:write_permission, creator: owner_user, user: user, project: project)
+    end
+  end
+
+  let(:another_writer_token) { Creation::Common.create_user_token(another_writer) }
+
+  with_custom_user(:another_writer)
+
+  for_lists_expects do |user, _action|
+    case user
+    when :admin
+      Verification.all
+    when :owner, :reader, :writer, :another_writer
+      verification
+    else
+      []
+    end
+  end
+
+  # `writer` user SHOULD be able to DELETE (because they are the verification creator)
+  # `writer` user SHOULD be able to PUT (update) (because they are the verification creator)
+  the_users :admin, :writer,
+    can_do: everything
+
+  # `another_writer` user should NOT be able to DELETE (because they are not the verification creator)
+  # `another_writer` user should NOT be able to PUT (update) (because they are not the verification creator)
+  the_user :another_writer, can_do: (reading + creation)
+
+  the_user :reader, can_do: reading, and_cannot_do: writing
+
+  # `owner` user SHOULD be able to DELETE (writer user's verification), (because they are a project owner)
+  # `owner` user NOT be able to PUT (update) (writer user's verification), (because they are NOT the creator)
+  the_user :owner, can_do: everything_but_update
+
+  the_user :anonymous, can_do: listing, and_cannot_do: not_listing, fails_with: :unauthorized
+  the_user :invalid, can_do: nothing, and_cannot_do: everything, fails_with: :unauthorized
+  the_user :no_access, can_do: listing, and_cannot_do: not_listing
+  the_user :harvester, can_do: nothing, and_cannot_do: everything
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -62,6 +62,6 @@ describe 'Users' do
     get '/my_account', **api_headers(reader_token)
 
     expect_success
-    expect(api_data).to include(contactable: 'no')
+    expect(api_data).to include(contactable: User::CONSENT_NO)
   end
 end

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe 'Verifications' do
+  render_error_responses
+  create_entire_hierarchy
+
+  before do
+    create(:verification, audio_event:, creator: owner_user, confirmed: Verification::CONFIRMATION_TRUE)
+    create(:verification, audio_event:, creator: writer_user, confirmed: Verification::CONFIRMATION_FALSE)
+  end
+
+  it 'can filter verifications by confirmed status' do
+    filter = {
+      filter: {
+        confirmed: { eq: Verification::CONFIRMATION_TRUE }
+      }
+    }
+    get '/verifications/filter', params: filter, **api_headers(writer_token)
+
+    expect(response).to have_http_status(:ok)
+    expect_number_of_items(2)
+    expect(api_data).to include(a_hash_including(confirmed: Verification::CONFIRMATION_TRUE))
+  end
+
+  it 'can filter verifications by creator' do
+    filter = {
+      filter: {
+        creator_id: { not_eq: owner_user.id }
+      }
+    }
+    get '/verifications/filter', params: filter, **api_headers(writer_token)
+
+    expect(response).to have_http_status(:ok)
+    expect_number_of_items(2)
+    expect(api_data).to contain_exactly(
+      a_hash_including(creator_id: writer_user.id),
+      a_hash_including(creator_id: writer_user.id)
+    )
+  end
+
+  it 'can filter verification by audio recording' do
+    filter = {
+      filter: {
+        'audio_recordings.id': { eq: audio_recording.id }
+      }
+    }
+    get '/verifications/filter', params: filter, **api_headers(writer_token)
+
+    expect(response).to have_http_status(:ok)
+    expect_number_of_items(3)
+  end
+
+  describe 'invalid requests' do
+    let(:payload) {
+      {
+        verification: {
+          tag_id: tag.id,
+          audio_event_id: audio_event.id,
+          confirmed: Verification::CONFIRMATION_TRUE
+        }
+      }
+    }
+
+    it 'cannot create a duplicate verification' do
+      post '/verifications', params: payload, **api_with_body_headers(writer_token)
+
+      expect(response).to have_http_status(409)
+      expect_error(:conflict, 'The item must be unique.', nil)
+    end
+  end
+end

--- a/spec/routing/studies_routing_spec.rb
+++ b/spec/routing/studies_routing_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-
-
 describe StudiesController, type: :routing do
   describe :routing do
     it { expect(get('/studies')).to route_to('studies#index', format: 'json') }

--- a/spec/routing/verifications_routing_spec.rb
+++ b/spec/routing/verifications_routing_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe VerificationsController, type: :routing do
+  describe :routing do
+    # nested routes
+    # index
+    it do
+      expect(get('audio_recordings/3/audio_events/4/verifications')).to \
+      route_to('verifications#index', audio_recording_id: '3',
+        audio_event_id: '4', format: 'json')
+    end
+
+    it do
+      expect(get('/projects/1/sites/2/audio_recordings/3/audio_events/4/verifications')).to \
+      route_to('errors#route_error',
+        requested_route: 'projects/1/sites/2/audio_recordings/3/audio_events/4/verifications')
+    end
+
+    # show
+    it do
+      expect(get('audio_recordings/3/audio_events/4/verifications/1')).to \
+      route_to('verifications#show', audio_recording_id: '3',
+        audio_event_id: '4', id: '1', format: 'json')
+    end
+
+    it do
+      expect(get('audio_events/4/verifications/1')).to \
+      route_to('errors#route_error', requested_route: 'audio_events/4/verifications/1')
+    end
+
+    # filter
+    it do
+      expect(get('audio_recordings/1/audio_events/1/verifications/?filter=skip')).to \
+      route_to('verifications#index', audio_recording_id: '1',
+        audio_event_id: '1', format: 'json', filter: 'skip')
+    end
+
+    it do
+      expect(get('audio_recordings/1/verifications/?filter=skip')).to \
+      route_to('errors#route_error', filter: 'skip', requested_route: 'audio_recordings/1/verifications')
+    end
+
+    # shallow routes
+    # index
+    it { expect(get('/verifications')).to route_to('verifications#index', format: 'json') }
+
+    # show
+    it { expect(get('verifications/1')).to route_to('verifications#show', id: '1', format: 'json') }
+
+    # create
+    it { expect(post('/verifications')).to route_to('verifications#create', format: 'json') }
+
+    # update
+    it { expect(put('/verifications/1')).to route_to('verifications#update', id: '1', format: 'json') }
+    it { expect(patch('/verifications/1')).to route_to('verifications#update', id: '1', format: 'json') }
+
+    # destroy
+    it { expect(delete('/verifications/1')).to route_to('verifications#destroy', id: '1', format: 'json') }
+
+    # filter
+    it do
+      expect(get('/verifications?filter=unsure')).to \
+      route_to('verifications#index', format: 'json', filter: 'unsure')
+    end
+
+    # negative cases
+    it { expect(post('/verifications/1')).to route_to('errors#route_error', requested_route: 'verifications/1') }
+    it { expect(put('/verifications')).to route_to('errors#route_error', requested_route: 'verifications') }
+    it { expect(delete('/verifications')).to route_to('errors#route_error', requested_route: 'verifications') }
+
+    it_behaves_like 'our api routing patterns', '/verifications', 'verifications', [:filterable]
+  end
+end

--- a/spec/support/creation_helper.rb
+++ b/spec/support/creation_helper.rb
@@ -34,6 +34,8 @@ module Creation
       prepare_audio_events_tags
       prepare_audio_event_comment
 
+      prepare_verification
+
       prepare_harvest
       prepare_harvest_item
 
@@ -77,7 +79,7 @@ module Creation
       }
     end
 
-    # creates an project with public (allow anon) permissions
+    # creates a project with public (allow anon) permissions
     # as well as a site, audio recording and dataset item
     def create_anon_hierarchy
       prepare_users
@@ -406,6 +408,10 @@ module Creation
       }
     end
 
+    def prepare_verification
+      let!(:verification) { Common.create_verification(writer_user, audio_event, tag) }
+    end
+
     # creates a whole lot of progress events for filter testing
     def prepare_many_progress_events
       let!(:progress_events_stats) {
@@ -475,6 +481,10 @@ module Creation
 
       def create_tag(creator)
         FactoryBot.create(:tag, creator:)
+      end
+
+      def create_verification(creator, audio_event, tag)
+        FactoryBot.create(:verification, creator:, audio_event:, tag:)
       end
 
       def create_provenance(creator)


### PR DESCRIPTION
# Adds a Verification API

The purpose is to implement a verifications table and API.  The motivation is to allow verifications made on the baw-workbench verification grid be persisted to the baw-server database.  closes #705 

## Changes

Adds a `Verification`:
- migration
- model
- model: filter settings
- model: schema
- controller
- model factory

Modifies existing files to include verification:
- routes
- abilities
- factory bot helpers
- model relations 

Adds relevant `Verification` specs:
- model
- requests
- permissions
- api
- routing 

## Problems

- [ ] A complete test run is needed and underway to identify problems + fixes will be appended to this request as needed

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
