### PR TITLE
Site event count

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,6 +115,11 @@ Rails/Output:
   Exclude:
     # the rails logger isn't available when patches are running
     - '**/patches/**'
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+  Exclude:
+    # We want neat syntax for migrations, especially for SQL functions
+    - '**/db/migrate/**'
 # https://github.com/rubocop/rubocop-rspec/issues/795
 RSpec/DescribedClass:
   EnforcedStyle: explicit

--- a/Gemfile
+++ b/Gemfile
@@ -149,9 +149,6 @@ gem 'pg'
 # in particular, we use `cast`, and `coalesce`
 gem 'arel_extensions', '>= 2.1.0'
 
-# allows for adding common table expressions to queries
-gem 'activerecord-cte'
-
 # MODELS
 # -------------------------------------
 gem 'activerecord_json_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,8 +141,6 @@ GEM
       activemodel (= 8.0.2)
       activesupport (= 8.0.2)
       timeout (>= 0.4.0)
-    activerecord-cte (0.4.0)
-      activerecord
     activerecord_json_validator (3.1.0)
       activerecord (>= 4.2.0, < 9)
       json_schemer (~> 2.2)
@@ -854,7 +852,6 @@ DEPENDENCIES
   aasm (> 5)
   actionview (~> 8.0.2)
   active_storage_validations
-  activerecord-cte
   activerecord_json_validator
   addressable
   after_commit_everywhere

--- a/app/controllers/audio_events/group_by_controller.rb
+++ b/app/controllers/audio_events/group_by_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module AudioEvents
+  # Controller for returning audio events grouped by parent resources (e.g., sites)
+  class GroupByController < ApplicationController
+    include Api::ControllerHelper
+    include Api::GroupBy
+
+    # GET | POST /audio_events/group_by/sites
+    # Returns a list of sites with a count of audio events for each site.
+    # Accepts filter object where:
+    #   the `filter` is applied to audio events
+    #   the `paging`, `sort` and `projection` options are invalid
+    def group_audio_events_by_sites
+      do_authorize_group_classes(Site, AudioEvent)
+
+      parent = Group.new(
+        model: Site,
+        base_query: Access::ByPermissionTable.sites(current_user, level: Access::Permission::READER)
+          .joins(:region),
+        projections: {
+          site_id: Site.arel_table[:id],
+          region_id: Region.arel_table[:id],
+          project_ids: Arel.grouping(Site.project_ids_arel),
+          location_obfuscated: Site.should_return_obfuscated_location_arel,
+          latitude: Site.latitude_arel,
+          longitude: Site.longitude_arel
+        }
+      )
+      child = Group.new(
+        model: AudioEvent,
+        base_query: Access::ByPermission.audio_events(current_user),
+        projections: {
+          audio_event_count: AudioEvent.arel_table[:id].count
+        }
+      )
+
+      result, opts = do_group_by_query(
+        parent:,
+        child:,
+        filter_settings: AudioEvent.filter_settings,
+        joins: { audio_recording: :site }
+      )
+
+      respond_group_by(result, opts)
+    end
+
+    private
+
+    # Allow anonymous access - authorization is handled by do_authorize_group_classes
+    def should_authenticate_user?
+      false
+    end
+  end
+end

--- a/app/controllers/audio_recordings/downloader_controller.rb
+++ b/app/controllers/audio_recordings/downloader_controller.rb
@@ -22,7 +22,7 @@ module AudioRecordings
         AudioRecording.filter_settings
       )
 
-      filter = build_filter_response_as_filter_query(query, opts)
+      filter = build_filter_response_as_filter_query(query, opts, filter_settings: AudioRecording.filter_settings)
       # ensure the needed fields (and only them) are returned
       filter[:projection] = { only: [:id, :recorded_date, :'sites.name', :site_id, :canonical_file_name] }
 

