### PR TITLE
feat: add reporting module and tag_accumulation endpoint

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class ReportsController < ApplicationController
+  include Api::ControllerHelper
+  include Api::Reporting
+
+  # POST /reports/tag_accumulation
+  # Returns a structured report of cumulative unique tag counts over time buckets.
+  # Accepts a filter object where:
+  #   the `filter` is applied to audio events
+  #   the `paging`, `sort` and `projection` options are invalid
+  # Accepts an `options` object where:
+  #   `bucket_size` (required) interval for bucket aggregation
+  def tag_accumulation
+    do_authorize_class(:filter, AudioEvent)
+
+    base_query = Access::ByPermissionTable.audio_events(current_user, level: Access::Permission::READER)
+
+    projections = {
+      bucket: Bucketer::BUCKETS[:bucket],
+      cumulative_unique_tag_count: TagAccumulation.cumulative_count
+    }
+
+    results, opts = execute_report(
+      base_query:,
+      template: TagAccumulation.new(report_options),
+      projections:
+    )
+
+    respond_report(results, opts)
+  end
+
+  private
+
+  # @return [Hash]
+  def report_options
+    options = api_options_params
+    options.require(:bucket_size)
+    options.permit(:bucket_size).to_h
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -29,4 +29,26 @@ class ApplicationRecord < ActiveRecord::Base
     scope ||= self
     attributes.keys.zip(scope.pick(*attributes.values)).to_h
   end
+
+  # Sometimes want to execute a generated SQL query that is related to a model,
+  # but the return type is so different that we don't want to cast it into any
+  # particular ActiveRecord model.
+  # This method is similar to exec_query but uses type hints from postgres to
+  # cast result values into primitive types
+  # @param query [#to_sql] e.g. Arel::SelectManager, ActiveRecord::Relation
+  # @return [Array<Hash>]
+  def self.exec_query_casted(query)
+    # We're intentionally not doing a filter query or an active record query here.
+    # The goal is speed and efficiency
+    connection_pool.with_connection do |connection|
+      connection.exec_query(query.to_sql) => result
+      # This is icky. What happens in real rails code is the ActiveRecord::Result
+      # object is consumed by ActiveRecord::Base.instantiate which turns takes
+      # in rows of untyped results and column types turns them into model objects.
+      columns = result.columns.map(&:to_sym)
+      result.cast_values.map do |row|
+        columns.zip(row).to_h
+      end
+    end
+  end
 end

--- a/app/modules/api/controller_helper.rb
+++ b/app/modules/api/controller_helper.rb
@@ -306,6 +306,23 @@ module Api
       params.permit!
     end
 
+    def api_filter_params_filter_only!
+      if params.key?(:paging) || params.key?(:sort) || params.key?(:projection)
+        raise CustomErrors::UnprocessableEntityError,
+          'Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+      end
+
+      api_filter_params_filter_only
+    end
+
+    def api_filter_params_filter_only
+      api_filter_params.to_h.slice(:filter)
+    end
+
+    def api_options_params
+      params.require(:options)
+    end
+
     # Filter out only paging parameters from the request.
     # Used in endpoints that are not standard but still need paging.
     # @param [Hash] route_parameters - additional route parameters to include in

--- a/app/modules/api/group_by.rb
+++ b/app/modules/api/group_by.rb
@@ -27,19 +27,6 @@ module Api
 
     private
 
-    def api_filter_params_filter_only!
-      if params.key?(:paging) || params.key?(:sort) || params.key?(:projection)
-        raise CustomErrors::UnprocessableEntityError,
-          'Paging, sorting, and projection parameters are not allowed in group by requests.'
-      end
-
-      api_filter_params_filter_only
-    end
-
-    def api_filter_params_filter_only
-      api_filter_params.to_h.slice(:filter)
-    end
-
     def group_cte_table
       @group_cte_table ||= Arel::Table.new(:grouped_table)
     end
@@ -94,16 +81,7 @@ module Api
 
       # We're intentionally not doing a filter query or an active record query here.
       # The goal is speed and efficiency
