### PR TITLE
Filters out not-ready recordings from audio recording endpoints

### DIFF
--- a/app/models/analysis_job.rb
+++ b/app/models/analysis_job.rb
@@ -399,11 +399,19 @@ class AnalysisJob < ApplicationRecord
       )
     end => base_scope
 
+    # never allow non-ready recordings to be included in the filter
+    base_scope = base_scope.status_ready
+
+    # additionally, since we enforce the ready check in the scope, we don't
+    # need to duplicate the condition that comes from the filter defaults
+    filter_settings = AudioRecording.filter_settings.dup
+    filter_settings[:defaults].delete(:filter)
+
     filter_query = Filter::Query.new(
       whole_filter,
       base_scope,
       AudioRecording,
-      AudioRecording.filter_settings
+      filter_settings
     )
 
     filter_query.query_without_paging_sorting

--- a/app/models/audio_recording.rb
+++ b/app/models/audio_recording.rb
@@ -184,6 +184,7 @@ class AudioRecording < ApplicationRecord
                                      })
   scope :total_data_bytes, -> { sum(arel_table[:data_length_bytes].cast('bigint')) }
   scope :total_duration_seconds, -> { sum(arel_table[:duration_seconds].cast('bigint')) }
+  scope :status_ready, -> { where(status: STATUS_READY) }
 
   # Allows this model to infer its timezone when included with larger queries
   # constructed by filter args.
@@ -385,7 +386,10 @@ class AudioRecording < ApplicationRecord
       action: :filter,
       defaults: {
         order_by: :recorded_date,
-        direction: :desc
+        direction: :desc,
+        filter: lambda {
+          Current.user&.admin? ? {} : { status: { eq: STATUS_READY } }
+        }
       },
       capabilities: {
         original_download: {

--- a/app/modules/api/controller_helper.rb
+++ b/app/modules/api/controller_helper.rb
@@ -174,7 +174,10 @@ module Api
     def filename(opts, format)
       # a rudimentary way of encoding filtering parameters into a filename
       # e.g. {id: {in: [1,2,3]}, name: {eq: '\n'}}  ==> id_in_1_2_3_name_eq_n
-      filter = opts[:filter]
+      # AT 2025: I decided not to include default filters in the filename
+      # because they don't add enough new information and just bloat otherwise
+      # simple filter file names
+      filter = opts[:filter_without_defaults]
       filter_part = filter.blank? ? '' : "_#{filter.to_json.gsub(/["{}\\\[\]]/, '').gsub(/:|,/, '_')}"
       "#{Time.now.utc.strftime('%Y%m%dT%H%M%SZ')}_#{resource_name_plural}#{filter_part}.#{format}"
     end

--- a/app/modules/api/response.rb
+++ b/app/modules/api/response.rb
@@ -349,6 +349,7 @@ module Api
 
       # build complete api response
       opts[:filter] = filter_query.filter if filter_query.filter.present?
