### PR TITLE
Verification upsert api route

### DIFF
--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -64,6 +64,20 @@ class VerificationsController < ApplicationController
     end
   end
 
+  # PUT /verifications
+  def create_or_update
+    do_load_or_new_resource(verification_params, find_keys: [:audio_event_id, :tag_id])
+    do_authorize_instance
+
+    return respond_change_fail unless @verification.save
+
+    if @verification.previously_new_record?
+      respond_create_success(shallow_verification_url(@verification))
+    else
+      respond_show
+    end
+  end
+
   # Handled in Archivable
   # DELETE /verifications/:id
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -840,7 +840,7 @@ class Ability
       check_audio_event(user, verification.audio_event.audio_recording.site, verification.audio_event)
     end
 
-    can [:create, :update], Verification do |verification|
+    can [:create, :update, :create_or_update], Verification do |verification|
       check_model(verification)
       Access::Core.check_orphan_site!(verification.audio_event.audio_recording.site)
 

--- a/app/modules/api/response.rb
+++ b/app/modules/api/response.rb
@@ -238,7 +238,7 @@ module Api
       error_hash = {}
       error_hash[:details] = opts[:error_details] if opts[:error_details].present? # string
       error_hash[:links] = response_error_links(opts[:error_links]) if opts[:error_links].present? # array
-      error_hash[:info] = opts[:error_info] if [:error_info].present? # hash or string or array
+      error_hash[:info] = opts[:error_info] if opts[:error_info].present? # hash or string or array
       error_hash
     end
 

--- a/baw-server.code-workspace
+++ b/baw-server.code-workspace
@@ -200,6 +200,7 @@
       "uploader",
       "uploaders",
       "upsert",
+      "upsertable",
       "urlsafe",
       "uuid",
       "walltime",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -536,6 +536,11 @@ Rails.application.routes.draw do
     post 'recover', on: :member, defaults: { format: 'json' }
   end
 
+  # https://github.com/QutEcoacoustics/baw-server/wiki/API:-Spec#upsert
+  concern :upsertable do
+    put '', on: :collection, defaults: { format: 'json' }, action: :create_or_update
+  end
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
@@ -765,7 +770,7 @@ Rails.application.routes.draw do
   resources :verifications, except: [:edit],
     as: 'shallow_verifications',
     defaults: { format: 'json' },
-    concerns: [:filterable]
+    concerns: [:filterable, :upsertable]
 
   # API audio_event create
   resources :audio_events, only: [], defaults: { format: 'json' }, concerns: [:filterable] do

--- a/config/solargraph.rb
+++ b/config/solargraph.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Instructions: https://solargraph.org/guides/rails
 # sourced from: https://gist.githubusercontent.com/castwide/28b349566a223dfb439a337aea29713e/raw/d1d4462b92f411b378d87a39482b830e012513bd/rails.rb
 
@@ -13,6 +14,8 @@
 # @!parse
 #   class ActionController::Base
 #     include ActionController::MimeResponds
+#     include ActionController::Parameters
+#     include ActionController::StrongParameters
 #     extend ActiveSupport::Callbacks::ClassMethods
 #     extend AbstractController::Callbacks::ClassMethods
 #   end

--- a/spec/api/verifications_spec.rb
+++ b/spec/api/verifications_spec.rb
@@ -40,6 +40,37 @@ describe 'verifications' do
           run_test!
         end
       end
+
+      put('create or update verification') do
+        model_sent_as_parameter_in_body
+
+        response(201, 'successful') do
+          schema_for_single
+          auto_send_model
+          run_test!
+        end
+
+        response(200, 'successful') do
+          schema_for_single
+
+          let(:existing_verification) {
+            create(:verification, audio_event:, tag:, creator: admin_user)
+          }
+
+          send_model do
+            {
+              'verification' => {
+                audio_event_id: existing_verification.audio_event_id,
+                tag_id: existing_verification.tag_id,
+                confirmed: Verification::CONFIRMATION_FALSE
+              }
+            }
+          end
+          run_test! do
+            expect_id_matches(existing_verification)
+          end
+        end
+      end
     end
 
     path '/verifications/new' do

--- a/spec/routing/verifications_routing_spec.rb
+++ b/spec/routing/verifications_routing_spec.rb
@@ -65,9 +65,8 @@ describe VerificationsController, type: :routing do
 
     # negative cases
     it { expect(post('/verifications/1')).to route_to('errors#route_error', requested_route: 'verifications/1') }
-    it { expect(put('/verifications')).to route_to('errors#route_error', requested_route: 'verifications') }
     it { expect(delete('/verifications')).to route_to('errors#route_error', requested_route: 'verifications') }
 
-    it_behaves_like 'our api routing patterns', '/verifications', 'verifications', [:filterable]
+    it_behaves_like 'our api routing patterns', '/verifications', 'verifications', [:filterable, :upsertable]
   end
 end

--- a/spec/support/shared_examples/our_api_routing_patterns.rb
+++ b/spec/support/shared_examples/our_api_routing_patterns.rb
@@ -3,13 +3,16 @@
 # Example
 #        it_behaves_like 'our api routing patterns', '/bookmarks', 'bookmarks', [:filterable, :capable, :invocable, :statistical]
 RSpec.shared_examples 'our api routing patterns' do |path, controller, concerns, extra_options = {}, example_invocable = 'start'|
-  raise 'unknown concerns' if (concerns - [:filterable, :capable, :invocable, :statistical, :archivable]).count > 0
+  raise 'unknown concerns' if (
+    concerns - [:filterable, :capable, :invocable, :statistical, :archivable, :upsertable]
+  ).count > 0
 
   let(:filterable) { concerns.include?(:filterable) ? :to : :not_to }
   let(:capable) { concerns.include?(:capable) ? :to : :not_to }
   let(:invocable) { concerns.include?(:invocable) ? :to : :not_to }
   let(:statistical) { concerns.include?(:statistical) ? :to : :not_to }
   let(:archivable) { concerns.include?(:archivable) ? :to : :not_to }
+  let(:upsertable) { concerns.include?(:upsertable) ? :to : :not_to }
 
   it {
     expect(get("#{path}/filter")).send(filterable, route_to(
@@ -74,6 +77,12 @@ RSpec.shared_examples 'our api routing patterns' do |path, controller, concerns,
   it {
     expect(post("#{path}/1/recover")).send(archivable, route_to(
       controller:, action: 'recover', id: '1', format: 'json', **extra_options
+    ))
+  }
+
+  it {
+    expect(put(path)).send(upsertable, route_to(
+      controller:, action: 'create_or_update', format: 'json', **extra_options
     ))
   }
 end


### PR DESCRIPTION
# Verification upsert api route

In the workbench client verification grid, a conflict is raised if an event has already been verified by the current user. Overwriting conflicts requires additional requests. This pull request adds a verifications upsert (update or insert) endpoint for current users, allowing single request creation/overwriting.

Closes (#724)

## Changes

- adds a new controller helper for upserting
- adds `create_or_update` action on verifications controller
- adds an `upsertable` route concern
- adds `upsertable` concern to our_api_routing_patterns shared examples 
- updates verification specs

## Problems

None identified. Full test suite in progress.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
