### PR TITLE
# Improve database conflict error messages

### DIFF
--- a/app/modules/api/response.rb
+++ b/app/modules/api/response.rb
@@ -242,8 +242,8 @@ module Api
       error_hash
     end
 
-    # @param [mixed] link_ids either a symbol that corresponds to predefined links
-    #                         or a hash with the keys :text and :url
+    # @param [Symbol, Hash] link_ids either a symbol that corresponds to
+    # predefined links or a hash with the keys :text and :url
     def response_error_links(link_ids)
       result = {}
       if link_ids.present?

--- a/app/modules/include_controller.rb
+++ b/app/modules/include_controller.rb
@@ -403,8 +403,23 @@ module IncludeController
       :conflict,
       'The item must be unique.',
       error,
-      'record_not_unique_response'
+      'record_not_unique_response',
+      parse_unique_violation_keys(error)
     )
+  end
+
+  # @param error [#exception] The database error containing
+  #   the violation message.
+  # @return [Hash, nil] an error_info hash containing the unique_violation key
+  #   => value pairs that caused the constraint violation, or nil if message
+  #   doesn't match the expected format.
+  def parse_unique_violation_keys(error)
+    match = error.message.match(/Key \((?<key>.*?)\)=\((?<value>.*?)\)/)
+    return {} unless match
+
+    keys = match[:key].split(', ')
+    values = match[:value].split(', ').map(&:to_i)
+    { error_info: { unique_violation: keys.zip(values).to_h } }
   end
 
   def custom_error_response(error)

--- a/spec/README.md
+++ b/spec/README.md
@@ -58,6 +58,13 @@ API tests that aren't covered by either the permissions or
 documentation/validation categories (such as complex behaviours) can be a request
 spec (`/spec/requests`).
 
+## Git LFS
+
+There are test fixtures that are tracked by Git LFS (Large File Storage). If Git
+LFS files weren't downloaded successfully, they will appear as pointer files.
+This can cause certain tests to fail. To fix this you can run the command `git
+lfs pull`. 
+
 ### Deprecated tests
 
 All tests in `spec/acceptance` are deprecated and should be replaced

--- a/spec/lib/modules/filter/query_spec.rb
+++ b/spec/lib/modules/filter/query_spec.rb
@@ -1224,7 +1224,7 @@ describe Filter::Query do
       )
 
       expected_sql = <<~SQL.squish
-        SELECT "audio_events"."id", "audio_events"."audio_recording_id", "audio_events"."start_time_seconds", "audio_events"."end_time_seconds", "audio_events"."low_frequency_hertz", "audio_events"."high_frequency_hertz", "audio_events"."is_reference", "audio_events"."creator_id", "audio_events"."updated_at", "audio_events"."created_at", "audio_events"."audio_event_import_file_id", "audio_events"."import_file_index", "audio_events"."provenance_id", "audio_events"."channel"
+        SELECT "audio_events"."id", "audio_events"."audio_recording_id", "audio_events"."start_time_seconds", "audio_events"."end_time_seconds", "audio_events"."low_frequency_hertz", "audio_events"."high_frequency_hertz", "audio_events"."is_reference", "audio_events"."creator_id", "audio_events"."updated_at", "audio_events"."created_at", "audio_events"."audio_event_import_file_id", "audio_events"."import_file_index", "audio_events"."provenance_id", "audio_events"."channel", "audio_events"."score"
         FROM "audio_events"
         INNER
         JOIN "audio_recordings"
@@ -1307,7 +1307,7 @@ describe Filter::Query do
       )
 
       expected_sql = <<~SQL.squish
-        SELECT "audio_events"."id", "audio_events"."audio_recording_id", "audio_events"."start_time_seconds", "audio_events"."end_time_seconds", "audio_events"."low_frequency_hertz", "audio_events"."high_frequency_hertz", "audio_events"."is_reference", "audio_events"."creator_id", "audio_events"."updated_at", "audio_events"."created_at", "audio_events"."audio_event_import_file_id", "audio_events"."import_file_index", "audio_events"."provenance_id", "audio_events"."channel"
+        SELECT "audio_events"."id", "audio_events"."audio_recording_id", "audio_events"."start_time_seconds", "audio_events"."end_time_seconds", "audio_events"."low_frequency_hertz", "audio_events"."high_frequency_hertz", "audio_events"."is_reference", "audio_events"."creator_id", "audio_events"."updated_at", "audio_events"."created_at", "audio_events"."audio_event_import_file_id", "audio_events"."import_file_index", "audio_events"."provenance_id", "audio_events"."channel", "audio_events"."score"
         FROM "audio_events"
         INNER JOIN "audio_recordings"
         ON ("audio_recordings"."deleted_at"

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -58,6 +58,31 @@ describe 'Common behaviour' do
     end
   end
 
+  describe 'conflicting parameters' do
+    create_entire_hierarchy
+
+    let(:payload) {
+      {
+        verification: {
+          tag_id: tag.id,
+          audio_event_id: audio_event.id,
+          confirmed: Verification::CONFIRMATION_TRUE
+        }
+      }
+    }
+
+    before do
+      create(:verification, audio_event:, creator: writer_user, confirmed: Verification::CONFIRMATION_TRUE)
+    end
+
+    it 'conflicting parameters should return a useful error message' do
+      post '/verifications', params: payload, **api_with_body_headers(writer_token)
+
+      error_info = { unique_violation: { audio_event_id: audio_event.id, tag_id: tag.id, creator_id: writer_user.id } }
+      expect_error(:conflict, 'The item must be unique.', error_info)
+    end
+  end
+
   describe 'filtering tests' do
     create_entire_hierarchy
 

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -129,8 +129,14 @@ describe 'Verifications' do
     it 'cannot create a duplicate verification' do
       post '/verifications', params: payload, **api_with_body_headers(writer_token)
 
-      expect(response).to have_http_status(409)
       expect_error(:conflict, 'The item must be unique.', nil)
+    end
+
+    it 'returns conflicting ids when unique constraint is violated' do
+      post '/verifications', params: payload, **api_with_body_headers(writer_token)
+
+      error_info = { unique_violation: { audio_event_id: audio_event.id, tag_id: tag.id, creator_id: writer_user.id } }
+      expect_error(:conflict, 'The item must be unique.', error_info)
     end
   end
 end


### PR DESCRIPTION
# Improve database conflict error messages

Database conflict errors will include the keys/values of rows with the unique constraint violation. This will benefit graceful error handling on the front-end.  

## Changes

- utilising the existing `error_info` object to return a hash `unique_violation` containing key value pairs for conflicting rows
- update test in verifications_spec
- expect_error still passes when using info=nil (default), preserving existing test behaviour
- unrelated in `app/modules/api/response.rb:242` bugfix? as symbol always evaluates to true

## Problems

None identified 

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