+      opts[:filter_without_defaults] = filter_query.supplied_filter if filter_query.supplied_filter.present?
       opts[:projection] = filter_query.projection if filter_query.projection.present?
       opts[:capabilities] = filter_query.capabilities if filter_query.capabilities.present?
       opts[:additional_params] = filter_query.parameters.except(

--- a/app/modules/custom_errors.rb
+++ b/app/modules/custom_errors.rb
@@ -234,6 +234,16 @@ module CustomErrors
     end
   end
 
+  # 500 for invalid filter settings - these are not user errors
+  # but errors in the filter settings.
+  class FilterSettingsError < CustomError
+    def initialize(message = nil)
+      super
+      @status_code = :internal_server_error
+      @prefix = 'Filter settings invalid'
+    end
+  end
+
   class AudioGenerationError < RuntimeError
     attr_reader :job_info
 

--- a/app/modules/filter/build.rb
+++ b/app/modules/filter/build.rb
@@ -125,9 +125,9 @@ module Filter
     # @param [Array<Arel::Nodes::Node>] conditions
     # @return [Arel::Nodes::Node] condition
     def combiner_one(combiner, conditions)
-      if conditions.blank? || conditions.size < 2
+      if conditions.blank?
         raise CustomErrors::FilterArgumentError,
-          "Combiner '#{combiner}' must have at least 2 entries, got #{conditions.size}."
+          "Combiner '#{combiner}' must have at least 1 entry, got #{conditions.size}."
       end
 
       transforms_collection = []

--- a/app/modules/filter/query.rb
+++ b/app/modules/filter/query.rb
@@ -29,6 +29,10 @@ module Filter
       :qsp_generic_filters, :paging, :sorting, :build,
       :custom_fields2, :capabilities
 
+    # Returns the filter provided by a request, before being merged onto the default filter
+    # @return [Hash] filter
+    attr_reader :supplied_filter
+
     # Convert a json POST body to an arel query.
     # @param [Hash] parameters
     # @param [ActiveRecord::Relation] query
@@ -55,13 +59,16 @@ module Filter
         raise ArgumentError, "query was not an ActiveRecord::Relation. Query: #{query}"
       end
 
-      validate_filter_settings(filter_settings)
+      reraise_as_internal_error do
+        validate_filter_settings(filter_settings)
+      end
       @valid_fields = filter_settings[:valid_fields].map(&:to_sym)
       @text_fields = filter_settings.include?(:text_fields) ? filter_settings[:text_fields].map(&:to_sym) : []
       @render_fields = filter_settings[:render_fields].map(&:to_sym)
       @filter_settings = filter_settings
       @default_sort_order = filter_settings[:defaults][:order_by]
       @default_sort_direction = filter_settings[:defaults][:direction]
+      @default_filter = filter_settings[:defaults].fetch(:filter, nil)
       @custom_fields2 = filter_settings[:custom_fields2] || {}
       @capabilities = filter_settings[:capabilities] || {}
       set_archived_param(parameters)
@@ -73,20 +80,28 @@ module Filter
 
       @parameters = decode_payload(@parameters)
 
-      @filter = @parameters.include?(:filter) && @parameters[:filter].present? ? @parameters[:filter] : {}
+      @supplied_filter = @parameters.include?(:filter) && @parameters[:filter].present? ? @parameters[:filter] : {}
       @projection = parse_projection(@parameters)
 
       # remove key_partial_match key from parameters hash
       parameters_for_generic = @parameters.dup
       parameters_for_generic.delete(key_partial_match) if parameters_for_generic.include?(key_partial_match)
 
+      # ensure filter is a hash
+      @supplied_filter, was_normalized = normalize_filter_root_array(@supplied_filter)
+
       # merge filters from qsp partial text match into POST body filter
       partial_match_filters = parse_qsp_partial_match_text(@parameters, key_partial_match, @text_fields)
-      @filter = add_qsp_to_filter(@filter, partial_match_filters, :or)
+      @supplied_filter = add_qsp_to_filter(@supplied_filter, partial_match_filters, :or)
 
       # merge filters from qsp generic equality match into POST body filter
       qsp_generic_filters = parse_qsp(nil, parameters_for_generic, key_prefix)
-      @filter = add_qsp_to_filter(@filter, qsp_generic_filters, :and)
+      @supplied_filter = add_qsp_to_filter(@supplied_filter, qsp_generic_filters, :and)
+
+      # merge default filter into the rest of the filter
+      reraise_as_internal_error do
+        @filter = merge_filters(@supplied_filter.dup, @default_filter, was_normalized:)
+      end
 
       # populate properties with qsp filter spec
       @qsp_text_filter = @parameters[key_partial_match]
@@ -207,7 +222,7 @@ module Filter
     end
 
     def is_paging_disabled?
-      @paging[:disable_paging] == 'true' || @paging[:disable_paging] == true
+      ['true', true].include?(@paging[:disable_paging])
     end
 
     def has_sort_params?
@@ -223,6 +238,18 @@ module Filter
     end
 
     private
+
+    # rebrand the error to be more specific and generate a better error message
+    def reraise_as_internal_error
+      yield
+    rescue CustomErrors::FilterArgumentError => e
+      # TODO: this is a bit of a hack, we should split the params validators out
+      # from the settings validators rather than doing dodgy error wrapping
+      # and re-raising
+      error = CustomErrors::FilterSettingsError.new(e.message)
+      error.set_backtrace(e.backtrace)
+      raise error
+    end
 
     def decode_payload(parameters)
       return parameters unless parameters.include?(:filter_encoded)
@@ -257,6 +284,16 @@ module Filter
       parameters
     end
 
+    # normalize a root filter array - the root array syntax is just syntactic sugar
+    # for a keyed "and" filter, so we convert it to that
+    # @param [Hash,Array] filter
+    # @return [Array(Hash,Boolean)]
+    def normalize_filter_root_array(filter)
+      return [{ and: filter }, true] if filter.is_a?(Array)
+
+      [filter, false]
+    end
+
     # Add qsp spec to filter
     # @param [Hash,Array] filter
     # @param [Hash] additional
@@ -264,14 +301,11 @@ module Filter
     # @return [Hash,Array]
     def add_qsp_to_filter(filter, additional, combiner)
       raise 'Additional filter items must be a hash.' unless additional.is_a?(Hash)
-      raise 'Filter must be a hash or array.' unless filter.is_a?(Hash) || filter.is_a?(Array)
+      raise 'Filter must be a hash.' unless filter.is_a?(Hash)
       raise 'Combiner should not be blank.' if combiner.blank? || !combiner.is_a?(Symbol)
 
       # don't do anything unless we need to
       #return filter if additional.size.zero?
-
-      # normalize a root filter array
-      filter = { and: filter } if filter.is_a?(Array)
 
       # return a merge of existing filter and qsp filters
       # {
@@ -308,6 +342,60 @@ module Filter
       end
 
       filter
+    end
+
+    # Merge default filter into supplied filter.
+    # @param [Hash,Array] filter
+    # @param [Hash,Proc,nil] default
+    # # @param [Boolean] was_normalized
+    #   true if the filter was normalized from a root array
+    # @return [Hash,Array]
+    def merge_filters(filter, default, was_normalized:)
+      return filter if default.blank?
+
+      # @type [Hash]
+      default = default.call if default.is_a?(Proc)
+
+      return filter if default.nil? || default.try(:empty?)
+
+      validate_hash(default)
+
+      # convert default filter to an array, if supplied filter is also an array
+      if was_normalized
+        default = default.map { |key, value| { key => value } }
+        # @type [Array]
+        merged = default + filter[:and]
+
+        # remove any entries if there are knockouts
+        merged.each_with_index do |rule, i|
+          # we're not up to the stage where supplied filters have been validated yet
+          next unless rule.is_a?(Hash)
+
+          # is any value in the rule a knockout (nil)?
+          rule.each do |key, value|
+            next unless value.nil?
+
+            # remove the knockout sigil
+            rule.delete(key)
+
+            # and search back for the given key in previous entries
+            # to do the actual knockout
+            merged[0..i].reverse_each do |previous|
+              previous.delete(key) if previous.is_a?(Hash) && previous.include?(key)
+            end
+          end
+        end
+
+        # finally remove any empty entries
+        merged.reject! do |rule|
+          rule.is_a?(Hash) && rule.empty?
+        end
+
+        filter.merge(and: merged)
+      else
+        # merge default filter into filter
+        default.deep_merge(filter).compact
+      end
     end
 
     # Add conditions to a query.

--- a/app/modules/filter/validate.rb
+++ b/app/modules/filter/validate.rb
@@ -251,7 +251,7 @@ module Filter
     # @raise [FilterArgumentError] if value is not a valid Hash.
     # @return [void]
     def validate_hash(value)
-      raise CustomErrors::FilterArgumentError, "Value must not be null, got #{value}" if value.blank?
+      raise CustomErrors::FilterArgumentError, "Value must not be null, got #{value}" if value.nil?
       raise CustomErrors::FilterArgumentError, "value must be a Hash, got #{value}" unless value.is_a?(Hash)
     end
 
@@ -396,6 +396,17 @@ module Filter
       end
       unless value[:defaults][:direction].is_a?(Symbol)
         raise CustomErrors::FilterArgumentError, 'Direction must be a symbol.'
+      end
+
+      if value[:defaults].include?(:filter)
+        case value[:defaults][:filter]
+        when Proc
+          validate_closure(value[:defaults][:filter])
+        when nil
+          # do nothing
+        else
+          validate_hash(value[:defaults][:filter])
+        end
       end
 
       # advanced filter settings

--- a/spec/lib/modules/filter/query_expressions_spec.rb
+++ b/spec/lib/modules/filter/query_expressions_spec.rb
@@ -105,6 +105,7 @@ describe Filter::Query do
           ON ("sites"."deleted_at" IS NULL)
           AND ("sites"."id" = "audio_recordings"."site_id")
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ((("audio_recordings"."recorded_date" AT TIME ZONE 'UTC') AT TIME ZONE "sites"."tzinfo_tz") = (('2022-02-02T22:22' AT TIME ZONE 'UTC') AT TIME ZONE "sites"."tzinfo_tz"))
           ORDER BY "audio_recordings"."recorded_date" DESC
           LIMIT 25 OFFSET 0
@@ -140,6 +141,7 @@ describe Filter::Query do
           INNER JOIN "offset_table"
           ON "sites"."tzinfo_tz" = "offset_table"."name"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ((("audio_recordings"."recorded_date" AT TIME ZONE 'UTC') AT TIME ZONE "offset_table"."base_offset") = (('2022-02-02T22:22' AT TIME ZONE 'UTC') AT TIME ZONE "offset_table"."base_offset"))
           ORDER BY "audio_recordings"."recorded_date" DESC
           LIMIT 25 OFFSET 0
@@ -168,6 +170,7 @@ describe Filter::Query do
           ON ("sites"."deleted_at" IS NULL)
           AND ("sites"."id" = "audio_recordings"."site_id")
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND (CAST((("audio_recordings"."recorded_date" AT TIME ZONE 'UTC') AT TIME ZONE "sites"."tzinfo_tz") AS time) = CAST('22:22' AS time))
           ORDER BY "audio_recordings"."recorded_date" DESC
           LIMIT 25 OFFSET 0
@@ -199,10 +202,12 @@ describe Filter::Query do
           SELECT "audio_recordings"."recorded_date"
           FROM "audio_recordings"
           LEFT OUTER JOIN "sites"
-          ON ("sites"."deleted_at" IS NULL) AND ("sites"."id" = "audio_recordings"."site_id")
+          ON ("sites"."deleted_at" IS NULL)
+          AND ("sites"."id" = "audio_recordings"."site_id")
           INNER JOIN "offset_table"
           ON "sites"."tzinfo_tz" = "offset_table"."name"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND (CAST((("audio_recordings"."recorded_date" AT TIME ZONE 'UTC') AT TIME ZONE "offset_table"."base_offset") AS time) = CAST('22:22' AS time))
           ORDER BY "audio_recordings"."recorded_date" DESC
           LIMIT 25 OFFSET 0
@@ -228,6 +233,7 @@ describe Filter::Query do
           SELECT "audio_recordings"."recorded_date"
           FROM "audio_recordings"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND (
           CAST("audio_recordings"."recorded_date" AS time) =
           CAST('22:22' AS time))
@@ -270,6 +276,7 @@ describe Filter::Query do
           INNER JOIN "offset_table"
           ON "sites"."tzinfo_tz" = "offset_table"."name"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND (((CAST(((("audio_recordings"."recorded_date" + CAST("audio_recordings"."duration_seconds" || ' seconds' as interval)) AT TIME ZONE 'UTC') AT TIME ZONE "offset_table"."base_offset") AS time) >= CAST('03:00' AS time))
           OR (CAST((("audio_recordings"."recorded_date" AT TIME ZONE 'UTC') AT TIME ZONE "offset_table"."base_offset") AS time) <= CAST('05:00' AS time))))
           ORDER BY "audio_recordings"."recorded_date" DESC

--- a/spec/lib/modules/filter/query_filter_arrays_spec.rb
+++ b/spec/lib/modules/filter/query_filter_arrays_spec.rb
@@ -94,7 +94,8 @@ describe Filter::Query do
           SELECT "audio_recordings"."recorded_date"
           FROM "audio_recordings"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
-          AND ((("audio_recordings"."recorded_date" = '2022-02-02 22:22:00')
+          AND ((("audio_recordings"."status" = 'ready')
+          AND ("audio_recordings"."recorded_date" = '2022-02-02 22:22:00')
           AND ("audio_recordings"."recorded_date" = '2022-02-03 22:22:00')
           AND ("audio_recordings"."site_id" = 3)))
           ORDER BY "audio_recordings"."recorded_date" DESC
@@ -125,6 +126,7 @@ describe Filter::Query do
           SELECT "audio_recordings"."recorded_date"
           FROM "audio_recordings"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."recorded_date" = '2022-02-02 22:22:00')
           AND ((("audio_recordings"."id" > 0)
           AND ("audio_recordings"."site_id" = 3)))
@@ -156,6 +158,7 @@ describe Filter::Query do
           SELECT "audio_recordings"."recorded_date"
           FROM "audio_recordings"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."recorded_date" = '2022-02-02 22:22:00')
           AND ((("audio_recordings"."id" > 0)
           OR ("audio_recordings"."site_id" = 3)))
@@ -197,6 +200,7 @@ describe Filter::Query do
           SELECT "audio_recordings"."recorded_date"
           FROM "audio_recordings"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."recorded_date" = '2022-02-02 22:22:00')
           AND ((((("audio_recordings"."id" > 0) AND ("audio_recordings"."site_id" = 3)))
           OR ((("audio_recordings"."id" > 1) OR ("audio_recordings"."site_id" = 4)))))