-      parent.model.connection_pool.with_connection do |connection|
-        connection.exec_query(grouped_query.to_sql) => result
-        # This is icky. What happens in real rails code is the ActiveRecord::Result
-        # object is consumed by ActiveRecord::Base.instantiate which turns takes
-        # in rows of untyped results and column types turns them into model objects.
-        columns = result.columns.map(&:to_sym)
-        result.cast_values.map do |row|
-          columns.zip(row).to_h
-        end
-      end => results
+      results = parent.model.exec_query_casted(grouped_query)
 
       [results, opts]
     end

--- a/app/modules/api/reporting.rb
+++ b/app/modules/api/reporting.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Applies request filters to base_query, passes the filtered relation
+    # through a report template, then applies projections to the resulting
+    # Arel query.
+    #
+    # @param base_query [ActiveRecord::Relation] permission-scoped query
+    # @param template [#call] callable report template that defines the report's
+    #   structure; must receive an ActiveRecord::Relation and return an
+    #   Arel::SelectManager
+    # @param projections [Hash{Symbol => Arel::Nodes::Node}] alias: expression
+    #   pairs to project from template
+    # @return [Array(Array<Hash>, Hash)] the query result and filter options
+    def execute_report(base_query:, template:, projections: {})
+      raise ArgumentError, 'template must respond to #call' unless template.respond_to?(:call)
+
+      filter = Filter::Query.new(
+        api_filter_params_filter_only!,
+        base_query,
+        AudioEvent,
+        AudioEvent.filter_settings
+      )
+
+      # Preserving the supplied filter to later return in the response
+      opts = {
+        filter: filter.filter,
+        filter_without_defaults: filter.supplied_filter
+      }
+
+      query = filter.query_without_paging_sorting
+      query = template.call(query)
+      query.project(*projections.map { |name, expression| expression.as(name.to_s) })
+
+      results = AudioEvent.exec_query_casted(query)
+      [results, opts]
+    end
+
+    def respond_report(result, opts = {})
+      render_format(result, opts)
+    end
+  end
+end

--- a/app/modules/api/reporting/bucketer.rb
+++ b/app/modules/api/reporting/bucketer.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Generic time-series bucketing utility.
+    # Generates a series of [t, t+interval) tsrange buckets, covering the
+    # minimum `start_at` to the maximum `end_at` from the given events table.
+    # Used by report templates (e.g. TagAccumulation) that need time-bucketed
+    # aggregation.
+    class Bucketer
+      include CteHelper
+
+      BOUNDS  = Arel::Table.new(:bounds)
+      BUCKETS = Arel::Table.new(:audio_event_buckets)
+
+      INTERVALS = {
+        'day' => { days: 1 },
+        'week' => { weeks: 1 },
+        'month' => { months: 1 },
+        'year' => { years: 1 }
+      }.freeze
+
+      Options = Data.define(:bucket_size) {
+        def interval_hash = INTERVALS.fetch(bucket_size) { raise KeyError, "#{bucket_size} not in #{INTERVALS.keys}" }
+        def interval_arel = Baw::Arel::Nodes::MakeInterval.new(**interval_hash)
+      }
+
+      attr_reader :options
+
+      # @param options [Hash]
+      # @option options [String] :bucket_size required
+      def initialize(options = {})
+        @options = Options.new(**options)
+      end
+
+      # Returns the two bucket-related CTEs [bounds, buckets]
+      # @param events_table [Arel::Table] the CTE table containing start_at/end_at columns
+      # @return [Array<Arel::Nodes::As>]
+      def bucket_ctes(events_table:)
+        [
+          cte(BOUNDS, bounds_cte(events_table, @options.bucket_size)),
+          cte(BUCKETS, buckets_cte(@options.interval_arel))
+        ]
+      end
+
+      private
+
+      # Use the events to determine bounds for generating the bucket series
+      def bounds_cte(events_table, interval)
+        events_table.project(
+          Arel.date_trunc(interval, events_table[:start_at].minimum).as('series_start'),
+          Arel.date_trunc(interval, events_table[:end_at].maximum).as('series_end')
+        )
+      end
+
+      # Using the bounds and supplied bucket interval to generate the main bucket cte
+      def buckets_cte(interval_arel)
+        series = Arel.generate_series(BOUNDS[:series_start], BOUNDS[:series_end], interval_arel).as('bucket_lower')
+        lower = series.right
+        upper = Arel::Nodes::InfixOperation.new('+', lower, interval_arel)
+
+        # Without `.on` Arel generates INNER JOIN LATERAL (not CROSS JOIN LATERAL?)
+        # which causes a syntax error
+        BOUNDS
+            .project(Arel.tsrange(lower, upper).as('bucket'))
+            .join(Arel::Nodes::Lateral.new(series))
+            .on(Arel.sql('true'))
+      end
+    end
+  end
+end

