### PR TITLE
Adds support for the audio/wave mime type

### DIFF
--- a/lib/gems/baw-app/lib/initializers/register_mime_types.rb
+++ b/lib/gems/baw-app/lib/initializers/register_mime_types.rb
@@ -7,7 +7,7 @@
 require 'action_dispatch/http/mime_type'
 
 # audio mime types
-Mime::Type.register 'audio/wav', :wav, ['audio/x-wav', 'audio/vnd.wave', 'audio/L16'], ['wave']
+Mime::Type.register 'audio/wav', :wav, ['audio/x-wav', 'audio/vnd.wave', 'audio/L16', 'audio/wave'], ['wave']
 Mime::Type.register 'audio/mpeg', :mp3, ['audio/mp3'], ['mp1', 'mp2', 'mp3', 'mpg', 'mpeg', 'mpeg3']
 Mime::Type.register 'audio/webm', :webm, ['audio/webma'], ['webma']
 Mime::Type.register 'audio/ogg', :ogg, ['audio/oga'], ['oga']

--- a/spec/fixtures/files/FL/Unknown/20220530_140528_Rec.wav
+++ b/spec/fixtures/files/FL/Unknown/20220530_140528_Rec.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7494b5f6e4f2fc2131f6d8970cff45e17fc6aa12278087bb87bef83eb5e37c4e
+size 4005888

--- a/spec/fixtures/files/FL/Unknown/README.md
+++ b/spec/fixtures/files/FL/Unknown/README.md
@@ -1,0 +1,11 @@
+# Attribution
+
+https://www.ecosounds.org/projects/1131/audio_recordings/840563
+
+Eavesdropping on Wetland Birds
+
+Monitoring wetlands in Australia
+
+See more information at Eavesdropping On Wetland Birds.
+
+Licensed with Creative Commons Attribution 4.0 International (CC BY 4.0). Any data used in research should include Elizabeth Znidersic as a co-author

--- a/spec/fixtures/files/WA_SMM/3.4_Normal/README.md
+++ b/spec/fixtures/files/WA_SMM/3.4_Normal/README.md
@@ -1,0 +1,10 @@
+# Provenance
+
+- Owner: Museums Victoria (Submitted by Nina Scarpelli)
+- License: CC-BY-SA 4.0
+- Contact: <https://github.com/ninascarpelli>
+- Link: <https://github.com/QutEcoacoustics/emu/issues/428>
+
+The files are from a Wildlife Acoustics Song Meter Micro.
+Firmware version 3.4.
+

--- a/spec/fixtures/files/WA_SMM/3.4_Normal/SMM215_20231117_095200.wav
+++ b/spec/fixtures/files/WA_SMM/3.4_Normal/SMM215_20231117_095200.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d8b378d90bca8f830b0786457f3874b27854c91047ad253b5536ce812bcc968
+size 2881142

--- a/spec/fixtures/fixtures.rb
+++ b/spec/fixtures/fixtures.rb
@@ -146,6 +146,15 @@ module Fixtures
   end
   # rubocop:enable Naming/MethodName
 
+  # A song meter mini file - totally normal
+  def self.smm_file
+    ensure_exists FILES_PATH / 'WA_SMM' / '3.4_Normal' / 'SMM215_20231117_095200.wav'
+  end
+
+  def self.fl_file
+    ensure_exists FILES_PATH / 'FL' / 'Unknown' / '20220530_140528_Rec.wav'
+  end
+
   #
   # Check a fixture exists
   #

--- a/spec/models/audio_recording_spec.rb
+++ b/spec/models/audio_recording_spec.rb
@@ -520,6 +520,16 @@ describe AudioRecording do
     expect(actual).to eq("#{uuid}.wav")
   end
 
+  # https://github.com/QutEcoacoustics/baw-server/issues/855
+  it 'returns the correct extension for audio/wave' do
+    ar = build(:audio_recording, media_type: 'audio/wave')
+    aggregate_failures do
+      expect(ar.original_format_calculated).to eq('wav')
+      expect(ar.canonical_filename).to end_with('.wav')
+      expect(ar.friendly_name).to end_with('.wav')
+    end
+  end
+
   describe 'friendly names' do
     let!(:site) { create(:site) }
     let!(:audio_recording) { create(:audio_recording, site:) }

--- a/spec/unit/patches/mime_type_spec.rb
+++ b/spec/unit/patches/mime_type_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-
-
 describe 'mime type extension patch' do
   let(:mime_types) {
     [
       ['audio/x-wav', 'wav'],
+      ['audio/wave', 'wav'],
       ['audio/wav', 'wav'],
       ['audio/vnd.wave', 'wav'],
       ['audio/mp3', 'mp3'],


### PR DESCRIPTION
EMU recently was integrates as a metadata provider. It reports the mime type of wave files as audio/wave and our mime patch did not recognize this mime type (see #816).

Now ensures audio/wave is associated with .wav extensions.

Also adds some more fixtures that are actually wave files so we can test better.

Fixes #855 