### PR TITLE
Fix quoting

### DIFF
--- a/baw-server.code-workspace
+++ b/baw-server.code-workspace
@@ -339,7 +339,15 @@
     "rubyLsp.featureFlags": {
       "all": true
     },
-    "rubyLsp.featuresConfiguration": {}
+    "rubyLsp.featuresConfiguration": {
+      "codeLens": {
+        "enableAll": true
+      },
+      "inlayHint": {
+        "enableAll": true
+      }
+    },
+    "testExplorer.addToEditorContextMenu": true
   },
   "extensions": {
     "recommendations": [

--- a/lib/gems/baw-audio-tools/lib/baw_audio_tools/audio_mp3splt.rb
+++ b/lib/gems/baw-audio-tools/lib/baw_audio_tools/audio_mp3splt.rb
@@ -21,8 +21,7 @@ module BawAudioTools
       target_no_ext = target.basename('.*')
       cmd_offsets = arg_offsets(start_offset, end_offset)
 
-      mp3splt_command = "#{@mp3splt_executable} -q -d \"#{target_dirname}\" -o \"#{target_no_ext}\" \"#{source}\" #{cmd_offsets}"
-      mp3splt_command
+      "#{@mp3splt_executable} -q -d '#{target_dirname}' -o '#{target_no_ext}' '#{source}' #{cmd_offsets}"
     end
 
     def arg_offsets(start_offset, end_offset)
@@ -34,7 +33,7 @@ module BawAudioTools
         start_offset = ' 0.0 '
       else
         start_offset = start_offset.to_f
-        start_offset = ' ' + (start_offset / 60.0).floor.to_s + '.' + format('%05.2f', (start_offset % 60)) + ' '
+        start_offset = ' ' + (start_offset / 60.0).floor.to_s + '.' + format('%05.2f', start_offset % 60) + ' '
         start_offset_num = start_offset.to_f
       end
 
@@ -44,7 +43,7 @@ module BawAudioTools
         cmd_arg += ' EOF '
       else
         end_offset = end_offset.to_f
-        end_offset_formatted = (end_offset / 60.0).floor.to_s + '.' + format('%05.2f', (end_offset % 60))
+        end_offset_formatted = (end_offset / 60.0).floor.to_s + '.' + format('%05.2f', end_offset % 60)
         cmd_arg += " #{end_offset_formatted} "
       end
 

--- a/lib/gems/baw-audio-tools/lib/baw_audio_tools/audio_shntool.rb
+++ b/lib/gems/baw-audio-tools/lib/baw_audio_tools/audio_shntool.rb
@@ -11,7 +11,7 @@ module BawAudioTools
 
     def info_command(source)
       # sox std out contains info
-      "#{@shntool_executable} info \"#{source}\""
+      "#{@shntool_executable} info '#{source}'"
     end
 
     def parse_info_output(output)
@@ -42,9 +42,9 @@ module BawAudioTools
     def check_for_errors(execute_msg)
       stdout = execute_msg[:stdout]
       stderr = execute_msg[:stderr]
-      if !stderr.blank? && stderr.include?(ERROR_NO_HANDLER)
-        raise Exceptions::AudioToolError, "shntool cannot open this file type.\n\t#{execute_msg[:execute_msg]}"
-      end
+      return unless stderr.present? && stderr.include?(ERROR_NO_HANDLER)
+
+      raise Exceptions::AudioToolError, "shntool cannot open this file type.\n\t#{execute_msg[:execute_msg]}"
     end
 
     def modify_command(source, _source_info, target, _start_offset = nil, _end_offset = nil)
@@ -54,18 +54,18 @@ module BawAudioTools
       #-a str Prefix str to base part of output filenames
       #-d dir Specify output directory
       #-n fmt Specifies  the  file  count output format.  The default is %02d, which gives two-digit zero-padded numbers (01, 02, 03, ...).
-      "#{@shntool_executable} split -O never -a \"#{File.dirname(target)}\" -d #{File.basename(target)} -n \"\" \"#{source}\" \"#{target}\" "
+      "#{@shntool_executable} split -O never -a '#{File.dirname(target)}' -d '#{File.basename(target)}' -n '' '#{source}' '#{target}' "
     end
 
     def arg_offsets(start_offset, end_offset)
       cmd_arg = ''
 
-      unless start_offset.blank?
+      if start_offset.present?
         start_offset_formatted = Time.at(start_offset.to_f).utc.strftime('%H:%M:%S.%2N')
         cmd_arg += "trim =#{start_offset_formatted}"
       end
 
-      unless end_offset.blank?
+      if end_offset.present?
         end_offset_formatted = Time.at(end_offset.to_f).utc.strftime('%H:%M:%S.%2N')
         cmd_arg += if start_offset.blank?
                      # if start offset was not included, include audio from the start of the file.

--- a/lib/gems/baw-audio-tools/lib/baw_audio_tools/audio_wac2wav.rb
+++ b/lib/gems/baw-audio-tools/lib/baw_audio_tools/audio_wac2wav.rb
@@ -70,7 +70,7 @@ module BawAudioTools
       raise ArgumentError "Source and Target are the same file: #{target}" if source == target
 
       # wac file is read from stdin, wav file is written to stdout
-      "#{@wac2wav_executable} < \"#{source}\" > \"#{target}\""
+      "#{@wac2wav_executable} < '#{source}' > '#{target}'"
     end
   end
 end

--- a/lib/gems/baw-audio-tools/lib/baw_audio_tools/image_image_magick.rb
+++ b/lib/gems/baw-audio-tools/lib/baw_audio_tools/image_image_magick.rb
@@ -13,13 +13,13 @@ module BawAudioTools
 
     def info_command(source)
       cmd_format = '"width:%[fx:w]|||height:%[fx:h]|||media_type:%m"'
-      "#{@image_magick_identify_exe} -quiet -regard-warnings -ping -format #{cmd_format} \"#{source}\""
+      "#{@image_magick_identify_exe} -quiet -regard-warnings -ping -format #{cmd_format} '#{source}'"
     end
 
     def parse_info_output(output)
       # contains key value output (separate on first colon(:))
       result = {}
-      output.strip.split(/\|\|\|/).each do |line|
+      output.strip.split('|||').each do |line|
         next unless line.include?(':')
 
         colon_index = line.index(':')
@@ -34,12 +34,13 @@ module BawAudioTools
     def check_for_errors(execute_msg)
       stdout = execute_msg[:stdout]
       stderr = execute_msg[:stderr]
-      if !stderr.blank? && stderr.include?(ERROR_UNABLE_TO_OPEN)
+      if stderr.present? && stderr.include?(ERROR_UNABLE_TO_OPEN)
         raise Exceptions::FileCorruptError, "Image magick could not open the file.\n\t#{execute_msg[:execute_msg]}"
       end
-      if !stderr.blank? && stderr.include?(ERROR_IMAGE_FORMAT)
-        raise Exceptions::NotAnImageFileError, "Image magick was given a non-image file.\n\t#{execute_msg[:execute_msg]}"
-      end
+      return unless stderr.present? && stderr.include?(ERROR_IMAGE_FORMAT)
+
+      raise Exceptions::NotAnImageFileError,
+        "Image magick was given a non-image file.\n\t#{execute_msg[:execute_msg]}"
     end
 
     def modify_command(source, target)
@@ -55,7 +56,7 @@ module BawAudioTools
 
       cmd_remove_dc_value = arg_remove_dc_value
 
-      "#{@image_magick_convert_exe} -quiet \"#{source}\" #{cmd_remove_dc_value} \"#{target}\""
+      "#{@image_magick_convert_exe} -quiet '#{source}' #{cmd_remove_dc_value} '#{target}'"
     end
 
     def arg_remove_dc_value

--- a/lib/gems/emu/lib/emu.rb
+++ b/lib/gems/emu/lib/emu.rb
@@ -59,6 +59,7 @@ module Emu
 
     output, error, status = nil
     time = Benchmark.measure do
+      # NOTE: the use of Open3.capture3 means we don't need to worry about shell expansion of funny characters
       output, error, status = Open3.capture3(*all_args)
     end
 

--- a/spec/lib/gems/baw_audio_tools/audio_ffmpeg_spec.rb
+++ b/spec/lib/gems/baw_audio_tools/audio_ffmpeg_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-
-
 describe BawAudioTools::AudioFfmpeg do
   include_context 'common'
   include_context 'audio base'
@@ -11,33 +9,55 @@ describe BawAudioTools::AudioFfmpeg do
   let(:analyse_duration) { '[wav @ 0x1d35020] max_analyze_duration 5000000 reached at 5015510 microseconds' }
   let(:estimate_duration) { '[mp3 @ 0x3279b60] Estimating duration from bitrate, this may be inaccurate' }
   let(:over_read) { '[mp3 @ 0x1edcb60] overread, skip -7 enddists: -6 -6' }
-  let(:channel_layout) { "[mp3 @ 0x327a5c0] Channel layout 'mono' with 1 channels does not match specified number of channels 2: ignoring specified channel layout" }
+  let(:channel_layout) {
+    "[mp3 @ 0x327a5c0] Channel layout 'mono' with 1 channels does not match specified number of channels 2: ignoring specified channel layout"
+  }
   let(:bytes_of_junk) { '[mp3 @ 0x2679c00] Skipping 0 bytes of junk at 0.' }
   let(:unknown_warning) { "[wav @ 0x1d35020] hello I'm an unknown warning" }
 
-  let(:frame_size_error_1) { "\n[null @ 0x5477dc0] Could not find codec parameters for stream 0 (Audio: mp3, 0 channels, s16p): unspecified frame size" }
+  let(:frame_size_error_1) {
+    "\n[null @ 0x5477dc0] Could not find codec parameters for stream 0 (Audio: mp3, 0 channels, s16p): unspecified frame size"
+  }
   let(:frame_size_error_2) { "\n[null @ 0x5477dc0] Failed to read frame size: Could not seek to 1026." }
 
   # join using $/ (new line separator)
-  let(:error_msg) { [analyse_duration, estimate_duration, over_read, channel_layout, bytes_of_junk, unknown_warning].shuffle.join($INPUT_RECORD_SEPARATOR) }
+  let(:error_msg) {
+    [analyse_duration, estimate_duration, over_read, channel_layout, bytes_of_junk,
+     unknown_warning].shuffle.join($INPUT_RECORD_SEPARATOR)
+  }
 
   it 'removes known warnings' do
     expect {
       audio_base.audio_ffmpeg.check_for_errors({ stderr: error_msg })
-    }.to_not raise_error
+    }.not_to raise_error
   end
 
   it 'raises on frame size type 1 errors' do
     expected_error_msg = "Ffmpeg could not get frame size (msg type 1).\n\tExternal program output"
     expect {
-      audio_base.audio_ffmpeg.check_for_errors({ stderr: "#{error_msg}#{frame_size_error_1}", execute_msg: 'External program output' })
+      audio_base.audio_ffmpeg.check_for_errors({ stderr: "#{error_msg}#{frame_size_error_1}",
+execute_msg: 'External program output' })
     }.to raise_error(BawAudioTools::Exceptions::FileCorruptError, expected_error_msg)
   end
 
   it 'raises on frame size type 2 errors' do
     expected_error_msg = "Ffmpeg could not get frame size (msg type 2).\n\tExternal program output"
     expect {
-      audio_base.audio_ffmpeg.check_for_errors({ stderr: "#{error_msg}#{frame_size_error_2}", execute_msg: 'External program output' })
+      audio_base.audio_ffmpeg.check_for_errors({ stderr: "#{error_msg}#{frame_size_error_2}",
+execute_msg: 'External program output' })
     }.to raise_error(BawAudioTools::Exceptions::FileCorruptError, expected_error_msg)
+  end
+
+  it 'formats info commands with single quotes' do
+    expect(audio_base.audio_ffmpeg.info_command(Fixtures.bar_lt_file)).not_to include('"')
+  end
+
+  it 'formats integrity commands with single quotes' do
+    expect(audio_base.audio_ffmpeg.integrity_command(Fixtures.bar_lt_file)).not_to include('"')
+  end
+
+  it 'formats modify commands with single quotes' do
+    dest = temp_file
+    expect(audio_base.audio_ffmpeg.modify_command(Fixtures.bar_lt_file, {}, dest)).not_to include('"')
   end
 end

--- a/spec/lib/gems/baw_audio_tools/audio_wac2wav_spec.rb
+++ b/spec/lib/gems/baw_audio_tools/audio_wac2wav_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-
-
 describe BawAudioTools::AudioWac2wav do
   include_context 'common'
   include_context 'audio base'
@@ -23,7 +21,7 @@ describe BawAudioTools::AudioWac2wav do
       target = temp_file(extension: '.wav')
 
       cmd = wac2wav.modify_command(source, target)
-      expected = "wac2wavcmd < \"#{source}\" > \"#{target}\""
+      expected = "wac2wavcmd < '#{source}' > '#{target}'"
 
       expect(cmd).to eq(expected)
     end
@@ -33,17 +31,18 @@ describe BawAudioTools::AudioWac2wav do
         source = audio_file_wac_1
         info = wac2wav.info(source)
         expect(info).to eq(version: 1, channels: 2, frame_size: 128, block_size: 32, media_type: 'audio/x-waac',
-                           flags: { wac: 0, triggered: 0, gps: 0, tag: 0 },
-                           sample_rate: 22_050, sample_count: 145_024, seek_size: 16, bit_rate_bps: 16,
-                           seek_entries: 8192, data_length_bytes: 394_644, duration_seconds: 6.577)
+          flags: { wac: 0, triggered: 0, gps: 0, tag: 0 },
+          sample_rate: 22_050, sample_count: 145_024, seek_size: 16, bit_rate_bps: 16,
+          seek_entries: 8192, data_length_bytes: 394_644, duration_seconds: 6.577)
       end