--- a/app/modules/api/reporting/cte_helper.rb
+++ b/app/modules/api/reporting/cte_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Mixin providing a helper for building CTE nodes
+    module CteHelper
+      def cte(table, query) = Arel::Nodes::As.new(table, query)
+    end
+  end
+end

--- a/app/modules/api/reporting/tag_accumulation.rb
+++ b/app/modules/api/reporting/tag_accumulation.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Report template with the required CTEs and joins to produce a report of
+    # cumulative unique tag counts over time buckets.
+    #
+    # Implements #call(query) for use as a template in execute_report.
+    class TagAccumulation
+      include CteHelper
+
+      EVENTS     = Arel::Table.new(:filtered_events)
+      FIRST_SEEN = Arel::Table.new(:first_seen_per_tag)
+      NEW_TAGS   = Arel::Table.new(:new_tags)
+
+      # @param options [Hash]
+      # @option options [String] :bucket_size required
+      def initialize(options = {})
+        @bucketer = Bucketer.new(options)
+      end
+
+      # @param query [ActiveRecord::Relation] base query
+      # @return [Arel::SelectManager]
+      def call(query)
+        query = query.joins(joins)
+
+        # Each tag_first_seen_bucket belongs to one [unit, unit+1) tsrange
+        Arel::SelectManager.new
+          .with(*ctes(query:))
+          .from(Bucketer::BUCKETS)
+          .join(NEW_TAGS, Arel::Nodes::OuterJoin)
+          .on(Bucketer::BUCKETS[:bucket].contains(NEW_TAGS[:tag_first_seen_bucket]))
+          .order(Bucketer::BUCKETS[:bucket])
+      end
+
+      # Arel expression to project cumulative unique tag count up to and
+      # including each bucket.
+      # @return [Arel::Nodes::Over]
+      def self.cumulative_count
+        # Cumulative count will stay flat on buckets with no newly seen tags
+        new_count = Arel.coalesce(NEW_TAGS[:new_tag_count], 0).sum
+        window = Arel::Nodes::Window.new
+          .order(Bucketer::BUCKETS[:bucket])
+          .tap { |w| w.rows(Arel::Nodes::Preceding.new) }
+
+        new_count.over(window)
+      end
+
+      private
+
+      def joins = { taggings: [:tag] }
+
+      def ctes(query:)
+        bucket_size = @bucketer.options.bucket_size
+
+        # Events_cte contains the effective_permissions cte;
+        # it becomes a nested cte in the final query (no performance impact).
+        [
+          cte(EVENTS, events_cte(query)),
+          *@bucketer.bucket_ctes(events_table: EVENTS),
+          cte(FIRST_SEEN, first_seen_cte(bucket_size)),
+          cte(NEW_TAGS, new_tags_cte)
+        ]
+      end
+
+      def events_cte(query)
+        query
+          .except(:select, :order, :limit, :offset)
+          .reselect(
+            Tagging.arel_table[:tag_id].as('tag_id'),
+            AudioEvent.start_date_arel.as('start_at'),
+            AudioEvent.end_date_arel.as('end_at')
+          ).arel
+      end
+
+      # To get the cumulative unique tag count, we only depend on when a tag *first* appears,
+      # so we collapse each tag to exactly one row - the first bucket it appears in
+      def first_seen_cte(interval)
+        EVENTS
+          .project(EVENTS[:tag_id], Arel.date_trunc(interval, EVENTS[:start_at]).minimum.as('tag_first_seen_bucket'))
+          .group(EVENTS[:tag_id])
+      end
+
+      # Now we can just count how many tags are first seen in each bucket -
+      # this is what will be accumulated in the final step
+      def new_tags_cte
+        FIRST_SEEN
+          .project(FIRST_SEEN[:tag_first_seen_bucket], Arel.star.count.as('new_tag_count'))
+          .group(FIRST_SEEN[:tag_first_seen_bucket])
+      end
+    end
+  end
+end