--- a/spec/lib/modules/filter/query_filter_defaults_spec.rb
+++ b/spec/lib/modules/filter/query_filter_defaults_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+describe Filter::Query do
+  create_entire_hierarchy
+
+  include SqlHelpers::Example
+
+  def compare_filter_sql(filter, sql_result)
+    filter_query = create_filter(filter)
+    comparison_sql(filter_query.query_full.to_sql, sql_result)
+    filter_query
+  end
+
+  describe 'default filters' do
+    context 'with no-op values' do
+      [
+        # backwards compatibility, a default filter is not required
+        {},
+        { filter: {} },
+        { filter: nil },
+        { filter: -> { {} } },
+        { filter: -> {} }
+      ].each do |defaults|
+        it "does not apply defaults when given #{defaults}" do
+          filter_settings = AudioRecording.filter_settings.dup
+          default_hash = filter_settings[:defaults].except(:filter).merge(defaults)
+
+          # should throw if invalid, this is the test
+          filter = Filter::Query.new(
+            {},
+            AudioRecording.all,
+            AudioRecording,
+            filter_settings.merge(defaults: default_hash)
+          )
+
+          # and nothing has been applied
+          expect(filter.filter).to eq({})
+
+          expect(filter.query_without_paging_sorting.count('*')).to eq(AudioRecording.count)
+        end
+      end
+    end
+
+    context 'with incorrect configuration' do
+      [
+        1,
+        [1],
+        'hello',
+        -> { 'hello' },
+        -> { 1 },
+        # we don't allow root arrays in the defaults
+        # root arrays are just syntactic sugar for keyed "and" filters and the
+        # merging implications are too complex to be worth it
+        [{ id: { gt: 0 } }],
+        -> { [{ id: { gt: 0 } }] }
+      ].each do |default_filter|
+        it 'requires a hash or an array of filters' do
+          filter_settings = AudioRecording.filter_settings
+          default = filter_settings[:defaults].merge(filter: default_filter)
+
+          expect {
+            Filter::Query.new(
+              {},
+              AudioRecording.all,
+              AudioRecording,
+              filter_settings.merge(defaults: default)
+            ).query_full
+          }.to raise_error(CustomErrors::FilterSettingsError, /Filter settings invalid: .*/)
+        end
+      end
+    end
+
+    shared_examples 'a filter with defaults' do |test_case|
+      describe "test case #{test_case[:name]}:" do
+        let(:default) { test_case[:default] }
+        let(:supplied) { test_case[:supplied] }
+        let(:expected) { test_case[:expected] }
+        let(:expected_set) { test_case[:expected_set] }
+        let(:where_clause) { test_case[:where_clause] }
+
+        def filter_query(default_filter, supplied_params)
+          filter_settings = AudioRecording.filter_settings
+          defaults = filter_settings[:defaults].except(:filter)
+
+          Filter::Query.new(
+            { filter: supplied_params },
+            AudioRecording.all,
+            AudioRecording,
+            filter_settings.merge(defaults: defaults.merge({ filter: default_filter }))
+          )
+        end
+
+        it 'is applied' do
+          expect(filter_query(default, supplied).filter).to eq(expected)
+        end
+
+        it 'is effectual' do
+          result = filter_query(default, supplied).query_full.to_a
+          if expected_set == :empty
+            expect(result).to be_empty
+          else
+            expect(result).not_to be_empty
+          end
+        end
+
+        it 'generates correct sql' do
+          contains_sql(
+            filter_query(default, supplied).query_full.to_sql,
+            where_clause
+          )
+        end
+      end
+    end
+
+    [
+      {
+        name: 'default filter',
+        default: { id: { lt: 0 } },
+        supplied: {},
+        expected: { id: { lt: 0 } },
+        expected_set: :empty,
+        where_clause: '"audio_recordings"."id" < 0'
+      },
+      {
+        name: 'default filter overridden by supplied filter',
+        default: { id: { lt: 0 } },
+        supplied: { id: { lt: 1_000_000 } },
+        expected: { id: { lt: 1_000_000 } },
+        where_clause: '"audio_recordings"."id" < 1000000'
+      },
+
+      {
+        name: 'default filter merged with supplied filter (same field)',
+        default: { id: { lt: 0 } },
+        supplied: { id: { gt: 0 } },
+        expected: { id: { lt: 0, gt: 0 } },
+        expected_set: :empty,
+        where_clause: '("audio_recordings"."id" < 0) AND ("audio_recordings"."id" > 0)'
+      },
+      {
+        name: 'default filter merged with supplied filter (different fields)',
+        default: { id: { lt: 0 } },
+        supplied: { duration_seconds: { gt: 3600 } },
+        expected: { id: { lt: 0 }, duration_seconds: { gt: 3600 } },
+        expected_set: :empty,
+        where_clause: '("audio_recordings"."id" < 0) AND ("audio_recordings"."duration_seconds" > 3600.0)'
+      },
+      {
+        name: 'default filter removed by supplied filter',
+        default: { id: { lt: 0 } },
+        supplied: { id: nil },
+        expected: {},
+        where_clause: ''
+      },
+      {
+        name: 'expression removal syntax when there is no expression to remove',
+        default: { id: { lt: 0 } },
+        supplied: { id: { lt: 0 }, duration_seconds: nil },
+        expected: { id: { lt: 0 } },
+        expected_set: :empty,
+        where_clause: '("audio_recordings"."id" < 0)'
+      },
+      {
+        name: 'default filter removed by supplied filter, with new expression',
+        default: { id: { lt: 0 } },
+        supplied: { id: nil, duration_seconds: { gt: 3600 } },
+        expected: { duration_seconds: { gt: 3600 } },
+        where_clause: '"audio_recordings"."duration_seconds" > 3600'
+      },
+      {
+        name: 'merging array filters (same field)',
+        default: { id: { lt: 0 } },
+        supplied: [{ id: { gt: 0 } }],
+        expected: { and: [{ id: { lt: 0 } }, { id: { gt: 0 } }] },
+        expected_set: :empty,
+        where_clause: '("audio_recordings"."id" < 0) AND ("audio_recordings"."id" > 0)'
+      },
+      {
+        name: 'merging array filters (same field and operator)',
+        default: { id: { lt: 0 } },
+        supplied: [{ id: { lt: 10 } }],
+        expected: { and: [{ id: { lt: 0 } }, { id: { lt: 10 } }] },
+        expected_set: :empty,
+        where_clause: '("audio_recordings"."id" < 0) AND ("audio_recordings"."id" < 10)'
+      },
+      {
+        name: 'merging array filters (different fields)',
+        default: { id: { lt: 0 } },
+        supplied: [{ id: { gt: 0 } }, { duration_seconds: { gt: 3600 } }],
+        expected: { and: [{ id: { lt: 0 } }, { id: { gt: 0 } }, { duration_seconds: { gt: 3600 } }] },
+        expected_set: :empty,
+        where_clause: '("audio_recordings"."id" < 0) AND ("audio_recordings"."id" > 0) AND ("audio_recordings"."duration_seconds" > 3600.0)'
+      },
+      {
+        name: 'merging array filters: can remove default filter',
+        default: { id: { lt: 0 } },
+        supplied: [{ duration_seconds: { gt: 3600 } }, { id: nil }],
+        expected: { and: [{ duration_seconds: { gt: 3600 } }] },
+        where_clause: '"audio_recordings"."duration_seconds" > 3600'
+      },
+      {
+        name: 'merging array filters: can remove default filter and add new filter',
+        default: { id: { lt: 0 } },
+        supplied: [{ id: nil }, { id: { lt: 1_000_000 } }],
+        # 1-expression and automatically gets flattened
+        expected: { and: [{ id: { lt: 1_000_000 } }] },
+        where_clause: '"audio_recordings"."id" < 1000000'
+      },
+      {
+        name: 'merging array filters: can add and remove expressions multiple times',
+        default: { id: { lt: 0 } },
+        supplied: [
+          { duration_seconds: { gt: 3600 } },
+          { id: { gt: -1 } },
+          { id: nil },
+          { id: { gt: 0 } },
+          { id: { gt: 1 } },
+          { id: nil }
+        ],
+        expected: { and: [{ duration_seconds: { gt: 3600 } }] },
+        where_clause: '"audio_recordings"."duration_seconds" > 3600'
+      },
+      {
+        name: 'merging filters: can remove and add _and_ expressions',
+        default: { and: [{ id: { lt: 0 } }] },
+        supplied: { and: nil, id: { gt: 0 } },
+        expected: { id: { gt: 0 } },
+        where_clause: '"audio_recordings"."id" > 0'
+      },
+      {
+        name: 'merging filters: can remove and add _and_ expressions with multiple default expressions',
+        default: { and: [{ id: { lt: 0 } }, { duration_seconds: { gt: 3600 } }] },
+        supplied: { and: nil, id: { gt: 0 } },
+        expected: { id: { gt: 0 } },
+        where_clause: '"audio_recordings"."id" > 0'
+      },
+      {
+        name: 'merging array filters: can remove _and_  multi values expressions',
+        default: { and: [{ id: { lt: 0 } }, { duration_seconds: { gt: 3600 } }] },
+        supplied: [{ and: nil }, { duration_seconds: { gt: 3600 } }],
+        expected: { and: [{ duration_seconds: { gt: 3600 } }] },
+        where_clause: '"audio_recordings"."duration_seconds" > 3600'
+      }
+    ].each do |test_case|
+      it_behaves_like 'a filter with defaults', test_case
+    end
+  end
+end

