### PR TITLE
Adds unique constraint to path on harvest_items

### DIFF
--- a/app/models/harvest_item.rb
+++ b/app/models/harvest_item.rb
@@ -23,7 +23,7 @@ require(BawApp.root / 'app/serializers/hash_serializer')
 #
 #  index_harvest_items_on_harvest_id  (harvest_id)
 #  index_harvest_items_on_info        (info) USING gin
-#  index_harvest_items_on_path        (path)
+#  index_harvest_items_on_path        (path) UNIQUE
 #  index_harvest_items_on_status      (status)
 #
 # Foreign Keys
@@ -54,7 +54,7 @@ class HarvestItem < ApplicationRecord
   # If the file has fixable mistakes they can be changed by the user here
   # (e.g. missing utc offset / site_id for a folder)
   STATUS_METADATA_GATHERED = :metadata_gathered
-  # the file is not valid for some reason we now about (missing utc offset which the user didn't fix)
+  # the file is not valid for some reason we know about (missing utc offset which the user didn't fix)
   STATUS_FAILED = :failed
   # successfully harvested the file, there will be an audio_recording that is available now
   STATUS_COMPLETED = :completed

--- a/db/migrate/20250211012005_add_path_unique_to_harvest_items.rb
+++ b/db/migrate/20250211012005_add_path_unique_to_harvest_items.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Remove duplicate paths from harvest_items and add unique constraint to path
+class AddPathUniqueToHarvestItems < ActiveRecord::Migration[7.2]
+  def change
+    reversible do |change|
+      change.up do
+        execute <<~SQL.squish
+          WITH ranked_items AS (
+              SELECT
+                id,
+                ROW_NUMBER() OVER (
+                  PARTITION BY path
+                  ORDER BY
+                    (audio_recording_id IS NOT NULL) DESC,
+                    pg_column_size(info) DESC
+                ) AS keep_rank
+              FROM harvest_items
+            )
+            DELETE FROM harvest_items
+            WHERE id IN (
+              SELECT id
+              FROM ranked_items
+              WHERE keep_rank > 1
+            );
+        SQL
+        remove_index :harvest_items, :path
+        add_index :harvest_items, :path, unique: true
+      end
+
+      change.down do
+        remove_index :harvest_items, :path
+        add_index :harvest_items, :path
+
+        Rails.logger.warn(
+          'This migration is backwards compatible but does not support reverse migration of the data
+          as the duplicate records were necessarily deleted to add the unique constraint.
+          `path` unique constraint reverted but no data has been changed.'
+        )
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3260,7 +3260,7 @@ CREATE INDEX index_harvest_items_on_info ON public.harvest_items USING gin (info
 -- Name: index_harvest_items_on_path; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_harvest_items_on_path ON public.harvest_items USING btree (path);
+CREATE UNIQUE INDEX index_harvest_items_on_path ON public.harvest_items USING btree (path);
 
 
 --
@@ -4350,6 +4350,7 @@ ALTER TABLE ONLY public.tags
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250211012005'),
 ('20250120064731'),
 ('20250113012304'),
 ('20241106015941'),

--- a/lib/gems/baw-workers/lib/baw_workers/jobs/harvest/harvest_job.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/jobs/harvest/harvest_job.rb
@@ -36,7 +36,12 @@ module BawWorkers
             end
 
             # otherwise create a new one
-            item = new_harvest_item(harvest, rel_path) if item.nil?
+            begin
+              item = new_harvest_item(harvest, rel_path) if item.nil?
+            rescue ::ActiveRecord::RecordNotUnique
+              logger.warn('Failed to create harvest item; path already exists in the database', rel_path: rel_path)
+              return false
+            end
 
             # we never want to harvest a completed item again
             if is_completed?(item)

--- a/spec/factories/audio_recording_factory.rb
+++ b/spec/factories/audio_recording_factory.rb
@@ -66,10 +66,12 @@ FactoryBot.define do
     status { 'ready' }
 
     creator
+
     uploader do
       # admin user
       User.find_by(roles_mask: 1)
     end
+
     site
 
     trait :status_new do

--- a/spec/factories/harvest_item_factory.rb
+++ b/spec/factories/harvest_item_factory.rb
@@ -19,7 +19,7 @@
 #
 #  index_harvest_items_on_harvest_id  (harvest_id)
 #  index_harvest_items_on_info        (info) USING gin
-#  index_harvest_items_on_path        (path)
+#  index_harvest_items_on_path        (path) UNIQUE
 #  index_harvest_items_on_status      (status)
 #
 # Foreign Keys
@@ -30,7 +30,7 @@
 #
 FactoryBot.define do
   factory :harvest_item do
-    path { "#{harvest.upload_directory_name}/some/relative/path.mp3" }
+    sequence(:path) { |n| "#{harvest.upload_directory_name}/some/relative/path_#{n}.mp3" }
 
     info { {} }
     status { :new }

--- a/spec/migrations/add_path_unique_to_harvest_items_spec.rb
+++ b/spec/migrations/add_path_unique_to_harvest_items_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_migration!
+
+describe AddPathUniqueToHarvestItems, :migration do
+  let(:longer_blob) do
+    { error: 'null', fixes: [{ version: 1, problems: { FL001: { status: 'NoOperation' } } }] }
+  end
+  let(:datetime) { "'#{Time.zone.now}'" }
+  let(:harvest_items) { create_harvest_items }
+
+  before do
+    # format the harvest items into a string of values for insertion
+    harvest_values = harvest_items.map { |x| "(#{x})" }.join(",\n")
+
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.connection.execute(
+        <<~SQL.squish
+          INSERT INTO projects (name, creator_id)
+          VALUES ('project1', #{pick_first_id_sql('users')});
+
+          INSERT INTO regions (project_id)
+          VALUES (#{pick_first_id_sql('projects')});
+
+          INSERT INTO sites (name, region_id, creator_id)
+          VALUES ( 'site1', #{pick_first_id_sql('regions')}, #{pick_first_id_sql('users')});
+
+          INSERT INTO audio_recordings (data_length_bytes, duration_seconds,
+          file_hash, media_type, recorded_date, uuid, creator_id, site_id, uploader_id)
+          VALUES ( 1234, 100.0, 'hash1', 'flac', #{datetime}, 'uuid1',
+            #{pick_first_id_sql('users')},
+            #{pick_first_id_sql('sites')},
+            #{pick_first_id_sql('users')});
+
+          INSERT INTO harvests (project_id, created_at, updated_at)
+          VALUES (#{pick_first_id_sql('projects')}, #{datetime}, #{datetime});
+
+          INSERT INTO harvest_items (path, status, info, audio_recording_id,
+          uploader_id, harvest_id, deleted, created_at, updated_at)
+          VALUES #{harvest_values};
+        SQL
+      )
+    end
+
+    expect(select_count_from('harvest_items')).to eq harvest_items.length
+  end
+
+  it 'removes duplicates correctly' do
+    migrate!
+
+    results = ActiveRecord::Base.connection.execute(
+      <<~SQL.squish
+        SELECT path, audio_recording_id, info FROM harvest_items ORDER BY id ASC;
+      SQL
+    )
+    audio_id = ActiveRecord::Base.connection.select_value(
+      <<~SQL.squish
+        SELECT id FROM audio_recordings ORDER BY id DESC LIMIT 1;
+      SQL
+    )
+
+    expect(results.ntuples).to eq(3)
+    expect(results.values).to eq(
+      [
+        # wins because has the largest info
+        ['harvest_1/path/one', nil,
+         '{"error": "null", "fixes": [{"version": 1, "problems": {"FL001": {"status": "NoOperation"}}}]}'],
+        # wins because has the largest info
+        ['harvest_1/path/two', nil,
+         '{"error": "null", "fixes": [{"version": 1, "problems": {"FL001": {"status": "NoOperation"}}}]}'],
+        # wins because it was completed and has a reference to an audio recording
+        ['harvest_1/path/three', audio_id, '{"error": "null"}']
+      ]
+    )
+  end
+
+  # Create a series of harvest item value tuples for combinations of status and path
+  # @return [Array<String>] values for each harvest item
+  def create_harvest_items
+    json_blob = ActiveRecord::Base.connection.quote({ error: 'null' }.to_json)
+    longer_json_blob = ActiveRecord::Base.connection.quote(longer_blob.to_json)
+
+    samples = [
+      ["'metadata_gathered'", "'harvest_1/path/one'"],
+      ["'failed'", "'harvest_1/path/two'"],
+      ["'failed'", "'harvest_1/path/three'"]
+    ]
+    sample_completed = [
+      "'harvest_1/path/three'", "'completed'", json_blob, pick_first_id_sql('audio_recordings'),
+      pick_first_id_sql('users'), pick_first_id_sql('harvests'), true, datetime, datetime
+    ]
+    common_values = ['NULL', pick_first_id_sql('users'), pick_first_id_sql('harvests'), false, datetime, datetime]
+
+    # For each [status, path] pair in samples, generate three test cases:
+    # two with json_blob and one with longer_json_blob (all appended with
+    # common_values), and return a flattened array of all test cases.
+    cases = samples.flat_map { |status, path|
+      [
+        [path, status, json_blob, *common_values],
+        [path, status, json_blob, *common_values],
+        [path, status, longer_json_blob, *common_values]
+      ]
+    }
+
+    cases << sample_completed
+    cases.map! { _1.join(', ') }
+  end
+
+  def pick_first_id_sql(table)
+    "(SELECT id FROM #{table} LIMIT 1)"
+  end
+
+  # Count the number of rows in a table
+  # @param table [String]
+  # @return [Integer] the number of rows in the table
+  def select_count_from(table)
+    ActiveRecord::Base.connection.exec_query("select count(*) from #{table}")[0]['count']
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -193,6 +193,9 @@ RSpec.configure do |config|
   require_relative 'support/audio_helper'
   config.include AudioHelper::Example
 
+  require_relative 'support/harvest_item_helpers'
+  config.include HarvestItemHelper::Example
+
   require_relative 'support/migrations_helper'
   config.include MigrationsHelpers, :migration
 

--- a/spec/requests/harvest/harvest_batch_spec.rb
+++ b/spec/requests/harvest/harvest_batch_spec.rb
@@ -831,11 +831,11 @@ describe 'Harvesting a batch of files' do
       duplicate_rows_query = <<~SQL.squish
         INSERT INTO harvest_items (#{columns})
         (
-          SELECT  'idontexist' AS "path", #{columns_without_path}
+          SELECT  path || series.index, #{columns_without_path}
           FROM  (
             SELECT #{columns} FROM harvest_items ORDER BY id DESC LIMIT 1
           ) AS t
-          CROSS JOIN LATERAL generate_series(1,#{duplicates})
+          CROSS JOIN LATERAL generate_series(1,#{duplicates}) series(index)
         )
       SQL
       ActiveRecord::Base.connection.execute(duplicate_rows_query)

--- a/spec/requests/harvest/harvest_naming_spec.rb
+++ b/spec/requests/harvest/harvest_naming_spec.rb
@@ -16,7 +16,7 @@ describe 'Harvesting files', :clean_by_truncation do
       Timecop.return
     end
 
-    let(:default_name) { "#{Time.now.strftime('%B')} #{Time.now.day.ordinalize} Upload" }
+    let(:default_name) { "#{Time.zone.now.strftime('%B')} #{Time.zone.now.day.ordinalize} Upload" }
 
     context 'when streaming' do
       it 'can set a name on create' do
@@ -130,7 +130,7 @@ describe 'Harvesting files', :clean_by_truncation do
         end
 
         step 'transition to :metadata_extraction' do
-          expect_enqueued_jobs(1, of_class: ::BawWorkers::Jobs::Harvest::ScanJob)
+          expect_enqueued_jobs(1, of_class: BawWorkers::Jobs::Harvest::ScanJob)
           perform_jobs(count: 1)
           expect_jobs_to_be(completed: 1, of_class: BawWorkers::Jobs::Harvest::ScanJob)
         end

--- a/spec/requests/harvest_items_spec.rb
+++ b/spec/requests/harvest_items_spec.rb
@@ -8,15 +8,15 @@ describe 'Harvest items info' do
   prepare_harvest
 
   before do
-    @hi1 = create_with_validations(fixable: 3, not_fixable: 1)
-    @hi2 = create_with_validations(fixable: 0, not_fixable: 1)
-    @hi3 = create_with_validations(fixable: 1, not_fixable: 0)
-    @hi4 = create_with_validations(fixable: 0, not_fixable: 1, sub_directories: 'a/b/c')
-    @hi5 = create_with_validations(fixable: 0, not_fixable: 0, sub_directories: 'a/b/c')
-    @hi6 = create_with_validations(fixable: 0, not_fixable: 0, sub_directories: 'a/b/d')
-    @hi7 = create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'a/b')
-    @hi8 = create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'a/b')
-    @hi9 = create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'z/b')
+    @hi1 = create_with_validations(fixable: 3, not_fixable: 1, audio: true)
+    @hi2 = create_with_validations(fixable: 0, not_fixable: 1, audio: true)
+    @hi3 = create_with_validations(fixable: 1, not_fixable: 0, audio: true)
+    @hi4 = create_with_validations(fixable: 0, not_fixable: 1, sub_directories: 'a/b/c', audio: true)
+    @hi5 = create_with_validations(fixable: 0, not_fixable: 0, sub_directories: 'a/b/c', audio: true)
+    @hi6 = create_with_validations(fixable: 0, not_fixable: 0, sub_directories: 'a/b/d', audio: true)
+    @hi7 = create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'a/b', audio: true)
+    @hi8 = create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'a/b', audio: true)
+    @hi9 = create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'z/b', audio: true)
   end
 
   it 'can query for harvest items (root path)' do
@@ -140,7 +140,7 @@ describe 'Harvest items info' do
 
       expect(results.headers).to eq ['id', 'harvest_id', 'path', 'status', 'audio_recording_id']
       rows = results.map(&:to_h)
-      HarvestItem.all.each { |item|
+      HarvestItem.find_each { |item|
         expect(rows).to include(a_hash_including(
           'id' => item.id.to_s,
           'harvest_id' => item.harvest_id.to_s,
@@ -155,9 +155,9 @@ describe 'Harvest items info' do
   context 'with lots of items' do
     before do
       50.times do
-        create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'a')
+        create_with_validations(fixable: 1, not_fixable: 0, sub_directories: 'a', audio: false)
 
-        create_with_validations(fixable: 0, not_fixable: 0, sub_directories: 'e')
+        create_with_validations(fixable: 0, not_fixable: 0, sub_directories: 'e', audio: false)
       end
     end
 
@@ -245,32 +245,5 @@ describe 'Harvest items info' do
 
       expect_has_paging(page: 1, total: 50)
     end
-  end
-
-  def create_with_validations(fixable: 0, not_fixable: 0, sub_directories: nil)
-    validations = []
-    fixable.times do
-      validations << BawWorkers::Jobs::Harvest::ValidationResult.new(
-        status: :fixable,
-        name: :wascally_wabbit,
-        message: nil
-      )
-    end
-    not_fixable.times do
-      validations << BawWorkers::Jobs::Harvest::ValidationResult.new(
-        status: :not_fixable,
-        name: :kiww_the_wabbit,
-        message: nil
-      )
-    end
-
-    info = BawWorkers::Jobs::Harvest::Info.new(
-      validations:
-    )
-
-    path = generate_recording_name(Time.zone.now)
-    path = File.join(*[harvest.upload_directory_name, sub_directories, path].compact)
-
-    create(:harvest_item, path:, status: HarvestItem::STATUS_METADATA_GATHERED, info:, harvest:)
   end
 end

--- a/spec/support/harvest_item_helpers.rb
+++ b/spec/support/harvest_item_helpers.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Helper methods for creating harvest items in tests
+module HarvestItemHelper
+  # Example methods for harvest item creation
+  module Example
+    # Creates a harvest item with specified validation results
+    # @param fixable [Integer] Number of fixable validation results to create
+    # @param not_fixable [Integer] Number of not fixable validation results to create
+    # @param sub_directories [String, nil] Optional subdirectories to append to the path
+    # @param audio [Boolean] Whether to create an associated audio recording
+    # @return [HarvestItem] The created harvest item
+    def create_with_validations(fixable: 0, not_fixable: 0, sub_directories: nil, audio: false)
+      validations = []
+      fixable.times do
+        validations << BawWorkers::Jobs::Harvest::ValidationResult.new(
+          status: :fixable,
+          name: :wascally_wabbit,
+          message: nil
+        )
+      end
+      not_fixable.times do
+        validations << BawWorkers::Jobs::Harvest::ValidationResult.new(
+          status: :not_fixable,
+          name: :kiww_the_wabbit,
+          message: nil
+        )
+      end
+
+      info = BawWorkers::Jobs::Harvest::Info.new(
+        validations:
+      )
+      time = Time.zone.now
+      path = generate_recording_name(time, suffix: time.subsec.numerator.to_s)
+      path = File.join(*[harvest.upload_directory_name, sub_directories, path].compact)
+
+      recording = (create(:audio_recording, site: site, creator: owner_user, uploader: admin_user) if audio)
+      create(
+        :harvest_item,
+        path:,
+        status: HarvestItem::STATUS_METADATA_GATHERED,
+        info:,
+        harvest:,
+        uploader: owner_user,
+        audio_recording: recording
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Adds unique constraint to path on harvest_items

The purpose of this PR is to update the `path` field on harvest_items to a unique index constraint. This will address the issue of duplicate harvest_item rows (same file path) being persisted to the harvest_items table, which occurs due to a race condition during the audio file enqueue process of a harvest job.  

Closes #660

## Changes

- migration to add unique constraint on path and delete existing duplicates in harvest items table
- migration test 
- handle exceptions such that duplicate path doesn't cause db exception to be raised
  -  behaviour tested in `harvest_job_spec`
- add a helper for shared test logic (creating harvest_items with validations)
- fixes across tests where setup included creating harvest items with duplicate paths

## Problems

- Database backup prior to running migration
- Test suite full run in progress

## Final Checklist

- [ x] Assign reviewers if you have permission
- [ x] Assign labels if you have permission
- [ x] Link issues related to PR
- [ x] Remove/Reduce warnings from edited files
- [ x] Unit tests have been added for changes
- [  ] Ensure CI build is passing