--- a/app/modules/baw/arel.rb
+++ b/app/modules/baw/arel.rb
@@ -32,6 +32,24 @@ module Baw
       ::Arel::Nodes::BindParam.new(value)
     end
 
+    # PostgreSQL generate_series(start, stop, step)
+    # @return [::Arel::Nodes::NamedFunction]
+    def generate_series(start, stop, step)
+      ::Arel::Nodes::NamedFunction.new('generate_series', [start, stop, step])
+    end
+
+    # PostgreSQL date_trunc(field, source)
+    # @return [::Arel::Nodes::NamedFunction]
+    def date_trunc(field, source)
+      ::Arel::Nodes::NamedFunction.new('date_trunc', [::Arel::Nodes.build_quoted(field), source])
+    end
+
+    # PostgreSQL tsrange(lower, upper, bounds)
+    # @return [::Arel::Nodes::NamedFunction]
+    def tsrange(lower, upper, bounds = '[)')
+      ::Arel::Nodes::NamedFunction.new('tsrange', [lower, upper, ::Arel::Nodes.build_quoted(bounds)])
+    end
+
     module NodeExtensions
       # Treat this node as an array.
       # Has no effect other than to allow array-like methods to be called on this node.

--- a/app/modules/baw/arel/nodes.rb
+++ b/app/modules/baw/arel/nodes.rb
@@ -63,8 +63,8 @@ module Baw
       end
 
       class MakeInterval < NamedFunctionWithNamedArguments
-        def initialize(years: nil, months: nil, days: nil, hours: nil, minutes: nil, seconds: nil)
-          args = { years:, months:, days:, hours:, mins: minutes, secs: seconds }.compact
+        def initialize(years: nil, months: nil, weeks: nil, days: nil, hours: nil, minutes: nil, seconds: nil)
+          args = { years:, months:, weeks:, days:, hours:, mins: minutes, secs: seconds }.compact
 
           raise ArgumentError, 'At least one argument must be supplied' if args.empty?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -859,6 +859,9 @@ Rails.application.routes.draw do
   # progress events
   resources :progress_events, defaults: { format: 'json' }, concerns: [:filterable]
 
+  # reporting routes
+  post 'reports/tag_accumulation', to: 'reports#tag_accumulation', defaults: { format: 'json' }
+
   # route to the home page of site
   root to: 'public#index'
 

--- a/lib/patches/range.rb
+++ b/lib/patches/range.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BawWeb
+  module Range
+    def as_json(_options = nil)
+      [first, last]
+    end
+  end
+end
+
+Range.prepend(BawWeb::Range)

--- a/spec/api/audio_events/group_by_spec.rb
+++ b/spec/api/audio_events/group_by_spec.rb
@@ -104,7 +104,7 @@ describe 'audio_events/group_by', type: :request do
         run_test! do
           expect_error(
             :unprocessable_entity,
-            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by requests.'
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
           )
         end
       end
@@ -115,7 +115,7 @@ describe 'audio_events/group_by', type: :request do
         run_test! do
           expect_error(
             :unprocessable_entity,
-            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by requests.'
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
           )
         end
       end
@@ -126,7 +126,7 @@ describe 'audio_events/group_by', type: :request do
         run_test! do
           expect_error(
             :unprocessable_entity,
-            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by requests.'
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
           )
         end
       end