--- a/app/controllers/harvest_items_controller.rb
+++ b/app/controllers/harvest_items_controller.rb
@@ -15,7 +15,7 @@ class HarvestItemsController < ApplicationController
     path = @harvest.harvester_relative_path(path)
 
     respond_to { |format|
-      query =  HarvestItem.includes([:harvest]).project_directory_listing(list_permissions, path)
+      query =  HarvestItem.includes(:harvest).project_directory_listing(list_permissions, path)
       format.json do
         @harvest_items, opts = Settings.api_response.response_advanced(
           api_filter_params,

--- a/app/models/analysis_job.rb
+++ b/app/models/analysis_job.rb
@@ -419,6 +419,10 @@ class AnalysisJob < ApplicationRecord
 
   # Queries current analysis jobs items and returns a hash of statistics for the
   # associated recordings.
+  # Note this does not count audio recordings multiple times if there are multiple
+  # analysis jobs items for the same recording.
+  # The purpose is to get some sense of the audio recordings being processed by this job,
+  # and counting size/duration multiple times would distort that.
   # @return [Hash<Symbol, Numeric>]
   def overall_statistics_query
     AudioRecording

--- a/app/modules/access/by_permission.rb
+++ b/app/modules/access/by_permission.rb
@@ -114,9 +114,9 @@ module Access
       # @param [Symbol, Array<Symbol>] levels
       # @param [Array<Integer>] project_ids
       # @return [ActiveRecord::Relation] sites
-      def sites(user, levels: Access::Core.levels, project_ids: nil)
+      def sites(user, levels: Access::Core.levels, project_ids: nil, query: nil)
         # project can be nil
-        query = Site.all
+        query ||= Site.all
         permission_sites(user, levels, query, project_ids:)
       end
 
@@ -310,8 +310,10 @@ module Access
       private
 
       def permission_admin(user, levels, query)
-        # since admin can access everything, any deny level returns nothing
-        # admin users have owner access to everything
+        # a query asking for things we *don't* have access to should return nothing
+        # but since admin can access everything, such a query would fail and return everything, which is
+        # nonsensical. So we special case it here and ensure that admin asking for things it doesn't have access to
+        # gets no results.
 
         is_admin = Access::Core.is_admin?(user)
         if is_admin

--- a/app/modules/access/by_permission_table.rb
+++ b/app/modules/access/by_permission_table.rb
@@ -1,0 +1,67 @@
+module Access
+  # This is a mirror for Access::ByPermission that uses the Effective Permission common table expression (CTE).
+  # It's different in two ways:
+  #   1. It uses a more modern approach that calculates permissions in a separate CTE
+  #      and joins that to the main query, rather than joining the permissions table multiple time
+  #      in per-row subqueries.
+  #   2. It exposes the effective permission level query so that it can be used in complex queries.
+  #      e.g. The driving use case is customizing data which should be visible to everyone, but
+  #      obfuscated for users without sufficient permission.
+  #
+  # Any methods in here should have a corresponding method in Access::ByPermission and should have tests
+  # asserting their behaviour is identical.
+  module ByPermissionTable
+    extend EffectivePermission
+
+    module_function
+
+    # Returns a query for projects the user has at least the given level of permission for.
+    # @param user [User]
+    # @param level [Symbol] the minimum permission level (see Permission levels)
+    # @param levels [Array<Symbol>] alternative to level, an array of specific permission levels (see Permission levels)
+    # @return [ActiveRecord::Relation<Project>] the approved projects
+    def projects(user, level: nil, levels: nil)
+      query = Project.all
+
+      apply(user, query, level:, levels:)
+    end
+
+    # Returns a query for sites the user has at least the given level of permission for.
+    # @param user [User]
+    # @param level [Symbol] the minimum permission level (see Permission levels)
+    # @param levels [Array<Symbol>] alternative to level, an array of specific permission levels (see Permission levels)
+    # @param project_ids [Array<Integer>] optional list of project IDs to further restrict results
+    # @return [ActiveRecord::Relation<Site>] the approved sites
+    def sites(user, level: nil, levels: nil, project_ids: nil)
+      query = Site.joins(:projects)
+
+      apply(user, query, level:, levels:, project_ids:)
+    end
+
+    def apply(user, query, level:, levels: nil, project_ids: nil)
+      user = Access::Validate.user(user)
+      validate_levels(level, levels)
+
+      if levels.present?
+        # special case: if levels is effectively NONE, and the user is Admin, then return nothing
+        # because admin has access to everything, so asking for things it doesn't have access to breaks our query logic
+        return query.none if Access::Core.is_admin?(user) && Access::Core.is_no_level?(levels)
+
+        build_levels_predicate(levels)
+      else
+        build_minimum_level_predicate(level)
+      end => predicate
+
+      predicate = predicate.and(Project.arel_table[:id].in(project_ids)) if project_ids.present?
+
+      add_effective_permissions_cte(query, user, project_ids:).where(predicate)
+    end
+
+    def validate_levels(level, levels)
+      raise ArgumentError, 'Cannot specify both level and levels.' if levels.present? && level.present?
+      raise ArgumentError, 'Must specify either level or levels.' if levels.blank? && level.blank?
+    end
+
+    private_class_method :apply, :validate_levels
+  end
+end

--- a/app/modules/access/core.rb
+++ b/app/modules/access/core.rb
@@ -24,16 +24,16 @@ module Access
         }
       end
 
-      # Get all the valid levels.
+      # Get all the valid level names.
       # @return [Array<Symbol>]
       def levels
         Access::Core.levels_hash.keys
       end
 
-      # Get value indicating no access level.
-      # @return [nil]
+      # Get a name representing no access level.
+      # @return [Symbol]
       def levels_none
-        nil
+        Permission::NONE
       end
 
       # Get a hash with symbols, names, action words for the available roles.

--- a/app/modules/access/effective_permission.rb
+++ b/app/modules/access/effective_permission.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Access
+  # Helpers for determining effective permissions inside a query.
+  # Useful for list/filtering based on effective permission.
+  module EffectivePermission
+    TABLE = Arel::Table.new(:effective_permissions).freeze
+    TABLE_NAME = TABLE.name.freeze
+    LEVEL_NAME = 'level'
+
+    module_function
+
+    # Joins the effective permissions CTE to the given query.
+    # It must have a project_id column to join on.
+    # See #effective_permissions for the description of the query.
+    # @param query [ActiveRecord::Relation]
+    # @param user [User]
+    # @param project_ids [Array<Integer>] filter by project if it is specified
+    # @return [ActiveRecord::Relation]
+    def add_effective_permissions_cte(query, user, project_ids: nil, project_table: nil)
+      project_table ||= Project.arel_table
+      cte_query = effective_permissions_for_projects_query(user, project_ids:)
+
+      query
+        .with(TABLE_NAME.to_s => cte_query)
+        .joins(
+          project_table
+            .join(TABLE, Arel::Nodes::OuterJoin)
+            .on(project_table[:id].eq(TABLE[:project_id]))
+            .join_sources
+        )
+    end
+
+    # For the current user, for each project, determine the effective permission level
+    # i.e. the highest permission level the user has for that project.
+    #
+    # Best used as a CTE or subquery. Note should be used with an outer join.
+    # If no matching row is found for a project, then the user has no permission for that project.
+    #
+    # Returns a query with two columns: project_id and level as an integer.
+    # (See Access::Permission::LEVEL_TO_INTEGER_MAP for mapping of permission levels to integers.)
+    # @param user [User]
+    # @param project_ids [Array<Integer>] filter by project if it is specified
+    # @return [Arel::SelectManager] Arel query that returns project_id and level
+    def effective_permissions_for_projects_query(user, project_ids: nil)
+      user = Access::Validate.user(user)
+
+      p = Project.arel_table
+      pm = ::Permission.arel_table
+
+      if Access::Core.is_admin?(user)
+        owner_level = Permission::LEVEL_TO_INTEGER_MAP[Permission::OWNER]
+        # weirdness alert: basically just returns all project_ids from the projects table
+        # rather than from the permissions table.
+        # We do this because we want one row per project, even if the admin user has no
+        # explicit permissions set.
+        return p
+            # optimization to reduce number of rows processed
+            .if_then(project_ids.present?) { _1.where(p[:id].in(project_ids)) }
+            .project(
+              p[:id].as('project_id'),
+              Arel.sql(owner_level.to_s).as(LEVEL_NAME)
+            )
+      end
+
+      case_statement = pm[:level]
+        .when(Permission::OWNER).then(Permission::LEVEL_TO_INTEGER_MAP[Permission::OWNER])
+        .when(Permission::WRITER).then(Permission::LEVEL_TO_INTEGER_MAP[Permission::WRITER])
+        .when(Permission::READER).then(Permission::LEVEL_TO_INTEGER_MAP[Permission::READER])
+        # I don't think this case can happen, since we don't store 'none', but just in case...
+        .else(Permission::LEVEL_TO_INTEGER_MAP[Permission::NONE])
+
+      query = pm
+
+      # This is mainly an optimization to reduce the number of rows we need to process.
+      # The parent query will still have to join to get the project ids we want.
+      query = pm.where(pm[:project_id].in(project_ids)) if project_ids.present?
+
+      # if we have a user, then filter for user or logged in permissions
+      if user.present?
+        query.where(pm[:user_id].eq(user.id).or(pm[:allow_logged_in].eq(true)))
+      else
+        # or we have no user, so filter out all irrelevant user or logged_in permissions
+        query.where(pm[:allow_anonymous].eq(true))
+      end => query
+
+      query
+        .group(pm[:project_id])
+        .project(
+          pm[:project_id],
+          case_statement.maximum.as(LEVEL_NAME)
+        )
+    end
+
+    # Builds an Arel predicate for filtering by effective permission level.
+    # Returns any record that is greater than or equal to the given level.
+    # @param level [Symbol] permission level (see Permission levels)
+    # @return [Arel::Nodes::Node] Arel predicate
+    def build_minimum_level_predicate(level)
+      level = Access::Validate.level(level)
+
+      Arel
+        .coalesce(TABLE[LEVEL_NAME], Permission.none_value)
+        .gteq(Permission.level_to_value(level))
+    end
+
+    # Builds an Arel predicate for filtering by effective permission level.
+    # Returns any record that is less than (and not equal to) the given level.
+    # This is useful for filtering out records that the user has too much access to.
+    # @param level [Symbol] permission level (see Permission levels)
+    # @return [Arel::Nodes::Node] Arel predicate
+    def build_maximum_level_predicate(level)
+      level = Access::Validate.level(level)
+
+      Arel
+        .coalesce(TABLE[LEVEL_NAME], Permission.none_value)
+        .lt(Permission.level_to_value(level))
+    end
+
+    # Builds an Arel predicate for filtering by effective permission levels.
+    # Returns any record that matches one of the given levels.
+    # @param levels [Array<Symbol>] permission levels (see Permission levels)
+    # @return [Arel::Nodes::Node] Arel predicate
+    def build_levels_predicate(levels)
+      levels = Access::Validate.levels(levels)
+
+      level_values = Permission.levels_to_values(levels)
+
+      Arel
+        .coalesce(TABLE[LEVEL_NAME], Permission.none_value)
+        .in(level_values)
+    end
+  end
+end

--- a/app/modules/access/permission.rb
+++ b/app/modules/access/permission.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 module Access
+  # Permission levels and related constants.
   module Permission
     OWNER = :owner
     WRITER = :writer
     READER = :reader
-    NONE = nil
+    NONE = :none
 
     OWNER_OR_ABOVE = [OWNER].freeze
     WRITER_OR_ABOVE = [OWNER, WRITER].freeze
@@ -14,5 +15,42 @@ module Access
     OWNER_OR_BELOW = [OWNER, WRITER, READER].freeze
     WRITER_OR_BELOW = [WRITER, READER].freeze
     READER_OR_BELOW = [READER].freeze
+
+    # Maps permission levels to integers for comparison
+    # DO NOT STORE the integer values in the database.
+    # The integer values may change if we add new permission levels.
+    LEVEL_TO_INTEGER_MAP = {
+      OWNER => 3,
+      WRITER => 2,
+      READER => 1,
+      NONE => 0
+    }.freeze
+
+    # Returns the integer value for no permission.
+    # @return [Integer]
+    def self.none_value
+      @none_value ||= LEVEL_TO_INTEGER_MAP[NONE]
+    end
+
+    # Converts an array of permission levels to their integer values.
+    # @param levels [Array<Symbol>] Array of permission levels
+    # @return [Array<Integer>]
+    def self.levels_to_values(levels)
+      # So it would be a valid query to search for an empty set of levels.
+      # But we do want to coerce to an array, because that's making an assumption
+      # on the intention.
+      raise ArgumentError, 'levels cannot be an array' unless levels.is_a?(Array)
+
+      levels.map { |level| level_to_value(level) }
+    end
+
+    # Converts a single permission level to its integer value.
+    # @param level [Symbol] Permission level to convert. `nil` is treated as `NONE`.
+    # @return [Integer]
+    def self.level_to_value(level)
+      return LEVEL_TO_INTEGER_MAP[NONE] if level.blank?
+
+      LEVEL_TO_INTEGER_MAP[level]
+    end
   end
 end

--- a/app/modules/access/validate.rb
+++ b/app/modules/access/validate.rb
@@ -9,17 +9,23 @@ module Access
       # @return [Symbol,nil] level
       def level(level)
         # ensure we choose just one element if an array was accidentally passed
-        level = level.first if level.is_a?(Array)
+        if level.is_a?(Array)
+          raise 'Deprecated: level should not be an array' if BawApp.dev_or_test?
+
+          level = level.first
+        end
 
         return nil if level.blank?
 
         case level.to_s
         when 'reader', 'read'
-          :reader
+          Permission::READER
         when 'writer', 'write'
-          :writer
+          Permission::WRITER
         when 'owner', 'own'
-          :owner
+          Permission::OWNER
+        when 'none', nil
+          nil
         else
           valid_levels = Access::Core.levels.map(&:to_s)
           raise ArgumentError, "Access level '#{level}' is not in available levels '#{valid_levels}'."
@@ -32,7 +38,7 @@ module Access
       def role(role)
         role = role[0] if role.is_a?(Array) && role.size == 1
         valid_roles = Access::Core.roles.map(&:to_s)
-        is_valid = !role.blank? && valid_roles.include?(role.to_s.to_sym)
+        is_valid = role.present? && valid_roles.include?(role.to_s.to_sym)
         raise ArgumentError, "User role '#{role}' is not in available roles '#{valid_roles}'." unless is_valid
 
         role

--- a/app/modules/api/controller_helper.rb
+++ b/app/modules/api/controller_helper.rb
@@ -76,6 +76,14 @@ module Api
       }
     end
 
+    # Override this method in your controller to provide a custom base query for Filter::Single.
+    # This is useful when you need to add CTEs or joins for custom calculated fields.
+    # Note: this should not do authorization checks - those are done on the found object later.
+    # @return [ActiveRecord::Relation, nil] the base query, or nil to use the default (Model.all)
+    def base_query_for_single
+      nil
+    end
+
     # Simply gets the id route parameter.
     # Defined so you can override it in your controller if you need to.
     # @return [String, Integer, nil]
@@ -102,11 +110,12 @@ module Api
       get_resource.send(:"#{attribute_name}=", current_user.id) if responds && is_blank && current_user_valid
     end
 
-    def respond_index(opts = {})
+    def respond_index(opts = {}, filter_settings: nil)
       opts[:projected_fields] ||= default_projected_fields_for_single
+      filter_settings ||= self.filter_settings
 
       items = get_resource_plural.map { |item|
-        Settings.api_response.prepare(item, current_user, nil, opts)
+        Settings.api_response.prepare(item, current_user, nil, opts, filter_settings:)
       }
 
       Settings.api_response.add_capabilities!(opts, resource_class)
@@ -115,14 +124,15 @@ module Api
     end
 
     # also used for update_success and new
-    def respond_show(additional_data = nil)
+    def respond_show(additional_data = nil, filter_settings: nil)
       item_resource = get_or_reload_resource
+      filter_settings ||= self.filter_settings
 
       opts = {
         projected_fields: default_projected_fields_for_single
       }
 
-      item = Settings.api_response.prepare(item_resource, current_user, additional_data, opts)
+      item = Settings.api_response.prepare(item_resource, current_user, additional_data, opts, filter_settings:)
 
       Settings.api_response.add_capabilities!(opts, resource_class, item_resource)
 
@@ -130,10 +140,12 @@ module Api
       render json: built_response, status: :ok, layout: false
     end
 
-    def respond_new
+    def respond_new(filter_settings: nil)
       item_resource = get_resource
 
-      item = Settings.api_response.prepare_new(item_resource, current_user)
+      filter_settings ||= self.filter_settings
+
+      item = Settings.api_response.prepare_new(item_resource, current_user, filter_settings:)
 
       opts = {}
       # Can't think of a valid context for this currently
@@ -143,14 +155,15 @@ module Api
       render json: built_response, status: :ok, layout: false
     end
 