+
       it 'succeeds for second test wac file' do
         source = audio_file_wac_2
         info = wac2wav.info(source)
         expect(info).to eq(version: 2, channels: 2, frame_size: 128, block_size: 32, media_type: 'audio/x-waac',
-                           flags: { wac: 8, triggered: 0, gps: 0, tag: 0 },
-                           sample_rate: 22_050, sample_count: 1_328_768, seek_size: 16, bit_rate_bps: 16,
-                           seek_entries: 8192, data_length_bytes: 974_218, duration_seconds: 60.262)
+          flags: { wac: 8, triggered: 0, gps: 0, tag: 0 },
+          sample_rate: 22_050, sample_count: 1_328_768, seek_size: 16, bit_rate_bps: 16,
+          seek_entries: 8192, data_length_bytes: 974_218, duration_seconds: 60.262)
       end
     end
 

--- a/spec/lib/gems/baw_workers/jobs/harvest/edge_cases/dollar_in_filename_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/harvest/edge_cases/dollar_in_filename_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# our jobs need access to the database from different connections
+# thus we can't use our normal transaction cleaning method
+describe 'HarvestJob can process files with dollar signs in their names', :clean_by_truncation do
+  include_context 'shared_test_helpers'
+
+  prepare_users
+  prepare_project
+  prepare_region
+  prepare_site
+
+  prepare_harvest_with_mappings do
+    [
+      BawWorkers::Jobs::Harvest::Mapping.new(
+        path: '',
+        site_id: site.id,
+        utc_offset: '+10:00',
+        recursive: false
+      )
+    ]
+  end
+
+  pause_all_jobs
+
+  before do
+    clear_original_audio
+    clear_harvester_to_do
+  end
+
+  it 'works' do
+    paths = copy_fixture_to_harvest_directory(
+      Fixtures.audio_file_mono,
+      harvest,
+      target_name: '20160506$175304.wav'
+    )
+
+    BawWorkers::Jobs::Harvest::HarvestJob.enqueue_file(harvest, paths.harvester_relative_path, should_harvest: true)
+
+    perform_jobs(count: 1)
+    expect_jobs_to_be completed: 1, of_class: BawWorkers::Jobs::Harvest::HarvestJob
+
+    item = HarvestItem.first
+
+    expect(item).to be_completed
+  end
+end