--- a/spec/lib/modules/filter/query_filter_encoded_spec.rb
+++ b/spec/lib/modules/filter/query_filter_encoded_spec.rb
@@ -49,7 +49,7 @@ describe Filter::Query do
           }).query_full
         }.to raise_error(
           CustomErrors::FilterArgumentError,
-          /filter_encoded was not a valid JSON payload: unexpected token at '.*'/
+          /filter_encoded was not a valid JSON payload: /
         )
       end
 
@@ -70,7 +70,7 @@ describe Filter::Query do
           }).query_full
         }.to raise_error(
           CustomErrors::FilterArgumentError,
-          /filter_encoded was not a valid JSON payload: unexpected token at '.*'/
+          /filter_encoded was not a valid JSON payload: /
         )
       end
     end
@@ -90,6 +90,7 @@ describe Filter::Query do
           JOIN "sites"
           ON "audio_recordings"."site_id" = "sites"."id"
           WHERE ("audio_recordings"."deleted_at" IS NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."id"
           IN (
           SELECT "audio_recordings"."id"
@@ -121,9 +122,10 @@ describe Filter::Query do
         complex_result = <<~SQL.squish
           SELECT "audio_recordings"."id"
           FROM "audio_recordings"
-          WHERE "audio_recordings"."deleted_at"
+          WHERE ("audio_recordings"."deleted_at"
           IS
-          NULL
+          NULL)
+          AND ("audio_recordings"."status" = 'ready')
           ORDER BY "audio_recordings"."recorded_date"
           DESC
           LIMIT 25
@@ -162,6 +164,7 @@ describe Filter::Query do
           WHERE ("audio_recordings"."deleted_at"
           IS
           NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."id"
           IN (
           SELECT "audio_recordings"."id"
@@ -202,6 +205,7 @@ describe Filter::Query do
           WHERE ("audio_recordings"."deleted_at"
           IS
           NULL)
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."id" = 1)
           AND ("audio_recordings"."id"
           IN (

--- a/spec/models/analysis_job_spec.rb
+++ b/spec/models/analysis_job_spec.rb
@@ -139,6 +139,18 @@ describe AnalysisJob do
 
       # there are a total of 10 recordings - the nine above and the default one
       # created by create_audio_recordings_hierarchy
+
+      # AT 2025: updated filter_as_relation to only return recordings that are
+      # are :ready, so all these tests should not include this extra test case.
+      create(:audio_recording, status: :aborted, site:)
+
+      # mock current user because our default scope uses it
+      # and we want to test that the scope always filters out not ready recordings
+      Current.user = admin_user
+    end
+
+    after do
+      ActiveSupport::CurrentAttributes.reset_all
     end
 
     let(:analysis_job) {
@@ -255,6 +267,7 @@ describe AnalysisJob do
           SELECT "audio_recordings"."id"
           FROM "audio_recordings"
           #{permissions_sql}
+          AND ("audio_recordings"."status" = 'ready')
         SQL
       )
 
@@ -273,6 +286,7 @@ describe AnalysisJob do
           SELECT "audio_recordings"."id"
           FROM "audio_recordings"
           #{permissions_sql}
+          AND ("audio_recordings"."status" = 'ready')
         SQL
       )
 
@@ -295,6 +309,7 @@ describe AnalysisJob do
           SELECT "audio_recordings"."id"
           FROM "audio_recordings"
           #{permissions_sql}
+          AND ("audio_recordings"."status" = 'ready')
           AND ("audio_recordings"."duration_seconds" >= 300.0)
         SQL
       )
@@ -327,6 +342,7 @@ describe AnalysisJob do
           SELECT "audio_recordings"."id"
           FROM "audio_recordings"
           #{permissions_sql}
+          AND ("audio_recordings"."status" = 'ready')
           AND ((("audio_recordings"."duration_seconds" = 10.0) OR ("audio_recordings"."duration_seconds" = 3600.0)))
         SQL
       )
@@ -348,6 +364,7 @@ describe AnalysisJob do
         SELECT "audio_recordings"."id"
         FROM "audio_recordings"
         #{permissions_sql}
+        AND ("audio_recordings"."status" = 'ready')
         AND ("audio_recordings"."id"
         IN (
         SELECT "audio_recordings"."id"

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -263,7 +263,19 @@ module RequestSpecHelpers
           .map { |x| hash_including({ id: get_id(x) }) }
           .to_a
 
-        expect(api_result).to include(data: match_array(inner))
+        expect(api_result).to include(data: a_collection_including(*inner))
+      end
+    end
+
+    def expect_does_not_have_ids(*expected)
+      expect(api_result[:data]).to be_a(Array)
+
+      expected = expected.flatten
+
+      aggregate_failures do
+        expected.each do |x|
+          expect(api_result[:data]).not_to include(hash_including({ id: get_id(x) }))
+        end
       end
     end
 

--- a/spec/support/sql_helpers.rb
+++ b/spec/support/sql_helpers.rb
@@ -10,5 +10,11 @@ module SqlHelpers
       b_mod = expected.gsub(/\s*([A-Z][A-Z]+)/, "\n\\1").gsub(/(\t| )+/, ' ').trim('\n')
       expect(a_mod).to eq(b_mod)
     end
+
+    def contains_sql(actual, expected)
+      a_mod = actual.gsub(/\s*([A-Z][A-Z]+)/, "\n\\1").gsub(/(\t| )+/, ' ').trim('\n')
+      b_mod = expected.gsub(/\s*([A-Z][A-Z]+)/, "\n\\1").gsub(/(\t| )+/, ' ').trim('\n')
+      expect(a_mod).to include(b_mod)
+    end
   end
 end


### PR DESCRIPTION
- also introduced the concept of filter defaults
- filter defaults can be overridden
- sets a filter default for status = ready for audio recordings filter settings

- also updates `filter_as_relation` for AnalysisJob to ensure only status ready recordings are used (not implemented as a default filter because we don't want it to be overridable)

Fixes #736