-    def respond_create_success(location = nil, additional_data = nil)
+    def respond_create_success(location = nil, additional_data = nil, filter_settings: nil)
       item_resource = get_or_reload_resource
+      filter_settings ||= self.filter_settings
 
       opts = {
         projected_fields: default_projected_fields_for_single
       }
 
-      item = Settings.api_response.prepare(item_resource, current_user, additional_data, opts)
+      item = Settings.api_response.prepare(item_resource, current_user, additional_data, opts, filter_settings:)
 
       Settings.api_response.add_capabilities!(opts, resource_class, item_resource)
 
@@ -171,15 +184,16 @@ module Api
       render json: built_response, status: :unprocessable_content, layout: false
     end
 
-    def respond_change_fail_with_resource(additional_data = nil)
+    def respond_change_fail_with_resource(additional_data = nil, filter_settings: nil)
       item_resource = get_resource
       item_resource = get_or_reload_resource if item_resource.persisted?
+      filter_settings ||= self.filter_settings
 
       opts = {
         projected_fields: default_projected_fields_for_single
       }
 
-      item = Settings.api_response.prepare(item_resource, current_user, additional_data, opts)
+      item = Settings.api_response.prepare(item_resource, current_user, additional_data, opts, filter_settings:)
 
       built_response = Settings.api_response.build(
         :unprocessable_content,
@@ -207,9 +221,11 @@ module Api
       )
     end
 
-    def respond_filter(content, opts = {})
+    def respond_filter(content, opts = {}, filter_settings: nil)
+      filter_settings ||= self.filter_settings
+
       items = content.map { |item|
-        Settings.api_response.prepare(item, current_user, nil, opts)
+        Settings.api_response.prepare(item, current_user, nil, opts, filter_settings:)
       }
 
       Settings.api_response.add_capabilities!(opts, resource_class)
@@ -259,10 +275,10 @@ module Api
     # request.
     # @return [Hash] - a hash including filter, paging, and sorting sub-hashes suitable for
     #  passing to the filter POST method.
-    def build_filter_response_as_filter_query(content, opts = {})
+    def build_filter_response_as_filter_query(content, opts = {}, filter_settings:)
       # add custom fields
       items = content.map { |item|
-        Settings.api_response.prepare(item, current_user, nil, opts)
+        Settings.api_response.prepare(item, current_user, nil, opts, filter_settings:)
       }
 
       # build out the normal response
@@ -331,7 +347,12 @@ module Api
     def do_load_resource
       # we augment the query here to allow us to fetch information needed for custom fields
       # Fixes https://github.com/QutEcoacoustics/baw-server/issues/565
-      current_filter = Filter::Single.new(default_filter_parameters_for_single, resource_class, filter_settings)
+      current_filter = Filter::Single.new(
+        default_filter_parameters_for_single,
+        resource_class,
+        filter_settings,
+        base_query: base_query_for_single
+      )
 
       resource = find_resource(current_filter.query)
 
@@ -347,7 +368,12 @@ module Api
       raise ArgumentError, 'find_keys must not be empty' if find_keys.blank?
       raise ArgumentError, 'find_keys must contain symbols' unless find_keys.all?(Symbol)
 
-      current_filter = Filter::Single.new(default_filter_parameters_for_single, resource_class, filter_settings)
+      current_filter = Filter::Single.new(
+        default_filter_parameters_for_single,
+        resource_class,
+        filter_settings,
+        base_query: base_query_for_single
+      )
 
       # we mimic find_sole_by here but we don't necessarily want raise to if not found
       # all `sole` does is retrieve two records - if there is more than one it raises
@@ -392,7 +418,12 @@ module Api
 
       # we augment the query here to allow us to fetch information needed for custom fields
       # Fixes https://github.com/QutEcoacoustics/baw-server/issues/565
-      current_filter = Filter::Single.new(default_filter_parameters_for_single, resource_class, filter_settings)
+      current_filter = Filter::Single.new(
+        default_filter_parameters_for_single,
+        resource_class,
+        filter_settings,
+        base_query: base_query_for_single
+      )
 
       resource = current_filter.query.find(resource.id)
 

--- a/app/modules/api/group_by.rb
+++ b/app/modules/api/group_by.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Api
+  # Supports actions that return aggregates of a parent-child relationship
+  module GroupBy
+    extend ActiveSupport::Concern
+
+    Group = Data.define(:model, :base_query, :projections) {
+      def initialize(model:, base_query:, projections:)
+        raise 'model must be an ActiveRecord::Base subclass' unless model < ActiveRecord::Base
+        raise 'base_query must be an ActiveRecord::Relation' unless base_query.is_a?(ActiveRecord::Relation)
+        raise 'projections must be an Hash of aliases to Arel nodes' unless projections.is_a?(Hash)
+
+        super
+      end
+    }
+
+    def do_authorize_group_classes(parent, child)
+      raise 'group_parent not set in controller' if parent.nil?
+      raise 'group_child not set in controller' if child.nil?
+
+      # Use :index for parent class authorization (e.g., Site)
+      # and :filter for child class authorization (e.g., AudioEvent)
+      do_authorize_class(:index, parent)
+      do_authorize_class(:filter, child)
+    end
+
+    private
+
+    def api_filter_params_filter_only!
+      if params.key?(:paging) || params.key?(:sort) || params.key?(:projection)
+        raise CustomErrors::UnprocessableEntityError,
+          'Paging, sorting, and projection parameters are not allowed in group by requests.'
+      end
+
+      api_filter_params_filter_only
+    end
+
+    def api_filter_params_filter_only
+      api_filter_params.to_h.slice(:filter)
+    end
+
+    def group_cte_table
+      @group_cte_table ||= Arel::Table.new(:grouped_table)
+    end
+
+    def do_group_by_query(
+      parent:,
+      child:,
+      filter_settings:,
+      joins: nil
+    )
+      parent_table = parent.model.arel_table
+
+      child_filter = Filter::Query.new(
+        # only allow filtering parameters (no paging, sorting, projection)
+        api_filter_params_filter_only!,
+        child.base_query,
+        child.model,
+        filter_settings
+      )
+
+      # opts is a strange blend between parent and child opts that would usually
+      # come from Settings.api_response.response
+      opts = {
+        filter: child_filter.filter,
+        filter_without_defaults: child_filter.supplied_filter
+      }
+
+      grouped_table = group_cte_table
+      grouped_query = child_filter
+        .query_without_paging_sorting
+        .joins(joins)
+        .group(parent_table[:id])
+        .reselect(
+          parent_table[:id].as('parent_id'),
+          *child.projections.map { |name, expression| expression.as(name.to_s) }
+        )
+
+      grouped_query = parent
+        .base_query
+        .with(grouped_table.name => grouped_query)
+        .joins(
+          parent_table
+            .join(grouped_table)
+            .on(grouped_table[:parent_id].eq(parent_table[:id]))
+            .join_sources
+        )
+        .select(
+          *parent.projections.map { |name, expression| expression.as(name.to_s) },
+          *child.projections.keys.map { |name| grouped_table[name.to_s] }
+        )
+        .order(parent_table[:id])
+
+      # We're intentionally not doing a filter query or an active record query here.
+      # The goal is speed and efficiency
+      parent.model.connection_pool.with_connection do |connection|
+        connection.exec_query(grouped_query.to_sql) => result
+        # This is icky. What happens in real rails code is the ActiveRecord::Result
+        # object is consumed by ActiveRecord::Base.instantiate which turns takes
+        # in rows of untyped results and column types turns them into model objects.
+        columns = result.columns.map(&:to_sym)
+        result.cast_values.map do |row|
+          columns.zip(row).to_h
+        end
+      end => results
+
+      [results, opts]
+    end
+
+    def respond_group_by(content, opts = {})
+      render_format(content, opts)
+    end
+  end
+end

--- a/app/modules/api/schema.rb
+++ b/app/modules/api/schema.rb
@@ -207,6 +207,51 @@ module Api
               },
               required: ['meta', 'data']
             },
+            filter_payload_filter: {
+              type: 'object'
+            },
+            filter_payload_paging: {
+              type: 'object',
+              properties: {
+                items: { type: 'integer', minimum: 1 },
+                page: { type: 'integer', minimum: 1 },
+                disable_paging: { type: 'boolean' }
+              }
+            },
+            filter_payload_sort: {
+              type: 'object',
+              properties: {
+                order_by: { type: 'string' },
+                direction: { type: 'string', enum: ['asc', 'desc'] }
+              }
+            },
+            filter_payload_projection: {
+              type: 'object',
+              properties: {
+                include: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  deprecated: true
+                },
+                exclude: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  deprecated: true
+                },
+                only: {
+                  type: 'array',
+                  items: { type: 'string' }
+                },
+                add: {
+                  type: 'array',
+                  items: { type: 'string' }
+                },
+                remove: {
+                  type: 'array',
+                  items: { type: 'string' }
+                }
+              }
+            },
             cms_blob: {
               type: 'object',
               required: [

--- a/app/modules/api/schema/helpers.rb
+++ b/app/modules/api/schema/helpers.rb
@@ -5,6 +5,37 @@ module Api
     # A small module that helps output boilerplate JSON schema definitions.
     # All the declarations here could be inlined with no ill-effect.
     module Helpers
+      def standard_array_response(item_schema)
+        {
+          allOf: [
+            { '$ref' => '#/components/schemas/standard_response' },
+            {
+              type: 'object',
+              properties: {
+                data: {
+                  type: 'array',
+                  items: item_schema
+                }
+              }
+            }
+          ]
+        }
+      end
+
+      def standard_single_response(item_schema)
+        {
+          allOf: [
+            { '$ref' => '#/components/schemas/standard_response' },
+            {
+              type: 'object',
+              properties: {
+                data: item_schema
+              }
+            }
+          ]
+        }
+      end
+
       def id(nullable: false, read_only: true)
         { '$ref' => nullable ? '#/components/schemas/nullableId' : '#/components/schemas/id', readOnly: read_only }
       end
@@ -98,6 +129,18 @@ module Api
           },
           required: false,
           allowEmptyValue: true
+        }
+      end
+
+      def filter_payload(filter: true, sorting: true, paging: true, projection: true)
+        {
+          type: 'object',
+          properties: {
+            filter: filter ? { '$ref' => '#/components/schemas/filter_payload_filter' } : nil,
+            sort: sorting ? { '$ref' => '#/components/schemas/filter_payload_sort' } : nil,
+            page: paging ? { '$ref' => '#/components/schemas/filter_payload_paging' } : nil,
+            projection: projection ? { '$ref' => '#/components/schemas/filter_payload_projection' } : nil
+          }
         }
       end
     end