--- a/spec/lib/gems/emu/emu_spec.rb
+++ b/spec/lib/gems/emu/emu_spec.rb
@@ -248,4 +248,16 @@ describe Emu do
       records: an_instance_of(Array)
     )
   end
+
+  it 'can handle files with bash expansion characters' do
+    file = temp_file(basename: 'weird $PATH [*]file.flac')
+    file.make_symlink(Fixtures.audio_file_mono)
+    actual = Emu::Metadata.extract(file)
+
+    expect(actual).to be_an_instance_of(Emu::ExecuteResult).and having_attributes(
+      success: true,
+      log: a_string_including("\n"),
+      records: an_instance_of(Array).and(include(a_hash_including('path' => file.to_s)))
+    )
+  end
 end

--- a/spec/support/stepwise/stepwise.rb
+++ b/spec/support/stepwise/stepwise.rb
@@ -326,9 +326,9 @@ RSpec.configure do |config|
 end
 
 # type hints for solargraph - these are never executed
-# rubocop:disable RSpec/EmptyExampleGroup, RSpec/RSpec/DescribeClass
-RSpec.describe '', :skip do
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/DescribeClass
+RSpec.describe '', skip: 'this is just type hints for solargraph' do
   extend Baw::Stepwise::ExampleGroup
   include Baw::Stepwise::Example
 end
-# rubocop:enable RSpec/EmptyExampleGroup
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/DescribeClass


### PR DESCRIPTION
Uses single quotes to escape paths to executables

Fixes https://github.com/QutEcoacoustics/baw-server/issues/825.

We should be able to process files that have, e.g. `$` symbols in them now