### PR TITLE
Emit score field from audio event responses

### DIFF
--- a/app/models/audio_event.rb
+++ b/app/models/audio_event.rb
@@ -16,7 +16,7 @@
 #  start_time_seconds                                                              :decimal(10, 4)   not null
 #  created_at                                                                      :datetime
 #  updated_at                                                                      :datetime
-#  audio_event_import_file_id                                                      :bigint
+#  audio_event_import_file_id                                                      :integer
 #  audio_recording_id                                                              :integer          not null
 #  creator_id                                                                      :integer          not null
 #  deleter_id                                                                      :integer

--- a/app/models/audio_event.rb
+++ b/app/models/audio_event.rb
@@ -16,7 +16,7 @@
 #  start_time_seconds                                                              :decimal(10, 4)   not null
 #  created_at                                                                      :datetime
 #  updated_at                                                                      :datetime
-#  audio_event_import_file_id                                                      :integer
+#  audio_event_import_file_id                                                      :bigint
 #  audio_recording_id                                                              :integer          not null
 #  creator_id                                                                      :integer          not null
 #  deleter_id                                                                      :integer
@@ -123,13 +123,13 @@ class AudioEvent < ApplicationRecord
                      :is_reference,
                      :created_at, :creator_id, :updated_at,
                      :duration_seconds,
-                     :audio_event_import_file_id, :import_file_index, :provenance_id, :channel],
+                     :audio_event_import_file_id, :import_file_index, :provenance_id, :channel, :score],
       render_fields: [:id, :audio_recording_id,
                       :start_time_seconds, :end_time_seconds,
                       :low_frequency_hertz, :high_frequency_hertz,
                       :is_reference,
                       :creator_id, :updated_at, :created_at,
-                      :audio_event_import_file_id, :import_file_index, :provenance_id, :channel],
+                      :audio_event_import_file_id, :import_file_index, :provenance_id, :channel, :score],
       custom_fields: lambda { |item, _user|
                        # do a query for the attributes that may not be in the projection
                        fresh_audio_event = AudioEvent.find(item.id)
@@ -236,8 +236,10 @@ class AudioEvent < ApplicationRecord
         audio_event_import_file_id: Api::Schema.id(nullable: true, read_only: true),
         import_file_index: { type: ['null', 'integer'], readOnly: true },
         provenance_id: Api::Schema.id(nullable: true),
-        channel: { type: ['null', 'integer'] }
-      }
+        channel: { type: ['null', 'integer'] },
+        score: { type: ['null', 'number'], readOnly: true }
+      },
+      required: [:score]
     }
   end
 

--- a/spec/models/audio_event_spec.rb
+++ b/spec/models/audio_event_spec.rb
@@ -16,7 +16,7 @@
 #  start_time_seconds                                                              :decimal(10, 4)   not null
 #  created_at                                                                      :datetime
 #  updated_at                                                                      :datetime
-#  audio_event_import_file_id                                                      :bigint
+#  audio_event_import_file_id                                                      :integer
 #  audio_recording_id                                                              :integer          not null
 #  creator_id                                                                      :integer          not null
 #  deleter_id                                                                      :integer

--- a/spec/models/audio_event_spec.rb
+++ b/spec/models/audio_event_spec.rb
@@ -16,7 +16,7 @@
 #  start_time_seconds                                                              :decimal(10, 4)   not null
 #  created_at                                                                      :datetime
 #  updated_at                                                                      :datetime
-#  audio_event_import_file_id                                                      :integer
+#  audio_event_import_file_id                                                      :bigint
 #  audio_recording_id                                                              :integer          not null
 #  creator_id                                                                      :integer          not null
 #  deleter_id                                                                      :integer


### PR DESCRIPTION
# Emit score field from audio event responses

Fixes: #762

## Changes

- Emits `score` from model returned from api
- Adds `score` as a required field on the audio_event model

## Problems

- API docs have not been updated

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