--- a/app/modules/baw/arel.rb
+++ b/app/modules/baw/arel.rb
@@ -13,6 +13,25 @@ module Baw
       Baw::Arel::Nodes::MakeInterval.new(seconds:)
     end
 
+    # Create a COALESCE function node.
+    # This exists because there is undesired functionality in ArelExtensions that
+    # tries to get the type of the column from the db schema.
+    # This fails for virtual tables (eg. CTEs) because they don't exist in the schema
+    # causing very confusing errors (because it fails silently, the transaction fails
+    # and not actual error is shown).
+    # TODO: can we remove ArelExtensions entirely?
+    # @return [::Arel::Nodes::Function]
+    def coalesce(*expressions)
+      ::Arel::Nodes::NamedFunction.new 'COALESCE', expressions
+    end
+
+    def wrap_value(value)
+      return value if ::Arel.arel_node?(value)
+      return nil if value.nil?
+
+      ::Arel::Nodes::BindParam.new(value)
+    end
+
     module NodeExtensions
       # Treat this node as an array.
       # Has no effect other than to allow array-like methods to be called on this node.

--- a/app/modules/filter/query.rb
+++ b/app/modules/filter/query.rb
@@ -27,7 +27,7 @@ module Filter
       :valid_fields, :text_fields, :filter_settings,
       :parameters, :filter, :projection, :qsp_text_filter,
       :qsp_generic_filters, :paging, :sorting, :build,
-      :custom_fields2, :capabilities
+      :custom_fields2
 
     # The fields actually requested by any projection (default or not)
     # after flattening. If projection was not requested this will be equivalent to `render_fields`.
@@ -76,7 +76,6 @@ module Filter
       @default_sort_direction = filter_settings[:defaults][:direction]
       @default_filter = filter_settings[:defaults].fetch(:filter, nil)
       @custom_fields2 = filter_settings[:custom_fields2] || {}
-      @capabilities = filter_settings[:capabilities] || {}
       set_archived_param(parameters)
 
       @build = Build.new(@table, filter_settings)

--- a/app/modules/filter/single.rb
+++ b/app/modules/filter/single.rb
@@ -21,10 +21,10 @@ module  Filter
     # @return [Set<Symbol>]
     attr_reader :projected_fields
 
-    def initialize(parameters, model, filter_settings)
+    def initialize(parameters, model, filter_settings, base_query: nil)
       @model = model
       @table = relation_table(model)
-      @initial_query = relation_all(model)
+      @initial_query = base_query || relation_all(model)
       validate_filter_settings(filter_settings)
 
       # we really only care about a small subset of the filter settings

--- a/baw-server.code-workspace
+++ b/baw-server.code-workspace
@@ -120,6 +120,7 @@
       "Phusion",
       "PIDFILE",
       "pids",
+      "plpgsql",
       "posix",
       "postgesql",
       "postgres",
@@ -347,7 +348,9 @@
         "enableAll": true
       }
     },
