### PR TITLE
Fixes faulty find_keys for verifications upsert

### DIFF
--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -66,7 +66,7 @@ class VerificationsController < ApplicationController
 
   # PUT /verifications
   def create_or_update
-    do_load_or_new_resource(verification_params, find_keys: [:audio_event_id, :tag_id])
+    do_load_or_new_resource(verification_params, find_keys: [:audio_event_id, :tag_id, :creator_id])
     do_authorize_instance
 
     return respond_change_fail unless @verification.save
@@ -101,7 +101,7 @@ class VerificationsController < ApplicationController
   def verification_params
     params.require(:verification).permit(
       :confirmed, :audio_event_id, :tag_id
-    )
+    ).merge(creator_id: current_user.id)
   end
 
   def verification_update_params

--- a/app/modules/custom_errors.rb
+++ b/app/modules/custom_errors.rb
@@ -200,6 +200,16 @@ module CustomErrors
     end
   end
 
+  class UpsertMatchNotUnique < CustomError
+    def initialize(message = nil, find_keys:)
+      super(message)
+      @status_code = :internal_server_error
+      @prefix = 'Upsert could not find a unique record with the given find keys'
+      @info = { find_keys: find_keys }
+      @should_notify_error = true
+    end
+  end
+
   class RequestedMediaDurationInvalid < UnprocessableEntityError; end
 
   # 400 Bad request

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -259,4 +259,52 @@ describe ApplicationController, type: :controller do
       expect(response.body).to eq('Ability')
     end
   end
+
+  describe 'invalid upsert find_keys' do
+    controller(VerificationsController) do
+      skip_before_action :authenticate_user!
+      skip_authorization_check
+
+      def create_or_update
+        # the find keys are not unique enough - need creator as well
+        do_load_or_new_resource(verification_params, find_keys: [:audio_event_id, :tag_id])
+
+        # rest om implementation not needed for test
+        raise 'unreachable'
+      end
+    end
+
+    let(:current_user) { create(:user) }
+    let(:another_user) { create(:user) }
+    let(:tag) { create(:tag) }
+    let(:audio_event) { create(:audio_event) }
+
+    before do
+      create(:verification, audio_event:, tag:, creator: another_user)
+      create(:verification, audio_event:, tag:, creator: current_user)
+    end
+
+    it 'fails if upsert find_keys match more than one record' do
+      routes.draw do
+        put '/verifications' => 'verifications#create_or_update', defaults: { format: 'json' }
+      end
+
+      bypass_rescue
+
+      expect {
+        request.env['HTTP_AUTHORIZATION'] = Creation::Common.create_user_token(current_user)
+        put :create_or_update, params: {
+          verification: {
+            audio_event_id: audio_event.id,
+            tag_id: tag.id,
+            confirmed: Verification::CONFIRMATION_TRUE
+          },
+          format: 'json'
+        }
+      }.to raise_error(CustomErrors::UpsertMatchNotUnique) { |error|
+        expect(error.message).to include('Upsert could not find a unique record with the given find keys')
+        expect(error.info).to match(hash_including(find_keys: [:audio_event_id, :tag_id]))
+      }
+    end
+  end
 end

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -9,11 +9,6 @@ describe 'Verifications' do
     create(:verification, audio_event:, creator: writer_user, confirmed: Verification::CONFIRMATION_FALSE)
   end
 
-  let(:update_verification) {
-    create(:verification, audio_event:, creator: writer_user, confirmed: Verification::CONFIRMATION_SKIP)
-  }
-  let(:second_event) { create(:audio_event, audio_recording:, creator: writer_user) }
-
   it 'can update a verification' do
     payload = {
       verification: {
@@ -32,46 +27,72 @@ describe 'Verifications' do
     )
   end
 
-  it 'can upsert a verification when a matching record exists' do
-    payload = {
-      verification: {
-        audio_event_id: update_verification.audio_event_id,
-        tag_id: update_verification.tag_id,
-        confirmed: Verification::CONFIRMATION_UNSURE
-      }
-    }
+  ['owner', 'writer'].each do |role|
+    describe "upserts for #{role}" do
+      let(:current_user) { send("#{role}_user") }
+      let(:current_user_token) { send("#{role}_token") }
+      before do
+        # we're creating an extra pre-existing verification so we can ensure the upsert
+        # find_by keys are correct
+        # See https://github.com/QutEcoacoustics/baw-server/issues/820
+        create(:verification, audio_event:, creator: admin_user, tag:, confirmed: Verification::CONFIRMATION_TRUE)
 
-    put '/verifications',
-      params: payload, **api_with_body_headers(writer_token)
+        # we update the existing verification so that it is owned by user under test
+        verification.update_attribute(:creator_id, current_user.id)
+      end
 
-    expect(response).to have_http_status(:ok)
-    expect(api_data).to include(
-      audio_event_id: update_verification.audio_event_id,
-      creator_id: writer_user.id,
-      tag_id: update_verification.tag_id,
-      confirmed: Verification::CONFIRMATION_UNSURE
-    )
-  end
+      # we need something to vary for the insert case,
+      # so we'll create a new audio event to hang a different verification off of
+      let(:second_event) { create(:audio_event, audio_recording:, creator: current_user) }
 
-  it 'can upsert a new verification when no matching record exists' do
-    payload = {
-      verification: {
-        audio_event_id: second_event.id,
-        tag_id: tag.id,
-        confirmed: Verification::CONFIRMATION_SKIP
-      }
-    }
-    put '/verifications',
-      params: payload, **api_with_body_headers(writer_token)
+      it 'can upsert a verification when a matching record exists (update)' do
+        payload = {
+          verification: {
+            audio_event_id: verification.audio_event_id,
+            tag_id: verification.tag_id,
+            confirmed: Verification::CONFIRMATION_TRUE
+          }
+        }
 
-    expect(response).to have_http_status(201)
-    expect(Verification.count).to eq(4)
-    expect(api_data).to include(
-      audio_event_id: second_event.id,
-      creator_id: writer_user.id,
-      tag_id: tag.id,
-      confirmed: Verification::CONFIRMATION_SKIP
-    )
+        put '/verifications',
+          params: payload, **api_with_body_headers(current_user_token)
+
+        expect(response).to have_http_status(:ok)
+        expect(api_data).to include(
+          # id should update existing record, so we match old id
+          id: verification.id,
+          audio_event_id: verification.audio_event_id,
+          creator_id: current_user.id,
+          tag_id: verification.tag_id,
+          confirmed: Verification::CONFIRMATION_TRUE
+        )
+      end
+
+      it 'can upsert a new verification when no matching record exists (create)' do
+        old_count = Verification.count
+        payload = {
+          verification: {
+            # so in this case, only the audio event id varies
+            audio_event_id: second_event.id,
+            tag_id: verification.tag_id,
+            confirmed: Verification::CONFIRMATION_TRUE
+          }
+        }
+        put '/verifications',
+          params: payload, **api_with_body_headers(current_user_token)
+
+        expect(response).to have_http_status(:created)
+        expect(Verification.count).to eq(old_count + 1)
+        expect(api_data).to include(
+          # this should of resulted in a new record, so we don't match old id
+          id: not_eq(verification.id),
+          audio_event_id: second_event.id,
+          creator_id: current_user.id,
+          tag_id: verification.tag_id,
+          confirmed: Verification::CONFIRMATION_TRUE
+        )
+      end
+    end
   end
 
   it 'can filter verifications by confirmed status' do


### PR DESCRIPTION
Fixes #820.

Also adds validation to the create_or_update method that aims to prevent this from happening invisibly.