--- a/spec/api/reports_spec.rb
+++ b/spec/api/reports_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'reports', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+
+  let(:skip_automatic_description) { true }
+
+  def self.response_body_schema
+    Api::Schema.standard_array_response(
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          bucket: {
+            type: 'array',
+            items: { type: 'string', format: 'date-time' }
+          },
+          cumulative_unique_tag_count: { type: 'number' }
+        },
+        required: [:bucket, :cumulative_unique_tag_count]
+      }
+    )
+  end
+
+  def self.request_body_schema
+    Api::Schema.filter_payload(filter: true, sorting: false, paging: false, projection: false).deep_merge(
+      properties: {
+        options: {
+          type: 'object',
+          properties: {
+            bucket_size: {
+              type: 'string',
+              enum: ['day', 'week', 'month', 'year']
+            }
+          },
+          required: [:bucket_size]
+        }
+      },
+      required: [:options]
+    )
+  end
+
+  path '/reports/tag_accumulation' do
+    post 'Gets cumulative unique tag counts over time buckets' do
+      tags 'reports'
+      consumes 'application/json'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns cumulative unique tag counts bucketed by a time interval.
+        The `options` parameter specifies the bucket size (day, week, month, or year).
+        The optional `filter` parameter is applied to audio events.
+        Results only include audio events the user has reader access to.
+      DESCRIPTION
+
+      parameter name: :request_body, in: :body, required: true,
+        schema: request_body_schema
+
+      response '200', 'tag accumulation report retrieved' do
+        schema(**response_body_schema)
+
+        let(:request_body) { { options: { bucket_size: 'day' }, filter: {} } }
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '200', 'filters audio events by tag' do
+        let(:request_body) do
+          {
+            options: { bucket_size: 'day' },
+            filter: { 'tags.id': { eq: tag.id } }
+          }
+        end
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '422', 'rejects paging parameters' do
+        let(:request_body) { { options: { bucket_size: 'day' }, paging: { items: 10 } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects sort parameters' do
+        let(:request_body) { { options: { bucket_size: 'day' }, sort: { order_by: 'id' } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects projection parameters' do
+        let(:request_body) { { options: { bucket_size: 'day' }, projection: { only: [:id] } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects missing options' do
+        let(:request_body) { { filter: {} } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: param is missing or the value is empty or invalid: options'
+          )
+        end
+      end
+
+      response '422', 'rejects empty options' do
+        let(:request_body) {
+          {
+            options: {},
+            filter: {}
+          }
+        }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: param is missing or the value is empty or invalid: options'
+          )
+        end
+      end
+
+      response '422', 'rejects options with missing bucket_size param' do
+        let(:request_body) {
+          {
+            options: { irrelevant: 'value' },
+            filter: {}
+          }
+        }
+
+        run_test! do
+          expect_error(
+            :unprocessable_entity,
+            'The request could not be understood: param is missing or the value is empty or invalid: bucket_size'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/audio_event_factory.rb
+++ b/spec/factories/audio_event_factory.rb
@@ -78,6 +78,17 @@ FactoryBot.define do
       end
     end
 
+    # using a specific tag
+    trait :using_tag do
+      transient { tag { nil } }
+      after(:create) do |audio_event, evaluator|
+        raise ArgumentError, 'tag must be provided for :using_tag trait' if evaluator.tag.nil?
+
+        create(:tagging, tag: evaluator.tag, audio_event: audio_event, creator: evaluator.creator)
+      end
+    end
+
+    factory :audio_event_using_tag, traits: [:using_tag]
     factory :audio_event_with_tags, traits: [:with_tags]
     factory :audio_event_with_comments, traits: [:with_comments]
     factory :audio_event_with_tags_and_comments, traits: [:with_tags, :with_comments]

--- a/spec/permissions/analysis_jobs_results_spec.rb
+++ b/spec/permissions/analysis_jobs_results_spec.rb
@@ -22,10 +22,12 @@
     describe "permissions for #{action}" do
       # override the default :index and :show actions to change the assertions
       # directory listing (this is equivalent to :index)
-      with_custom_action(:index, path: '', verb: :get, expect: -> { expect_data_is_hash })
+      with_custom_action(:index, path: '', verb: :get, expect: lambda { |_user, _action|
+        expect_data_is_hash
+      })
       # file blob (this is equivalent to :show)
-      with_custom_action(:show, path: '/Test1/Test2/test-CASE.csv', verb: :get, expect: lambda {
-        expect_binary_response('text/csv')
+      with_custom_action(:show, path: '/Test1/Test2/test-CASE.csv', verb: :get, expect: lambda { |_user, _action|
+        expect_binary_response(mime: 'text/csv')
       })
 
       items_reading = Set[:index, :show]

--- a/spec/permissions/audio_events_group_by_spec.rb
+++ b/spec/permissions/audio_events_group_by_spec.rb
@@ -23,7 +23,7 @@ describe AudioEvents::GroupByController do
       path: 'sites',
       verb: :get,
       expect: lambda { |_user, _action|
-        expect(api_response).to include(:data)
+        expect(api_result).to include(:data)
       }
     )
 

--- a/spec/permissions/cms_spec.rb
+++ b/spec/permissions/cms_spec.rb
@@ -17,12 +17,12 @@ describe 'CMS permissions' do
   end
 
   custom_index = { path: '', verb: :get, expect: lambda { |_user, _action|
-    expect(api_response).to include({
+    expect(api_result).to include({
       slug: 'index'
     })
   }, action: :index }
   custom_show = { path: '{cms_path}', verb: :get, expect: lambda { |_user, _action|
-    expect(api_response).to include({
+    expect(api_result).to include({
       slug: 'credits'
     })
   }, action: :show }

--- a/spec/permissions/harvest_items_spec.rb
+++ b/spec/permissions/harvest_items_spec.rb
@@ -39,8 +39,8 @@ describe 'Harvest items permissions (nested)' do
     path: '',
     verb: :get,
     expect: lambda { |_user, _action|
-      expect(api_response).to include({
-        summary: a_hash
+      expect(api_result).to include({
+        data: a_kind_of(Array)
       })
     }
   )
@@ -114,8 +114,8 @@ describe 'Harvest items permissions (shallow)' do
     path: '',
     verb: :get,
     expect: lambda { |_user, _action|
-      expect(api_response).to include({
-        summary: a_hash
+      expect(api_result).to include({
+        data: a_kind_of(Array)
       })
     }
   )

--- a/spec/permissions/reports_spec.rb
+++ b/spec/permissions/reports_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe 'Reports permissions' do
+  create_entire_hierarchy
+
+  given_the_route '/reports' do
+    {
+      id: :invalid
+    }
+  end
+
+  send_create_body do
+    [{}, :json]
+  end
+
+  send_update_body do
+    [{}, :json]
+  end
+
+  let(:day) { audio_recording.recorded_date.utc.at_beginning_of_day }
+
+  with_custom_action(:tag_accumulation, path: 'tag_accumulation', verb: :post,
+    body: -> { { options: { bucket_size: 'day' }, filter: {} } },
+    expect: lambda { |user, _action|
+      if user == :no_access
+        expect(api_result[:data].length).to eq(0)
+      else
+        expect(api_data).to match([{ bucket: [day, day + 1.day], cumulative_unique_tag_count: 1.0 }])
+      end
+    })
+
+  # Any authenticated user with at least reader access can use the tag_accumulation endpoint
+  ensures :admin, :owner, :writer, :reader,
+    can: [:tag_accumulation],
+    cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+    fails_with: :not_found
+
+  # Users without project access cannot see any results (empty response but still succeeds)
+  ensures :no_access,
+    can: [:tag_accumulation],
+    cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+    fails_with: :not_found
+
+  # Harvester cannot access the endpoint
+  ensures :harvester,
+    cannot: [:tag_accumulation],
+    fails_with: :forbidden
+
+  ensures :harvester,
+    cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+    fails_with: :not_found
+
+  # Anonymous users cannot access the endpoint
+  ensures :anonymous,
+    cannot: [:tag_accumulation],
+    fails_with: :unauthorized
+
+  ensures :anonymous,
+    cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
+    fails_with: :not_found
+
+  # Invalid tokens cannot access the endpoint
+  ensures :invalid,
+    cannot: [:tag_accumulation, :index, :show, :create, :update, :destroy, :new, :filter],
+    fails_with: [:unauthorized, :not_found]
+end

--- a/spec/permissions/stats_spec.rb
+++ b/spec/permissions/stats_spec.rb
@@ -18,8 +18,8 @@ describe 'Stats permissions' do
   end
 
   with_custom_action(:index, path: '', verb: :get, expect: lambda { |_user, _action|
-    expect(api_response).to include({
-      summary: a_hash
+    expect(api_data).to include({
+      summary: a_kind_of(Hash)
     })
   })
 

--- a/spec/permissions/status_spec.rb
+++ b/spec/permissions/status_spec.rb
@@ -18,7 +18,7 @@ describe 'Status permissions' do
   end
 
   with_custom_action(:index, path: '', verb: :get, expect: lambda { |_user, _action|
-    expect(api_response).to include({ status: 'good' })
+    expect(api_result).to include({ status: 'good' })
   })
 
   ensures :admin, :owner, :writer, :reader, :no_access, :harvester, :anonymous,

--- a/spec/permissions/verifications_spec.rb
+++ b/spec/permissions/verifications_spec.rb
@@ -106,25 +106,26 @@ describe 'Verification permissions (shallow)' do
     end
   end
 
+  let(:another_verification) {
+    {
+      confirmed: Verification::CONFIRMATION_TRUE,
+      audio_event_id: audio_event.id,
+      tag_id: create(:tag).id
+    }
+  }
+
   with_custom_action(
     :create_or_update,
     path: '',
     verb: :put,
     body: lambda {
-      [{
-        'verification' => {
-          confirmed: Verification::CONFIRMATION_TRUE,
-          audio_event_id: audio_event.id,
-          tag_id: create(:tag).id
-        }
-      }, :json]
+      [{ 'verification' => another_verification }, :json]
     },
     expect: lambda { |_user, _action|
-      expect(api_response).to include({
-        summary: a_hash
-      })
+      expect(api_data).to match(a_hash_including(another_verification))
     }
   )
+
   # `writer` user SHOULD be able to DELETE (because they are the verification creator)
   # `writer` user SHOULD be able to PUT (update) (because they are the verification creator)
   the_users :admin, :writer, can_do: everything

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+describe 'reports/tag_accumulation' do
+  create_audio_recordings_hierarchy
+
+  let(:recording_start) { Time.parse('2000-03-06 07:06:59') }
+  let(:tags) { create_list(:tag, 3, creator: writer_user) }
+  let(:which_tags) { [[0, 1], [0, 0], nil, [2, 2]] }
+  let(:period) { 1.day }
+  let!(:recordings) {
+    start = recording_start
+    which_tags.map do |index|
+      recording = create(:audio_recording, site: site, creator: writer_user, recorded_date: start)
+      if index
+        tags.fetch_values(*index).each do |tag|
+          create(:audio_event_using_tag, audio_recording: recording, creator: writer_user, tag: tag)
+        end
+      end
+
+      start += period
+      recording
+    end
+  }
+
+  before do
+    # create an audio_event that writer_user has no access to, to prove it is not included in the counts
+    create(:audio_event_with_tags)
+  end
+
+  context 'with bucket size of day' do
+    let(:body) { { options: { bucket_size: 'day' }, filter: {} } }
+    let(:final_day_count) { 3.0 }
+    let(:expected_day_buckets) do
+      day1, day2, day3, day4 = recordings.map { |recording| recording.recorded_date.utc.at_beginning_of_day }
+      [
+        { bucket: [day1, day1 + 1.day], cumulative_unique_tag_count: 2.0 },
+        { bucket: [day2, day2 + 1.day], cumulative_unique_tag_count: 2.0 },
+        { bucket: [day3, day3 + 1.day], cumulative_unique_tag_count: 2.0 },
+        { bucket: [day4, day4 + 1.day], cumulative_unique_tag_count: final_day_count }
+      ]
+    end
+
+    it 'returns the correct buckets and counts' do
+      post '/reports/tag_accumulation', params: body, **api_headers(writer_token)
+
+      expect_success
+      expect(api_data).to match expected_day_buckets
+    end
+
+    context 'with filter by tag' do
+      let(:body) do
+        {
+          options: { bucket_size: 'day' },
+          filter: { 'tags.id': { in: [tags.first.id, tags.second.id] } }
+        }
+      end
+
+      it 'returns counts only for audio events with the specified tag' do
+        post '/reports/tag_accumulation', params: body, **api_headers(writer_token)
+
+        expect_success
+        expect(api_data).to match expected_day_buckets[0..1]
+      end
+    end
+
+    context 'with multiple tags per audio event' do
+      let(:final_day_count) { 4.0 }
+
+      before do
+        existing_event = recordings.last.audio_events.first
+        create(:tagging, tag: create(:tag, creator: writer_user), audio_event: existing_event)
+      end
+
+      it 'counts unique tags correctly' do
+        post '/reports/tag_accumulation', params: body, **api_headers(writer_token)
+        expect_success
+        expect(api_data).to match expected_day_buckets
+      end
+    end
+  end
+
+  context 'with bucket size of week' do
+    it 'returns the correct buckets and counts' do
+      body = { options: { bucket_size: 'week' }, filter: {} }
+      expected = [
+        {
+          bucket: [
+            recording_start.utc.at_beginning_of_week(:monday),
+            recording_start.utc.at_beginning_of_week(:monday) + 1.week
+          ],
+          cumulative_unique_tag_count: 3.0
+        }
+      ]
+
+      post '/reports/tag_accumulation', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match expected
+    end
+  end
+
+  context 'with bucket size of month' do
+    let(:recording_start) { Time.parse('2000-01-01 00:00:59') }
+    let(:period) { 2.months }
+
+    it 'returns the correct buckets and counts' do
+      body = { options: { bucket_size: 'month' }, filter: {} }
+      bucket_one = recording_start.utc.at_beginning_of_month
+      expected = [
+        { bucket: [bucket_one, bucket_one + 1.month], cumulative_unique_tag_count: 2.0 },
+        { bucket: [bucket_one + 1.month, bucket_one + 2.months], cumulative_unique_tag_count: 2.0 },
+        { bucket: [bucket_one + 2.months, bucket_one + 3.months], cumulative_unique_tag_count: 2.0 },
+        { bucket: [bucket_one + 3.months, bucket_one + 4.months], cumulative_unique_tag_count: 2.0 },
+        { bucket: [bucket_one + 4.months, bucket_one + 5.months], cumulative_unique_tag_count: 2.0 },
+        { bucket: [bucket_one + 5.months, bucket_one + 6.months], cumulative_unique_tag_count: 2.0 },
+        { bucket: [bucket_one + 6.months, bucket_one + 7.months], cumulative_unique_tag_count: 3.0 }
+      ]
+
+      post '/reports/tag_accumulation', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match expected
+    end
+  end
+
+  context 'with bucket size of year' do
+    let(:recording_start) { Time.parse('2000-01-01 00:00:59') }
+    let(:period) { 5.months }
+
+    it 'returns the correct buckets and counts' do
+      body = { options: { bucket_size: 'year' }, filter: {} }
+      expected = [
+        {
+          bucket: [recording_start.utc.at_beginning_of_year,
+                   recording_start.utc.at_beginning_of_year + 1.year], cumulative_unique_tag_count: 2.0
+        },
+        {
+          bucket: [recording_start.utc.at_beginning_of_year + 1.year,
+                   recording_start.utc.at_beginning_of_year + 2.years], cumulative_unique_tag_count: 3.0
+        }
+      ]
+
+      post '/reports/tag_accumulation', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match expected
+    end
+  end
+end

--- a/spec/routing/reports_routing_spec.rb
+++ b/spec/routing/reports_routing_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe ReportsController, type: :routing do
+  describe 'routing' do
+    it {
+      expect(post('/reports/tag_accumulation')).to(
+        route_to('reports#tag_accumulation', format: 'json')
+      )
+    }
+  end
+end

--- a/spec/support/shared_examples/permissions_for.rb
+++ b/spec/support/shared_examples/permissions_for.rb
@@ -88,7 +88,7 @@ RSpec.shared_examples 'permissions for' do |options|
       expect_id_matches(route_params[:id])
     when :list
       expect_has_ids(get_expected_list_items(user, action))
-    when is_a?(Proc)
+    when Proc
       instance_exec(user, action, &expect)
     end
   end


### PR DESCRIPTION
# feat: add reporting module and tag_accumulation endpoint

Establish a pattern for generating custom reports, with a new `/reports/tag_accumulation` endpoint that returns cumulative unique tag counts (via audio events) over configurable time buckets.

Related to #653

## Changes

- Add route `POST /reports/tag_accumulation`
- Add `ReportsController` with `tag_accumulation` action. Actions define the report query template and projections, and delegate execution to the `Api::Reporting` module
- Add `Api::Reporting` module - `#execute_report` applies filters, query template + projections to the input query + executes
- Add `ApplicationRecord.exec_query_casted` for executing queries and returning type-cast `Array<Hash>` results
- Add `Api::Reporting::TagAccumulation` - report query template that produces cumulative unique tag counts per time bucket
- Add `Api::Reporting::Bucketer` - generates time-series `tsrange` buckets for a given bucket size (day/week/month/year)

Unrelated bug fix to `with_custom_action` permission spec helper, expectation procs were not being evaluated, + update relevant permission specs affected 

## Problems

No problems identified.

## Visual Changes

No visual changes.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [x] Ensure CI build is passing