-    "testExplorer.addToEditorContextMenu": true
+    "testExplorer.addToEditorContextMenu": true,
+    "github.copilot.chat.agent.thinkingTool": true,
+    "github.copilot.chat.alternateGptPrompt.enabled": true
   },
   "extensions": {
     "recommendations": [

--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -99,6 +99,8 @@ actions:
     cache_to_redis: true
   audio_check:
     queue: maintenance_<%= BawApp.env %>
+  maintenance:
+    queue: maintenance_<%= BawApp.env %>
   active_storage:
     queue: active_storage_<%= BawApp.env %>
   active_job_default:

--- a/db/migrate/20260113000000_add_obfuscated_coordinates_to_sites.rb
+++ b/db/migrate/20260113000000_add_obfuscated_coordinates_to_sites.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Add obfuscated latitude and longitude to sites for privacy-preserving location data.
+# The backfill job is automatically enqueued after the migration commits.
+class AddObfuscatedCoordinatesToSites < ActiveRecord::Migration[8.0]
+  def change
+    change_table :sites, bulk: true do |t|
+      t.decimal :obfuscated_longitude, precision: 9, scale: 6
+      t.decimal :obfuscated_latitude, precision: 9, scale: 6
+      t.boolean :custom_obfuscated_location, default: false, null: false,
+        comment: 'True if the obfuscated location was set by the user or false if generated'
+    end
+
+    add_index :sites, :obfuscated_latitude
+    add_index :sites, :obfuscated_longitude
+
+    # Drop jitter SQL functions if they exist from a previous migration attempt
+    reversible do |dir|
+      dir.up do
+        execute 'DROP FUNCTION IF EXISTS obfuscate_location(numeric, numeric, numeric, text, numeric, boolean);'
+        execute 'DROP FUNCTION IF EXISTS sample_two_immutable_randoms(text, numeric);'
+        execute 'DROP FUNCTION IF EXISTS clamp(numeric, numeric, numeric);'
+      end
+    end
+
+    up_only do
+      # Enqueue the backfill job after the migration transaction commits
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.perform_later
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1944,7 +1944,10 @@ CREATE TABLE public.sites (
     description text,
     tzinfo_tz character varying(255),
     rails_tz character varying(255),
-    region_id integer
+    region_id integer,
+    obfuscated_longitude numeric(9,6),
+    obfuscated_latitude numeric(9,6),
+    custom_obfuscated_location boolean DEFAULT false NOT NULL
 );
 
 
@@ -3525,6 +3528,20 @@ CREATE INDEX index_sites_on_deleter_id ON public.sites USING btree (deleter_id);
 
 
 --
+-- Name: index_sites_on_obfuscated_latitude; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sites_on_obfuscated_latitude ON public.sites USING btree (obfuscated_latitude);
+
+
+--
+-- Name: index_sites_on_obfuscated_longitude; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sites_on_obfuscated_longitude ON public.sites USING btree (obfuscated_longitude);
+
+
+--
 -- Name: index_sites_on_updater_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4464,7 +4481,8 @@ ALTER TABLE ONLY public.tags
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
-('20251126025112'),
+('20260113000000'),
+('20251103151227'),
 ('20250912033944'),
 ('20250909090000'),
 ('20250723051530'),

--- a/lib/gems/baw-app/lib/initializers/config.rb
+++ b/lib/gems/baw-app/lib/initializers/config.rb
@@ -18,6 +18,10 @@ class BawConfigContract < Dry::Validation::Contract
         required(:queue).filled(:string)
       end
 
+      required(:maintenance).hash do
+        required(:queue).filled(:string)
+      end
+
       required(:media).hash do
         required(:queue).filled(:string)
         required(:cache_to_redis).filled(:bool)

--- a/lib/gems/baw-workers/lib/baw_workers/jobs/maintenance/backfill_sites_obfuscated_locations_job.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/jobs/maintenance/backfill_sites_obfuscated_locations_job.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Jobs
+    module Maintenance
+      # Backfills obfuscated locations for sites that have coordinates but no obfuscated coordinates.
+      # This job processes sites in batches to avoid memory issues and can be safely re-run.
+      #
+      # Usage:
+      #   BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.perform_later
+      #
+      class BackfillSitesObfuscatedLocationsJob < BawWorkers::Jobs::ApplicationJob
+        queue_as Settings.actions.maintenance.queue
+
+        perform_expects
+
+        def perform
+          logger.info('Starting backfill of obfuscated locations for sites')
+
+          updated = 0
+          failed = 0
+
+          sites_to_update.find_each do |site|
+            backfill_site(site)
+            updated += 1
+          rescue StandardError => e
+            failed += 1
+            logger.error("Failed to update site #{site.id}", exception: e)
+          end
+
+          logger.info('Backfill complete', updated:, failed:)
+
+          { updated:, failed: }
+        end
+
+        def create_job_id
+          ::BawWorkers::ActiveJob::Identity::Generators.generate_timestamp(self)
+        end
+
+        def name
+          job_id
+        end
+
+        private
+
+        # Find sites that have coordinates but no obfuscated coordinates
+        # and where the obfuscated location is system-generated (not user-provided)
+        def sites_to_update
+          sites = Site.arel_table
+
+          sites[:obfuscated_latitude].eq(nil).and(sites[:latitude].not_eq(nil))
+            .or(
+            sites[:obfuscated_longitude].eq(nil).and(sites[:longitude].not_eq(nil))
+          ) => predicate
+
+          Site
+            .where(custom_obfuscated_location: false)
+            .where(predicate)
+        end
+
+        def backfill_site(site)
+          # Directly call update_obfuscated_location since the callback only fires
+          # when latitude/longitude changes. For backfill, we need to generate
+          # obfuscated values for existing coordinates.
+          site.update_obfuscated_location unless site.custom_obfuscated_location
+          site.save!(touch: false)
+
+          if site.latitude.present? && site.obfuscated_latitude.nil?
+            raise "Obfuscated latitude not set for site #{site.id}"
+          end
+
+          if site.longitude.present? && site.obfuscated_longitude.nil? # rubocop:disable Style/GuardClause
+            raise "Obfuscated longitude not set for site #{site.id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/emu/lib/emu/metadata.rb
+++ b/lib/gems/emu/lib/emu/metadata.rb
@@ -13,7 +13,7 @@ module Emu
     def extract(path)
       raise ArgumentError, 'path must exist and be pathname' unless path.is_a?(Pathname) && path.exist?
 
-      Emu.execute('metadata', '--no-wamd-offsets', path)
+      Emu.execute('metadata', path)
     end
   end
 end

--- a/spec/api/audio_events/group_by_spec.rb
+++ b/spec/api/audio_events/group_by_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'audio_events/group_by', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+
+  let(:skip_automatic_description) { true }
+
+  def self.body_schema
+    Api::Schema.standard_array_response(
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          site_id: Api::Schema.id,
+          region_id: Api::Schema.id(nullable: true),
+          project_ids: {
+            type: 'array',
+            items: Api::Schema.id
+          },
+          location_obfuscated: { type: 'boolean' },
+          latitude: { type: ['number', 'null'], minimum: -90, maximum: 90 },
+          longitude: { type: ['number', 'null'], minimum: -180, maximum: 180 },
+          audio_event_count: { type: 'integer' }
+        },
+        required: [
+          :site_id, :region_id, :project_ids, :location_obfuscated,
+          :latitude, :longitude, :audio_event_count
+        ]
+      }
+    )
+  end
+
+  path '/audio_events/group_by/sites' do
+    get 'Gets audio events grouped by site' do
+      tags 'audio_events'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns a list of sites with counts of audio events per site.
+        The filter parameter is applied to audio events (not sites).
+        Results only include sites the user has reader access to.
+        Location coordinates may be obfuscated based on user permissions.
+      DESCRIPTION
+
+      response '200', 'audio events grouped by site retrieved' do
+        schema(**body_schema)
+
+        run_test! do
+          expect_json_response
+          expect(api_result).to include(:data)
+        end
+      end
+    end
+
+    post 'Gets audio events grouped by site with filter' do
+      tags 'audio_events'
+      consumes 'application/json'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns a list of sites with counts of audio events per site.
+        The filter parameter is applied to audio events (not sites).
+        Results only include sites the user has reader access to.
+        Location coordinates may be obfuscated based on user permissions.
+      DESCRIPTION
+
+      parameter name: :filter_body, in: :body, required: false,
+        schema: Api::Schema.filter_payload(filter: true, sorting: false, paging: false, projection: false)
+
+      response '200', 'audio events grouped by site retrieved' do
+        schema(**body_schema)
+
+        let(:filter_body) { {} }
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '200', 'filters audio events by tag' do
+        let(:filter_body) do
+          {
+            filter: {
+              'tags.id': {
+                eq: tag.id
+              }
+            }
+          }
+        end
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '422', 'rejects paging parameters' do
+        let(:filter_body) { { paging: { items: 10 } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects sort parameters' do
+        let(:filter_body) { { sort: { order_by: 'id' } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects projection parameters' do
+        let(:filter_body) { { projection: { only: [:id] } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by requests.'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/site_factory.rb
+++ b/spec/factories/site_factory.rb
@@ -4,31 +4,35 @@
 #
 # Table name: sites
 #
-#  id                 :integer          not null, primary key
-#  deleted_at         :datetime
-#  description        :text
-#  image_content_type :string
-#  image_file_name    :string
-#  image_file_size    :bigint
-#  image_updated_at   :datetime
-#  latitude           :decimal(9, 6)
-#  longitude          :decimal(9, 6)
-#  name               :string           not null
-#  notes              :text
-#  rails_tz           :string(255)
-#  tzinfo_tz          :string(255)
-#  created_at         :datetime
-#  updated_at         :datetime
-#  creator_id         :integer          not null
-#  deleter_id         :integer
-#  region_id          :integer
-#  updater_id         :integer
+#  id                   :integer          not null, primary key
+#  deleted_at           :datetime
+#  description          :text
+#  image_content_type   :string
+#  image_file_name      :string
+#  image_file_size      :bigint
+#  image_updated_at     :datetime
+#  latitude             :decimal(9, 6)
+#  longitude            :decimal(9, 6)
+#  name                 :string           not null
+#  notes                :text
+#  obfuscated_latitude  :decimal(9, 6)
+#  obfuscated_longitude :decimal(9, 6)
+#  rails_tz             :string(255)
+#  tzinfo_tz            :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  creator_id           :integer          not null
+#  deleter_id           :integer
+#  region_id            :integer
+#  updater_id           :integer
 #
 # Indexes
 #
-#  index_sites_on_creator_id  (creator_id)
-#  index_sites_on_deleter_id  (deleter_id)
-#  index_sites_on_updater_id  (updater_id)
+#  index_sites_on_creator_id            (creator_id)
+#  index_sites_on_deleter_id            (deleter_id)
+#  index_sites_on_obfuscated_latitude   (obfuscated_latitude)
+#  index_sites_on_obfuscated_longitude  (obfuscated_longitude)
+#  index_sites_on_updater_id            (updater_id)
 #
 # Foreign Keys
 #
@@ -58,6 +62,8 @@ FactoryBot.define do
       latitude { Random.rand(-90.0..90.0) }
       # -180 and 180 degrees
       longitude { Random.rand(-180.0..180.0) }
+
+      custom_obfuscated_location { false }
     end
 
     # the after(:create) yields two values; the instance itself and the

--- a/spec/lib/gems/baw_workers/jobs/harvest/edge_cases/file_goes_missing_after_fixes_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/harvest/edge_cases/file_goes_missing_after_fixes_spec.rb
@@ -56,7 +56,7 @@ describe 'HarvestJob', :clean_by_truncation do
         {
           name: :does_not_exist,
           status: :not_fixable,
-          message: 'File /data/test/harvester_to_do/harvest_1/audio.wav does not exist'
+          message: "File #{harvest_item.absolute_path} does not exist"
         }
       ]
     end

--- a/spec/lib/gems/baw_workers/jobs/maintenance/backfill_sites_obfuscated_locations_job_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/maintenance/backfill_sites_obfuscated_locations_job_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+describe BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob do
+  prepare_users
+  prepare_project
+  prepare_region
+
+  pause_all_jobs
+
+  before do
+    clear_pending_jobs
+  end
+
+  let(:queue_name) { Settings.actions.maintenance.queue }
+
+  context 'when checking basic job behaviour' do
+    it 'works on the maintenance queue' do
+      expect(BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.queue_name).to eq(queue_name)
+    end
+
+    it 'can enqueue' do
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.perform_later
+      expect_enqueued_jobs(1, of_class: BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob)
+
+      clear_pending_jobs
+    end
+
+    it 'has a sensible name' do
+      job = BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new
+
+      expect(job.name).to match(/BackfillSitesObfuscatedLocationsJob:\d+/)
+    end
+  end
+
+  context 'when backfilling' do
+    let!(:site_with_coords) do
+      create(:site, :with_lat_long, region:, projects: [project]).tap do |s|
+        # Simulate a site that was created before the migration
+        s.update_columns(obfuscated_latitude: nil, obfuscated_longitude: nil)
+      end
+    end
+
+    let!(:site_without_coords) do
+      create(:site, region:, projects: [project], latitude: nil, longitude: nil)
+    end
+
+    let!(:site_already_backfilled) do
+      create(:site, :with_lat_long, region:, projects: [project])
+      # This site already has obfuscated coordinates from the factory
+    end
+
+    let!(:site_with_custom_obfuscation) do
+      create(:site, :with_lat_long, region:, projects: [project]).tap do |s|
+        # Simulate a site with user-provided obfuscated location
+        s.update_columns(
+          obfuscated_latitude: nil,
+          obfuscated_longitude: nil,
+          custom_obfuscated_location: true
+        )
+      end
+    end
+
+    it 'backfills sites that need obfuscated coordinates' do
+      expect(site_with_coords.obfuscated_latitude).to be_nil
+      expect(site_with_coords.obfuscated_longitude).to be_nil
+
+      result = BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+
+      expect(result).to match hash_including(updated: 1, failed: 0)
+
+      site_with_coords.reload
+      expect(site_with_coords.obfuscated_latitude).to be_a(Numeric).and(
+        be_within(Site::JITTER_RANGE).of(site_with_coords.latitude)
+      )
+      expect(site_with_coords.obfuscated_longitude).to be_a(Numeric).and(
+        be_within(Site::JITTER_RANGE).of(site_with_coords.longitude)
+      )
+    end
+
+    it 'does not update sites without coordinates' do
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+
+      site_without_coords.reload
+      expect(site_without_coords.obfuscated_latitude).to be_nil
+      expect(site_without_coords.obfuscated_longitude).to be_nil
+    end
+
+    it 'does not update sites that already have obfuscated coordinates' do
+      original_lat = site_already_backfilled.obfuscated_latitude
+      original_lng = site_already_backfilled.obfuscated_longitude
+
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+
+      site_already_backfilled.reload
+      expect(site_already_backfilled.obfuscated_latitude).to eq(original_lat)
+      expect(site_already_backfilled.obfuscated_longitude).to eq(original_lng)
+    end
+
+    it 'does not update sites with custom obfuscated locations' do
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+
+      site_with_custom_obfuscation.reload
+      expect(site_with_custom_obfuscation.obfuscated_latitude).to be_nil
+      expect(site_with_custom_obfuscation.obfuscated_longitude).to be_nil
+    end
+
+    it 'handles partial coordinates (latitude only)' do
+      site = create(:site, region:, projects: [project], latitude: -27.5, longitude: nil)
+      site.update_columns(obfuscated_latitude: nil)
+
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+
+      site.reload
+      expect(site.obfuscated_latitude).not_to be_nil
+      expect(site.obfuscated_longitude).to be_nil
+    end
+
+    it 'handles partial coordinates (longitude only)' do
+      site = create(:site, region:, projects: [project], latitude: nil, longitude: 153.0)
+      site.update_columns(obfuscated_longitude: nil)
+
+      BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+
+      site.reload
+      expect(site.obfuscated_latitude).to be_nil
+      expect(site.obfuscated_longitude).not_to be_nil
+    end
+
+    it 'can be safely re-run' do
+      # First run
+      result1 = BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+      expect(result1[:updated]).to eq(1)
+
+      # Second run should update nothing
+      result2 = BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob.new.perform
+      expect(result2[:updated]).to eq(0)
+    end
+  end
+end

--- a/spec/migrations/add_obfuscated_coordinates_to_sites_spec.rb
+++ b/spec/migrations/add_obfuscated_coordinates_to_sites_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_migration!
+
+describe AddObfuscatedCoordinatesToSites, :migration do
+  include ActiveJob::TestHelper
+
+  # We need to test that:
+  # 1. The migration adds the new columns
+  # 2. The migration enqueues the backfill job after commit
+
+  let(:sites_table) { table(:sites) }
+  let(:users_table) { table(:users) }
+
+  ignore_pending_jobs
+
+  before do
+    # Create a user for the site's creator_id
+    user = users_table.create!(user_name: 'Test User', email: 'test@example.com', encrypted_password: 'password')
+
+    # Create test sites with coordinates
+    sites_table.create!(
+      id: 1,
+      name: 'Site with coordinates',
+      latitude: -27.5,
+      longitude: 153.0,
+      creator_id: user.id
+    )
+
+    sites_table.create!(
+      id: 2,
+      name: 'Site without coordinates',
+      latitude: nil,
+      longitude: nil,
+      creator_id: user.id
+    )
+  end
+
+  after do
+    clear_pending_jobs
+  end
+
+  it 'adds obfuscated coordinate columns to sites table' do
+    migrate!
+
+    # Refresh the table definition
+    sites_table.reset_column_information
+
+    expect(sites_table.column_names).to include('obfuscated_latitude')
+    expect(sites_table.column_names).to include('obfuscated_longitude')
+    expect(sites_table.column_names).to include('custom_obfuscated_location')
+  end
+
+  it 'sets default value for custom_obfuscated_location' do
+    migrate!
+
+    sites_table.reset_column_information
+
+    site = sites_table.find(1)
+    expect(site.custom_obfuscated_location).to be false
+  end
+
+  it 'enqueues the backfill job after migration commits' do
+    migrate!
+
+    # The job should have been enqueued
+    expect_enqueued_jobs(1, of_class: BawWorkers::Jobs::Maintenance::BackfillSitesObfuscatedLocationsJob)
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -4,31 +4,35 @@
 #
 # Table name: sites
 #
-#  id                 :integer          not null, primary key
-#  deleted_at         :datetime
-#  description        :text
-#  image_content_type :string
-#  image_file_name    :string
-#  image_file_size    :bigint
-#  image_updated_at   :datetime
-#  latitude           :decimal(9, 6)
-#  longitude          :decimal(9, 6)
-#  name               :string           not null
-#  notes              :text
-#  rails_tz           :string(255)
-#  tzinfo_tz          :string(255)
-#  created_at         :datetime
-#  updated_at         :datetime
-#  creator_id         :integer          not null
-#  deleter_id         :integer
-#  region_id          :integer
-#  updater_id         :integer
+#  id                   :integer          not null, primary key
+#  deleted_at           :datetime
+#  description          :text
+#  image_content_type   :string
+#  image_file_name      :string
+#  image_file_size      :bigint
+#  image_updated_at     :datetime
+#  latitude             :decimal(9, 6)
+#  longitude            :decimal(9, 6)
+#  name                 :string           not null
+#  notes                :text
+#  obfuscated_latitude  :decimal(9, 6)
+#  obfuscated_longitude :decimal(9, 6)
+#  rails_tz             :string(255)
+#  tzinfo_tz            :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  creator_id           :integer          not null
+#  deleter_id           :integer
+#  region_id            :integer
+#  updater_id           :integer
 #
 # Indexes
 #
-#  index_sites_on_creator_id  (creator_id)
-#  index_sites_on_deleter_id  (deleter_id)
-#  index_sites_on_updater_id  (updater_id)
+#  index_sites_on_creator_id            (creator_id)
+#  index_sites_on_deleter_id            (deleter_id)
+#  index_sites_on_obfuscated_latitude   (obfuscated_latitude)
+#  index_sites_on_obfuscated_longitude  (obfuscated_longitude)
+#  index_sites_on_updater_id            (updater_id)
 #
 # Foreign Keys
 #
@@ -37,29 +41,6 @@
 #  sites_deleter_id_fk  (deleter_id => users.id)
 #  sites_updater_id_fk  (updater_id => users.id)
 #
-latitudes = [
-  { -100 => false },
-  { -91 => false },
-  { -90 => true },
-  { -89 => true },
-  { 0 => true },
-  { 89 => true },
-  { 90 => true },
-  { 91 => false },
-  { 100 => false }
-]
-
-longitudes = [
-  { -200 => false },
-  { -181 => false },
-  { -180 => true },
-  { -179 => true },
-  { 0 => true },
-  { 179 => true },
-  { 180 => true },
-  { 181 => false },
-  { 200 => false }
-]
 
 describe Site do
   it 'has a valid factory' do
@@ -83,113 +64,213 @@ describe Site do
     expect(s.errors[:name].size).to eq 1
   end
 
-  it 'obfuscates locations' do
-    s = Site.new(latitude: -30.0873, longitude: 145.894)
+  describe 'location obfuscation' do
+    latitudes = [
+      { -100 => false },
+      { -91 => false },
+      { -90 => true },
+      { -89 => true },
+      { 0 => true },
+      { 89 => true },
+      { 90 => true },
+      { 91 => false },
+      { 100 => false }
+    ]
 
-    aggregate_failures do
-      expect(s.custom_latitude).to be_within(Site::JITTER_RANGE).of(s.latitude)
-      expect(s.custom_longitude).to be_within(Site::JITTER_RANGE).of(s.longitude)
+    longitudes = [
+      { -200 => false },
+      { -181 => false },
+      { -180 => true },
+      { -179 => true },
+      { 0 => true },
+      { 179 => true },
+      { 180 => true },
+      { 181 => false },
+      { 200 => false }
+    ]
+    it 'obfuscates locations' do
+      s = Site.new(latitude: -30.0873, longitude: 145.894)
+      s.valid? # trigger before_validation callback
 
-      jitter_exclude_range = Site::JITTER_RANGE * 0.1
-      expect(s.custom_latitude).not_to be_within(jitter_exclude_range).of(s.latitude)
-      expect(s.custom_longitude).not_to be_within(jitter_exclude_range).of(s.longitude)
+      aggregate_failures do
+        expect(s.obfuscated_latitude).to be_within(Site::JITTER_RANGE).of(s.latitude)
+        expect(s.obfuscated_longitude).to be_within(Site::JITTER_RANGE).of(s.longitude)
+
+        jitter_exclude_range = Site::JITTER_RANGE * 0.1
+        expect(s.obfuscated_latitude).not_to be_within(jitter_exclude_range).of(s.latitude)
+        expect(s.obfuscated_longitude).not_to be_within(jitter_exclude_range).of(s.longitude)
+      end
     end
-  end
 
-  it 'location obfuscation is stable' do
-    s1 = Site.new(latitude: -30.0873, longitude: 145.894)
-    s2 = Site.new(latitude: -30.0873, longitude: 145.894)
+    it 'location obfuscation is stable' do
+      s1 = Site.new(latitude: -30.0873, longitude: 145.894, name: 'abc')
+      s2 = Site.new(latitude: -30.0873, longitude: 145.894, name: 'abc')
 
-    # tiny one digit change in longitude
-    s3 = Site.new(latitude: -30.0873, longitude: 145.895)
+      # tiny one digit change in longitude
+      s3 = Site.new(latitude: -30.0873, longitude: 145.895, name: 'abc')
+      # tiny one digit change in latitude
+      s4 = Site.new(latitude: -30.0872, longitude: 145.894, name: 'abc')
 
-    # tiny one digit change in latitude
-    s4 = Site.new(latitude: -30.0872, longitude: 145.894)
+      [s1, s2, s3, s4].each(&:valid?) # trigger before_validation callback
 
-    expect(s1.custom_latitude).to eq(s2.custom_latitude)
-    expect(s1.custom_latitude).to eq(s2.custom_latitude)
+      expect(s1.obfuscated_latitude).to eq(s2.obfuscated_latitude)
+      expect(s1.obfuscated_longitude).to eq(s2.obfuscated_longitude)
 
-    expect(s1.custom_latitude).not_to eq(s3.custom_latitude)
-    expect(s1.custom_latitude).not_to eq(s3.custom_latitude)
+      expect(s1.obfuscated_latitude).not_to eq(s3.obfuscated_latitude)
+      expect(s1.obfuscated_longitude).not_to eq(s3.obfuscated_longitude)
 
-    expect(s1.custom_latitude).not_to eq(s4.custom_latitude)
-    expect(s1.custom_latitude).not_to eq(s4.custom_latitude)
-  end
+      expect(s1.obfuscated_latitude).not_to eq(s4.obfuscated_latitude)
+      expect(s1.obfuscated_longitude).not_to eq(s4.obfuscated_longitude)
+    end
 
-  it 'obfuscates lat/longs properly' do
-    original_lat = -23.0
-    original_lng = 127.0
-    s = build(:site, :with_lat_long)
+    it 'obfuscates lat/longs properly' do
+      original_lat = -23.0
+      original_lng = 127.0
+      s = build(:site, :with_lat_long)
 
-    jitter_range = Site::JITTER_RANGE
-    jitter_exclude_range = Site::JITTER_RANGE * 0.1
+      jitter_range = Site::JITTER_RANGE
+      jitter_exclude_range = Site::JITTER_RANGE * 0.1
 
-    lat_min = Site::LATITUDE_MIN
-    lat_max = Site::LATITUDE_MAX
-    lng_min = Site::LONGITUDE_MIN
-    lng_max = Site::LONGITUDE_MAX
+      lat_min = Site::LATITUDE_MIN
+      lat_max = Site::LATITUDE_MAX
+      lng_min = Site::LONGITUDE_MIN
+      lng_max = Site::LONGITUDE_MAX
 
-    100.times {
-      s.latitude = original_lat
-      s.longitude = original_lng
+      100.times {
+        s.latitude = original_lat
+        s.longitude = original_lng
 
-      jit_lat = Site.add_location_jitter(s.latitude, lat_min, lat_max, s.location_jitter_seed)
-      jit_lng = Site.add_location_jitter(s.longitude, lng_min, lng_max, s.location_jitter_seed)
+        jit_lat = Site.add_location_jitter(s.latitude, lat_min, lat_max, s.location_jitter_seed)
+        jit_lng = Site.add_location_jitter(s.longitude, lng_min, lng_max, s.location_jitter_seed)
 
-      expect(jit_lat).to be_within(jitter_range).of(s.latitude)
-      expect(jit_lat).not_to be_within(jitter_exclude_range).of(s.latitude)
+        expect(jit_lat).to be_within(jitter_range).of(s.latitude)
+        expect(jit_lat).not_to be_within(jitter_exclude_range).of(s.latitude)
 
-      expect(jit_lng).to be_within(jitter_range).of(s.longitude)
-      expect(jit_lng).not_to be_within(jitter_exclude_range).of(s.longitude)
-    }
-  end
+        expect(jit_lng).to be_within(jitter_range).of(s.longitude)
+        expect(jit_lng).not_to be_within(jitter_exclude_range).of(s.longitude)
+      }
+    end
 
-  it 'returns nil for obfuscated location when inputs are nil' do
-    s1 = Site.new(latitude: nil, longitude: 145.894)
-    s2 = Site.new(latitude: -30.0873, longitude: nil)
-    s3 = Site.new(latitude: nil, longitude: nil)
+    it 'returns nil for obfuscated location when inputs are nil' do
+      s1 = Site.new(latitude: nil, longitude: 145.894)
+      s2 = Site.new(latitude: -30.0873, longitude: nil)
+      s3 = Site.new(latitude: nil, longitude: nil)
 
-    expect([s1.custom_latitude, s2.custom_latitude, s3.custom_latitude]).to match(
-      [
-        nil,
-        be_within(Site::JITTER_RANGE).of(-30.0873),
-        nil
-      ]
-    )
+      [s1, s2, s3].each(&:valid?) # trigger before_validation callback
 
-    expect([s1.custom_longitude, s2.custom_longitude, s3.custom_longitude]).to match(
-      [
-        be_within(Site::JITTER_RANGE).of(145.894),
-        nil,
-        nil
-      ]
-    )
-  end
+      expect([s1.obfuscated_latitude, s2.obfuscated_latitude, s3.obfuscated_latitude]).to match(
+        [
+          nil,
+          be_within(Site::JITTER_RANGE).of(-30.0873),
+          nil
+        ]
+      )
 
-  it 'latitude should be within the range [-90, 90]' do
-    site = build(:site)
+      expect([s1.obfuscated_longitude, s2.obfuscated_longitude, s3.obfuscated_longitude]).to match(
+        [
+          be_within(Site::JITTER_RANGE).of(145.894),
+          nil,
+          nil
+        ]
+      )
+    end
 
-    latitudes.each { |value, pass|
-      site.latitude = value
-      if pass
-        expect(site).to be_valid
-      else
-        expect(site).not_to be_valid
+    it 'latitude should be within the range [-90, 90]' do
+      site = build(:site)
+
+      latitudes.each { |value, pass|
+        site.latitude = value
+        if pass
+          expect(site).to be_valid
+        else
+          expect(site).not_to be_valid
+        end
+      }
+    end
+
+    it 'longitudes should be within the range [-180, 180]' do
+      site = build(:site)
+
+      longitudes.each { |value, pass|
+        site.longitude = value
+        if pass
+          expect(site).to be_valid
+        else
+          expect(site).not_to be_valid
+        end
+      }
+    end
+
+    describe 'auto-generated obfuscated coordinates' do
+      it 'generates obfuscated coordinates on create when coordinates are present' do
+        site = create(:site, :with_lat_long)
+
+        expect(site.obfuscated_latitude).to be_present
+        expect(site.obfuscated_longitude).to be_present
+        expect(site.custom_obfuscated_location).to be false
+        expect(site.obfuscated_latitude).to be_within(Site::JITTER_RANGE).of(site.latitude)
+        expect(site.obfuscated_longitude).to be_within(Site::JITTER_RANGE).of(site.longitude)
       end
-    }
-  end
 
-  it 'longitudes should be within the range [-180, 180]' do
-    site = build(:site)
+      it 'does not generate obfuscated coordinates on create when coordinates are nil' do
+        site = create(:site, latitude: nil, longitude: nil)
 
-    longitudes.each { |value, pass|
-      site.longitude = value
-      if pass
-        expect(site).to be_valid
-      else
-        expect(site).not_to be_valid
+        expect(site.obfuscated_latitude).to be_nil
+        expect(site.obfuscated_longitude).to be_nil
       end
-    }
+
+      it 'updates obfuscated coordinates when latitude changes and generated flag is true' do
+        site = create(:site, :with_lat_long)
+        original_obfuscated_lat = site.obfuscated_latitude
+
+        site.update!(latitude: site.latitude + 1.0)
+
+        expect(site.obfuscated_latitude).not_to eq(original_obfuscated_lat)
+        expect(site.obfuscated_latitude).to be_within(Site::JITTER_RANGE).of(site.latitude)
+      end
+
+      it 'updates obfuscated coordinates when longitude changes and generated flag is true' do
+        site = create(:site, :with_lat_long)
+        original_obfuscated_lng = site.obfuscated_longitude
+
+        site.update!(longitude: site.longitude + 1.0)
+
+        expect(site.obfuscated_longitude).not_to eq(original_obfuscated_lng)
+        expect(site.obfuscated_longitude).to be_within(Site::JITTER_RANGE).of(site.longitude)
+      end
+
+      it 'does not update obfuscated coordinates when custom_obfuscated_location is true' do
+        site = create(:site, :with_lat_long)
+        custom_obfuscated_lat = -45.0
+        custom_obfuscated_lng = 145.0
+
+        # Simulate user-provided obfuscated location
+        site.update!(
+          obfuscated_latitude: custom_obfuscated_lat,
+          obfuscated_longitude: custom_obfuscated_lng,
+          custom_obfuscated_location: true
+        )
+
+        # Now change the real coordinates
+        site.update!(latitude: -30.0, longitude: 150.0)
+
+        # Obfuscated should remain as user set them
+        expect(site.obfuscated_latitude).to eq(custom_obfuscated_lat)
+        expect(site.obfuscated_longitude).to eq(custom_obfuscated_lng)
+        expect(site.custom_obfuscated_location).to be true
+      end
+
+      it 'does not update obfuscated coordinates when non-coordinate fields change' do
+        site = create(:site, :with_lat_long)
+        original_obfuscated_lat = site.obfuscated_latitude
+        original_obfuscated_lng = site.obfuscated_longitude
+
+        site.update!(name: 'new name')
+
+        expect(site.obfuscated_latitude).to eq(original_obfuscated_lat)
+        expect(site.obfuscated_longitude).to eq(original_obfuscated_lng)
+      end
+    end
   end
 
   it { is_expected.to have_many(:projects).through(:projects_sites) }

--- a/spec/permissions/audio_events_group_by_spec.rb
+++ b/spec/permissions/audio_events_group_by_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe AudioEvents::GroupByController do
+  describe 'permissions' do
+    create_entire_hierarchy
+
+    given_the_route '/audio_events/group_by' do
+      {
+        id: :invalid
+      }
+    end
+
+    send_create_body do
+      [{}, :json]
+    end
+
+    send_update_body do
+      [{}, :json]
+    end
+
+    with_custom_action(
+      :sites,
+      path: 'sites',
+      verb: :get,
+      expect: lambda { |_user, _action|
+        expect(api_response).to include(:data)
+      }
+    )
+
+    # Any authenticated user with at least reader access can use the group_by endpoint
+    ensures :admin, :owner, :writer, :reader,
+      can: [:sites],
+      cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+      fails_with: :not_found
+
+    # Users without project access cannot see any results (empty response but still succeeds)
+    ensures :no_access,
+      can: [:sites],
+      cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+      fails_with: :not_found
+
+    # Harvester cannot access the endpoint
+    ensures :harvester,
+      cannot: [:sites],
+      fails_with: :forbidden
+
+    ensures :harvester,
+      cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+      fails_with: :not_found
+
+    # Anonymous users can access the endpoint
+    ensures :anonymous,
+      can: [:sites]
+
+    ensures :anonymous,
+      cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+      fails_with: :not_found
+
+    # Invalid tokens cannot access the endpoint
+    ensures :invalid,
+      cannot: [:sites, :index, :show, :create, :update, :destroy, :new, :filter],
+      fails_with: [:unauthorized, :not_found]
+  end
+end

--- a/spec/requests/analysis_jobs/basic_workflow_spec.rb
+++ b/spec/requests/analysis_jobs/basic_workflow_spec.rb
@@ -12,7 +12,8 @@ describe 'AnalysisJobs', :clean_by_truncation do
 
     step 'we should see updated stats' do
       # 10 recordings, 2 scripts, 20 job items
-      assert_job_totals(overall_count: 20)
+      # overall count counts audio recordings, not job items, hence 10 not 20
+      assert_job_totals(overall_count: 10)
       assert_job_progress(status_new_count: 20, transition_queue_count: 20, result_empty_count: 20)
 
       # nothing in redis - scheduled job takes care on enqueueing

--- a/spec/requests/audio_events/group_by_spec.rb
+++ b/spec/requests/audio_events/group_by_spec.rb
@@ -1,0 +1,90 @@
+describe 'audio_events/group_by' do
+  create_audio_recordings_hierarchy
+
+  let!(:tag) { create(:tag, text: 'kookaburra', creator: owner_user) }
+  let!(:site2) { create(:site, :with_lat_long, region:, projects: [project]) }
+
+  before do
+    create_list(:audio_event, 5, audio_recording: audio_recording)
+    other_event = create(:audio_event, audio_recording:, creator: owner_user)
+    create(:tagging, tag:, audio_event: other_event, creator: owner_user)
+
+    second_recording = create(:audio_recording, site: site2)
+    create_list(:audio_event, 3, audio_recording: second_recording)
+  end
+
+  def check_locations(data, obfuscated)
+    site1_result = data[0]
+    site2_result = data[1]
+
+    aggregate_failures do
+      expect(site1_result[:site_id]).to eq site.id
+      expect(site1_result[:location_obfuscated]).to eq obfuscated
+      expect(site1_result[:latitude]).to eq(obfuscated ? site.obfuscated_latitude : site.latitude)
+      expect(site1_result[:longitude]).to eq(obfuscated ? site.obfuscated_longitude : site.longitude)
+
+      expect(site2_result[:site_id]).to eq site2.id
+      expect(site2_result[:location_obfuscated]).to eq obfuscated
+      expect(site2_result[:latitude]).to eq(obfuscated ? site2.obfuscated_latitude : site2.latitude)
+      expect(site2_result[:longitude]).to eq(obfuscated ? site2.obfuscated_longitude : site2.longitude)
+    end
+  end
+
+  it 'can return a result' do
+    get '/audio_events/group_by/sites', **api_headers(owner_token)
+
+    expect_success
+
+    expect(api_data).to match [
+      a_hash_including(
+        site_id: site.id,
+        region_id: region.id,
+        project_ids: [
+          project.id
+        ],
+        audio_event_count: 6
+      ),
+      a_hash_including(
+        site_id: site2.id,
+        region_id: region.id,
+        project_ids: [
+          project.id
+        ],
+        audio_event_count: 3
+      )
+    ]
+
+    check_locations(api_data, false)
+  end
+
+  it 'can return a result with filter' do
+    params = {
+      filter: {
+        'tags.text': { eq: tag.text }
+      }
+    }
+
+    get '/audio_events/group_by/sites', params:, **api_headers(owner_token)
+
+    expect_success
+
+    expect(api_data).to match [
+      a_hash_including(
+        site_id: site.id,
+        region_id: region.id,
+        project_ids: [
+          project.id
+        ],
+        audio_event_count: 1
+      )
+    ]
+  end
+
+  it 'preserves obfuscated locations' do
+    get '/audio_events/group_by/sites', **api_headers(reader_token)
+
+    expect_success
+
+    check_locations(api_data, true)
+  end
+end

--- a/spec/routing/audio_events/group_by_routing_spec.rb
+++ b/spec/routing/audio_events/group_by_routing_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe AudioEvents::GroupByController, type: :routing do
+  describe 'routing' do
+    it {
+      expect(get('/audio_events/group_by/sites')).to(
+        route_to('audio_events/group_by#group_audio_events_by_sites', format: 'json')
+      )
+    }
+
+    it {
+      expect(post('/audio_events/group_by/sites')).to(
+        route_to('audio_events/group_by#group_audio_events_by_sites', format: 'json')
+      )
+    }
+  end
+end

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -194,30 +194,11 @@ module ApiSpecHelpers
     end
 
     def schema_for_single
-      schema allOf: [
-        { '$ref' => '#/components/schemas/standard_response' },
-        {
-          type: 'object',
-          properties: {
-            data: (get_parent_param :baw_model_schema)
-          }
-        }
-      ]
+      schema(**Api::Schema.standard_single_response(get_parent_param(:baw_model_schema)))
     end
 
     def schema_for_many
-      schema allOf: [
-        { '$ref' => '#/components/schemas/standard_response' },
-        {
-          type: 'object',
-          properties: {
-            data: {
-              type: 'array',
-              items: (get_parent_param :baw_model_schema)
-            }
-          }
-        }
-      ]
+      schema(**Api::Schema.standard_array_response(get_parent_param(:baw_model_schema)))
     end
 
     # the way rspec creates describe blocks makes each new

--- a/spec/support/creation_helper.rb
+++ b/spec/support/creation_helper.rb
@@ -84,6 +84,7 @@ module Creation
     def create_anon_hierarchy
       prepare_users
       prepare_project_anon
+      prepare_dataset
 
       let!(:site_anon) {
         Common.create_site(owner_user, project_anon)

--- a/spec/unit/modules/access/access_spec.rb
+++ b/spec/unit/modules/access/access_spec.rb
@@ -1,5 +1,3 @@
-
-
 describe Access do
   # https://github.com/QutEcoacoustics/baw-server/issues/333
   context 'a user has multiple assigned permissions' do
@@ -7,8 +5,8 @@ describe Access do
 
     def test_level_name
       levels = Access::Core.user_levels(owner_user, project)
-
-      Access::Core.get_level_name(levels)
+      highest_level = Access::Core.highest(levels)
+      Access::Core.get_level_name(highest_level)
     end
 
     example 'a user is an owner and also has logged in read permissions' do

--- a/spec/unit/modules/access/by_permission_table_spec.rb
+++ b/spec/unit/modules/access/by_permission_table_spec.rb
@@ -1,0 +1,129 @@
+describe Access::ByPermissionTable do
+  create_audio_recordings_hierarchy
+  create_anon_hierarchy
+
+  let!(:another_project) { create(:project) }
+
+  before do
+    create(:permission,
+      project: project_anon,
+      creator: owner_user,
+      user: nil,
+      level: 'writer',
+      allow_logged_in: true)
+  end
+
+  context 'with projects it works as expected' do
+    def common(user)
+      Access::ByPermissionTable
+        .projects(user, level: Access::Permission::READER)
+        .order(:id)
+        .pluck(:id)
+    end
+
+    example 'for admin' do
+      expect(common(admin_user)).to eq([project.id, project_anon.id, another_project.id])
+    end
+
+    example 'for owner' do
+      expect(common(owner_user)).to eq([project.id, project_anon.id])
+    end
+
+    example 'for writer' do
+      expect(common(writer_user)).to eq([project.id, project_anon.id])
+    end
+
+    example 'for reader' do
+      expect(common(reader_user)).to eq([project.id, project_anon.id])
+    end
+
+    example 'for anonymous' do
+      expect(common(nil)).to eq([project_anon.id])
+    end
+  end
+
+  context 'with sites it works as expected' do
+    def common(user)
+      Access::ByPermissionTable
+        .sites(user, level: Access::Permission::READER)
+        .order(:id)
+        .pluck(:id)
+    end
+
+    example 'for admin' do
+      expect(common(admin_user)).to eq([site.id, site_anon.id])
+    end
+
+    example 'for owner' do
+      expect(common(owner_user)).to eq([site.id, site_anon.id])
+    end
+
+    example 'for writer' do
+      expect(common(writer_user)).to eq([site.id, site_anon.id])
+    end
+
+    example 'for reader' do
+      expect(common(reader_user)).to eq([site.id, site_anon.id])
+    end
+
+    example 'for anonymous' do
+      expect(common(nil)).to eq([site_anon.id])
+    end
+
+    example 'with project_ids filter' do
+      expect(
+        Access::ByPermissionTable
+          .sites(reader_user, level: Access::Permission::READER, project_ids: [project.id])
+          .order(:id)
+          .pluck(:id)
+      ).to eq([site.id])
+    end
+
+    example 'with project_ids filter excluding all' do
+      expect(
+        Access::ByPermissionTable
+          .sites(reader_user, level: Access::Permission::READER, project_ids: [another_project.id])
+          .order(:id)
+          .pluck(:id)
+      ).to eq([])
+    end
+  end
+
+  context 'with Access::ByPermission the behaviour is identical' do
+    ['reader_user', 'writer_user', 'owner_user', 'admin_user', nil].each do |user_name|
+      context "when user is #{user_name || 'anonymous'}" do
+        example 'for projects' do
+          user = user_name.nil? ? nil : send(user_name)
+
+          by_permission_result = Access::ByPermission
+            .projects(user, levels: Access::Permission::READER_OR_ABOVE)
+            .order(:id)
+            .pluck(:id)
+
+          by_permission_table_result = Access::ByPermissionTable
+            .projects(user, levels: Access::Permission::READER_OR_ABOVE)
+            .order(:id)
+            .pluck(:id)
+
+          expect(by_permission_table_result).to eq(by_permission_result)
+        end
+
+        example 'for sites' do
+          user = user_name.nil? ? nil : send(user_name)
+
+          by_permission_result = Access::ByPermission
+            .sites(user, levels: Access::Permission::READER_OR_ABOVE)
+            .order(:id)
+            .pluck(:id)
+
+          by_permission_table_result = Access::ByPermissionTable
+            .sites(user, levels: Access::Permission::READER_OR_ABOVE)
+            .order(:id)
+            .pluck(:id)
+
+          expect(by_permission_table_result).to eq(by_permission_result)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/modules/access/effective_permission_spec.rb
+++ b/spec/unit/modules/access/effective_permission_spec.rb
@@ -1,0 +1,110 @@
+describe Access::EffectivePermission do
+  create_audio_recordings_hierarchy
+  create_anon_hierarchy
+
+  let!(:another_project) { create(:project) }
+  let(:owner_level) { Access::Permission::LEVEL_TO_INTEGER_MAP[Access::Permission::OWNER] }
+  let(:writer_level) { Access::Permission::LEVEL_TO_INTEGER_MAP[Access::Permission::WRITER] }
+  let(:reader_level) { Access::Permission::LEVEL_TO_INTEGER_MAP[Access::Permission::READER] }
+
+  before do
+    create(:permission,
+      project: project_anon,
+      creator: owner_user,
+      user: nil,
+      level: 'writer',
+      allow_logged_in: true)
+  end
+
+  def execute(user, project_ids: nil)
+    Access::EffectivePermission
+      .add_effective_permissions_cte(Project.all, user, project_ids: project_ids)
+      .order('projects.id')
+      .pluck('projects.id', 'level')
+  end
+
+  context 'without project scoping' do
+    example 'admin has effective permission level determined correctly' do
+      expect(execute(admin_user)).to match([
+        [project.id, owner_level],
+        [project_anon.id, owner_level],
+        [another_project.id, owner_level]
+      ])
+    end
+
+    example 'owner has effective permission level determined correctly' do
+      expect(execute(owner_user)).to match([
+        [project.id, owner_level],
+        [project_anon.id, owner_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'writer has effective permission level determined correctly' do
+      expect(execute(writer_user)).to match([
+        [project.id, writer_level],
+        [project_anon.id, writer_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'reader has effective permission level determined correctly' do
+      expect(execute(reader_user)).to match([
+        [project.id, reader_level],
+        # this one is higher than user's level due to logged in writer access
+        [project_anon.id, writer_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'anonymous has effective permission level determined correctly' do
+      expect(execute(nil)).to match([
+        [project.id, nil],
+        [project_anon.id, reader_level],
+        [another_project.id, nil]
+      ])
+    end
+  end
+
+  context 'with project scoping' do
+    example 'admin has effective permission level determined correctly' do
+      expect(execute(admin_user, project_ids: [project_anon.id])).to match([
+        [project.id, nil],
+        [project_anon.id, owner_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'owner has effective permission level determined correctly' do
+      expect(execute(owner_user, project_ids: [project_anon.id])).to match([
+        [project.id, nil],
+        [project_anon.id, owner_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'writer has effective permission level determined correctly' do
+      expect(execute(writer_user, project_ids: [project_anon.id])).to match([
+        [project.id, nil],
+        [project_anon.id, writer_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'reader has effective permission level determined correctly' do
+      expect(execute(reader_user, project_ids: [project_anon.id])).to match([
+        [project.id, nil],
+        [project_anon.id, writer_level],
+        [another_project.id, nil]
+      ])
+    end
+
+    example 'anonymous has effective permission level determined correctly' do
+      expect(execute(nil, project_ids: [project_anon.id])).to match([
+        [project.id, nil],
+        [project_anon.id, reader_level],
+        [another_project.id, nil]
+      ])
+    end
+  end
+end


### PR DESCRIPTION
This pull request implements location privacy for sites through coordinate obfuscation and adds a new API endpoint for grouping sites by audio event counts.

Changes:

- Adds database columns for obfuscated site coordinates with automatic jittering for non-owner users
   - Initially went down the path of generating obfuscated locations in SQL but the query was massive and complex and arguably not that fast
   - Chose instead to just store obfuscated coordinates. This makes queries much simpler and also opens up letting us
       - set no public coordinates for sites
       - set custom public coordinates for sites
       - use adjustable jitter ranges to set public coordinates for sites
- Also adds a migration job for ensuring all sites get their new obfuscated locations
- Implements a new groupable API concern and sites/group_by endpoint for aggregating audio event counts by site
- Replaces activerecord-cte gem with native Rails CTE support 
- Adds new CTE based batch permissions queries in Access::EffectivePermission and Access::ByPermissionTable modules which allow more efficient permission queries but also allow for permission level checks in queries (e.g. use the obfuscated coordinates in the query if the current user is not a project owner for this site)
-
## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Remove/Reduce warnings from edited files
- [ ] Unit tests have been added for changes
- [ ] Ensure CI build is passing
