### PR TITLE
feat: add reports/tag_diel_activity endpoint

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,6 +4,31 @@ class ReportsController < ApplicationController
   include Api::ControllerHelper
   include Api::Reporting
 
+  # POST /reports/tag_diel_activity
+  # Returns a structured report of tag frequencies over diel time buckets.
+  # Accepts a filter object where:
+  #   the `filter` is applied to audio events
+  #   the `paging`, `sort` and `projection` options are invalid
+  # Accepts an `options` object where:
+  #   `bucket_size` (required) interval for bucket aggregation
+  def tag_diel_activity
+    do_authorize_class(:filter, AudioEvent)
+
+    base_query = Access::ByPermissionTable.audio_events(current_user, level: Access::Permission::READER)
+
+    projections = {
+      tags: TagDielActivity.tag_frequency_array
+    }
+
+    results, opts = execute_report(
+      base_query:,
+      template: TagDielActivity.new(report_options),
+      projections:
+    )
+
+    respond_report(results, opts)
+  end
+
   # POST /reports/tag_frequency
   # Returns a structured report of tag frequencies over time buckets.
   # Accepts a filter object where:

--- a/app/modules/api/reporting/tag_diel_activity.rb
+++ b/app/modules/api/reporting/tag_diel_activity.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Report template with the required CTEs and joins to produce a report of
+    # diel activity, i.e. tag frequencies over configurable time buckets aligned
+    # to a 24-hour period.
+    #
+    # Implements #call(query) for use as a template in execute_report.
+    class TagDielActivity
+      include CteHelper
+
+      EVENTS = Arel::Table.new(:filtered_events)
+      COUNT_EVENTS = Arel::Table.new(:count_events)
+      COUNT_EVENTS_BUCKETED = Arel::Table.new(:count_events_bucketed)
+
+      BUCKET_LOWER = :bucket_lower
+      EVENT_BUCKET_LOWER = :event_bucket_lower
+      SECONDS_IN_A_DAY = 86_400
+      INTERVALS = {
+        'minute' => 60,
+        'halfhour' => 1800,
+        'hour' => 3600
+      }.freeze
+
+      # Duration in :seconds and number of buckets to cover a 24-hour period
+      Config = Data.define(:bucket_size)
+
+      # @param options [Hash]
+      # @option options [String] :bucket_size required
+      def initialize(options = {})
+        size = options.fetch(:bucket_size)
+        config = INTERVALS.fetch(size) { invalid_bucket_size!(size) }
+
+        @config = Config.new(config)
+      end
+
+      # @param query [ActiveRecord::Relation] base query
+      # @return [Arel::SelectManager]
+      def call(query)
+        query = query.joins(joins)
+
+        COUNT_EVENTS_BUCKETED
+          .project(bucket_array)
+          .with(*ctes(query:))
+          .group(COUNT_EVENTS_BUCKETED[BUCKET_LOWER])
+          .order(COUNT_EVENTS_BUCKETED[BUCKET_LOWER])
+      end
+
+      # Arel expression for a JSON array of tag_id and event count pairs,
+      # coalescing to an empty array for null tags.
+      def self.tag_frequency_array
+        Arel
+          .json({
+            tag_id: COUNT_EVENTS_BUCKETED[:tag_id],
+            events: COUNT_EVENTS_BUCKETED[:events]
+          })
+          .group
+          .filter(COUNT_EVENTS_BUCKETED[:tag_id].is_not_null)
+          .coalesce('[]')
+      end
+
+      private
+
+      def joins = { taggings: [:tag] }
+
+      def ctes(query:)
+        [
+          cte(EVENTS, events_cte(query)),
+          cte(COUNT_EVENTS, count_events_cte),
+          cte(COUNT_EVENTS_BUCKETED, count_events_bucketed_cte)
+        ]
+      end
+
+      def events_cte(query)
+        bucket_index = (audio_event_seconds_from_midnight / @config.bucket_size).floor
+        event_bucket_lower = bucket_index * @config.bucket_size
+
+        query
+          .except(:select, :order, :limit, :offset)
+          .reselect(
+            Tagging.arel_table[:tag_id].as('tag_id'),
+            event_bucket_lower.as(EVENT_BUCKET_LOWER.to_s)
+          ).arel
+      end
+
+      def count_events_cte
+        EVENTS
+          .project(Arel.star, EVENTS[:tag_id].count.as('events'))
+          .group(EVENTS[EVENT_BUCKET_LOWER], EVENTS[:tag_id])
+      end
+
+      def count_events_bucketed_cte
+        final_bucket_lower = SECONDS_IN_A_DAY - @config.bucket_size
+
+        buckets = Arel::Table.new('buckets')
+        bucket_series = Arel.generate_series(0, final_bucket_lower, @config.bucket_size).as(BUCKET_LOWER.to_s)
+        bucket_series_query = Arel::SelectManager.new.project(bucket_series).as(buckets.name)
+
+        Arel::SelectManager.new
+          .project(
+            COUNT_EVENTS[:tag_id],
+            COUNT_EVENTS[:events],
+            buckets[BUCKET_LOWER]
+          )
+          .from(bucket_series_query)
+          .join(COUNT_EVENTS, Arel::Nodes::OuterJoin)
+          .on(COUNT_EVENTS[EVENT_BUCKET_LOWER].eq(buckets[BUCKET_LOWER]))
+      end
+
+      # Used to align event start times to a common diel period
+      def midnight(col) = Arel.date_trunc('day', col) # + offset
+
+      # Subtracting midnight gives seconds since the start of the diel period, which can then be bucketed
+      def audio_event_seconds_from_midnight
+        # ! TODO: remove Subtraction.new when arel-extensions is removed. See https://github.com/QutEcoacoustics/baw-server/issues/966
+        Arel::Nodes::Subtraction.new(
+          AudioEvent.start_date_arel,
+          midnight(AudioEvent.start_date_arel)
+        ).extract('epoch')
+      end
+
+      def bucket_array
+        # ! TODO: remove Addition.new when arel-extensions is removed. See https://github.com/QutEcoacoustics/baw-server/issues/966
+        Arel.json([
+          COUNT_EVENTS_BUCKETED[BUCKET_LOWER],
+          Arel::Nodes::Addition.new(COUNT_EVENTS_BUCKETED[BUCKET_LOWER], @config.bucket_size)
+        ]).as('bucket')
+      end
+
+      def invalid_bucket_size!(size) = raise KeyError, "#{size} not in #{INTERVALS.keys}"
+    end
+  end
+end

--- a/app/modules/api/schema/helpers.rb
+++ b/app/modules/api/schema/helpers.rb
@@ -159,26 +159,28 @@ module Api
         }
       end
 
-      def bucket
+      def bucket(diel: false)
+        description = diel ? 'in seconds from the start of the diel cycle' : 'as an ISO8601 interval string'
+
         {
           bucket: {
             type: 'array',
-            items: { type: 'string', format: 'date-time' },
+            items: diel ? { type: 'integer' } : { type: 'string', format: 'date-time' },
             minItems: 2,
             maxItems: 2,
             additionalItems: false,
-            description: 'The start and end of the time bucket as an ISO8601 interval string'
+            description: "The start and end of the time bucket #{description}"
           }
         }
       end
 
-      def report_options
+      def report_options(diel: false)
         {
           type: 'object',
           properties: {
             bucket_size: {
               type: 'string',
-              enum: ['day', 'week', 'month', 'year']
+              enum: diel ? ['minute', 'half-hour', 'hour'] : ['day', 'week', 'month', 'year']
             }
           },
           required: [:bucket_size]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -862,6 +862,7 @@ Rails.application.routes.draw do
   # reporting routes
   post 'reports/tag_accumulation(.:format)', to: 'reports#tag_accumulation', defaults: { format: 'json' }
   post 'reports/tag_frequency(.:format)', to: 'reports#tag_frequency', defaults: { format: 'json' }
+  post 'reports/tag_diel_activity(.:format)', to: 'reports#tag_diel_activity', defaults: { format: 'json' }
 
   # route to the home page of site
   root to: 'public#index'

--- a/spec/api/reports/tag_diel_activity_spec.rb
+++ b/spec/api/reports/tag_diel_activity_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'reports', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+
+  let(:skip_automatic_description) { true }
+
+  def self.response_body_schema
+    Api::Schema.standard_array_response(
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          **Api::Schema.bucket(diel: true),
+          tags: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                tag_id: { type: Api::Schema.id },
+                events: { type: 'integer', description: 'The number of events with the given tag in the bucket' }
+              }
+            }
+          },
+          readOnly: true
+        },
+        required: [:bucket, :tags]
+      }
+    )
+  end
+
+  def self.request_body_schema
+    Api::Schema.filter_payload(
+      filter: true, sorting: false, paging: false, projection: false, options: Api::Schema.report_options(diel: true)
+    )
+  end
+
+  path '/reports/tag_diel_activity' do
+    post 'Gets event frequency per tag across diel time buckets' do
+      tags 'reports'
+      consumes 'application/json'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns event frequency per tag across diel time buckets.
+        The `options` parameter specifies the bucket size (minute, halfhour, hour).
+        The optional `filter` parameter is applied to audio events.
+        Results only include audio events the user has reader access to.
+      DESCRIPTION
+
+      parameter name: :request_body, in: :body, required: true,
+        schema: request_body_schema
+
+      response '200', 'tag diel activity report retrieved' do
+        schema(**response_body_schema)
+
+        let(:request_body) { { options: { bucket_size: 'hour' }, filter: {} } }
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '200', 'filters audio events by tag' do
+        let(:request_body) do
+          {
+            options: { bucket_size: 'hour' },
+            filter: { 'tags.id': { eq: tag.id } }
+          }
+        end
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '422', 'rejects paging parameters' do
+        let(:request_body) { { options: { bucket_size: 'hour' }, paging: { items: 10 } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects sort parameters' do
+        let(:request_body) { { options: { bucket_size: 'hour' }, sort: { order_by: 'id' } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects projection parameters' do
+        let(:request_body) { { options: { bucket_size: 'hour' }, projection: { only: [:id] } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects missing options' do
+        let(:request_body) { { filter: {} } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: param is missing or the value is empty or invalid: options'
+          )
+        end
+      end
+
+      response '422', 'rejects empty options' do
+        let(:request_body) {
+          {
+            options: {},
+            filter: {}
+          }
+        }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: param is missing or the value is empty or invalid: options'
+          )
+        end
+      end
+
+      response '422', 'rejects options with missing bucket_size param' do
+        let(:request_body) {
+          {
+            options: { irrelevant: 'value' },
+            filter: {}
+          }
+        }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: param is missing or the value is empty or invalid: bucket_size'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/permissions/reports_spec.rb
+++ b/spec/permissions/reports_spec.rb
@@ -39,21 +39,37 @@ describe 'Reports permissions' do
       end
     })
 
+  with_custom_action(:tag_diel_activity, path: 'tag_diel_activity', verb: :post,
+    body: -> { { options: { bucket_size: 'hour' }, filter: {} } },
+    expect: lambda { |user, _action|
+      if user == :no_access
+        expect(api_data).to match((0..23).map { |i| { bucket: [i * 3600, (i + 1) * 3600], tags: [] } })
+      else
+        expect(api_data).to match(
+            (0..23).map { |i|
+              bucket_lower = i * 3600
+              tags = bucket_lower == 25_200 ? [{ tag_id: tag.id, events: 1 }] : []
+              { bucket: [bucket_lower, bucket_lower + 3600], tags: tags }
+            }
+          )
+      end
+    })
+
   # Any authenticated user with at least reader access can use the reports/tag_* endpoints
   ensures :admin, :owner, :writer, :reader,
-    can: [:tag_accumulation, :tag_frequency],
+    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
     cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: :not_found
 
-  # Users without project access cannot see any results (empty response but still succeeds)
+  # Users without project access can call these endpoints, but receive no visible tag results
   ensures :no_access,
-    can: [:tag_accumulation, :tag_frequency],
+    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
     cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: :not_found
 
   # Harvester cannot access the endpoint
   ensures :harvester,
-    cannot: [:tag_accumulation, :tag_frequency],
+    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
     fails_with: :forbidden
 
   ensures :harvester,
@@ -62,7 +78,7 @@ describe 'Reports permissions' do
 
   # Anonymous users cannot access the endpoint
   ensures :anonymous,
-    cannot: [:tag_accumulation, :tag_frequency],
+    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
     fails_with: :unauthorized
 
   ensures :anonymous,
@@ -71,6 +87,7 @@ describe 'Reports permissions' do
 
   # Invalid tokens cannot access the endpoint
   ensures :invalid,
-    cannot: [:tag_accumulation, :tag_frequency, :index, :show, :create, :update, :destroy, :new, :filter],
+    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :index, :show, :create, :update, :destroy, :new,
+             :filter],
     fails_with: [:unauthorized, :not_found]
 end

--- a/spec/requests/reports/tag_diel_activity_spec.rb
+++ b/spec/requests/reports/tag_diel_activity_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+describe 'reports/tag_diel_activity' do
+  create_audio_recordings_hierarchy
+
+  let(:recording_start) { Time.parse('2000-03-06 07:06:59Z').utc }
+
+  let(:tags) { create_list(:tag, 3, creator: writer_user) }
+
+  let(:which_tags) { [[0, 1], [0, 0], nil, [2, 2]] }
+
+  let(:period) { 1.day + 1.hour }
+
+  let!(:recordings) do
+    which_tags.map.with_index do |index, i|
+      recording = create(
+        :audio_recording,
+        site: site,
+        creator: writer_user,
+        recorded_date: recording_start + (i * period)
+      )
+
+      if index
+        tags.fetch_values(*index).each do |tag|
+          create(
+            :audio_event_using_tag,
+            audio_recording: recording,
+            creator: writer_user,
+            tag: tag
+          )
+        end
+      end
+
+      recording
+    end
+  end
+
+  let(:final_bucket_array) { [a_hash_including(tag_id: tags[2].id, events: 2)] }
+  let(:result_buckets) do
+    {
+      25_200 => array_including(a_hash_including(tag_id: tags[0].id, events: 1), a_hash_including(tag_id: tags[1].id, events: 1)), #nolint
+      28_800 => [a_hash_including(tag_id: tags[0].id, events: 2)],
+      32_400 => [],
+      36_000 => final_bucket_array
+    }
+  end
+
+  let(:expected_data) do
+    (0..(interval[:buckets] - 1)).map { |i|
+      bucket_lower = i * interval[:bucket_size]
+      {
+        bucket: [bucket_lower, bucket_lower + interval[:bucket_size]],
+        tags: result_buckets.fetch(bucket_lower, [])
+      }
+    }
+  end
+
+  before do
+    # create an audio_event that writer_user has no access to, to prove it is not included in the counts
+    create(:audio_event_with_tags)
+  end
+
+  context 'with bucket size of hour' do
+    let(:body) { { options: { bucket_size: 'hour' }, filter: {} } }
+    let(:interval) { { bucket_size: Api::Reporting::TagDielActivity::INTERVALS['hour'], buckets: 24 } }
+
+    it 'returns the correct buckets and tag frequency arrays' do
+      post '/reports/tag_diel_activity', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match(expected_data)
+    end
+
+    context 'with filter by tag' do
+      let(:body) do
+        {
+          options: { bucket_size: 'hour' },
+          filter: { 'tags.id': { in: [tags.first.id, tags.second.id] } }
+        }
+      end
+
+      let(:result_buckets) do
+        {
+          25_200 => array_including(a_hash_including(tag_id: tags[0].id, events: 1), a_hash_including(tag_id: tags[1].id, events: 1)), #nolint
+          28_800 => [a_hash_including(tag_id: tags[0].id, events: 2)]
+        }
+      end
+
+      it 'returns bucketed tag frequency only for audio events with the specified tag' do
+        post '/reports/tag_diel_activity', params: body, **api_headers(writer_token)
+        expect_success
+
+        expect(api_data).to match expected_data
+      end
+    end
+
+    context 'with multiple tags per audio event' do
+      let!(:new_tagging) {
+        existing_event = recordings.last.audio_events.first
+        create(:tagging, tag: create(:tag, creator: writer_user), audio_event: existing_event)
+      }
+
+      let(:final_bucket_array) {
+        array_including(a_hash_including(tag_id: tags[2].id, events: 2),
+          a_hash_including(tag_id: new_tagging.tag.id, events: 1))
+      }
+
+      it 'counts unique tags correctly' do
+        post '/reports/tag_diel_activity', params: body, **api_headers(writer_token)
+        expect_success
+
+        expect(api_data).to match expected_data
+      end
+    end
+  end
+
+  context 'with bucket size of halfhour' do
+    let(:body) { { options: { bucket_size: 'halfhour' }, filter: {} } }
+    let(:interval) { { bucket_size: Api::Reporting::TagDielActivity::INTERVALS['halfhour'], buckets: 48 } }
+
+    # with an offset of 20 minutes between recordings, we expect the second
+    # recording's events are pooled into the same bucket as the first
+    # recording's events (compared to the hour bucket size context where they
+    # are in separate buckets).
+    let(:period) { 1.day + 20.minutes }
+    let(:result_buckets) do
+      {
+        25_200 => array_including(a_hash_including(tag_id: tags[0].id, events: 3), a_hash_including(tag_id: tags[1].id, events: 1)), #nolint
+        27_000 => [],
+        28_800 => final_bucket_array
+      }
+    end
+
+    it 'returns the correct buckets and tag frequency arrays' do
+      post '/reports/tag_diel_activity', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match(expected_data)
+    end
+  end
+
+  context 'with bucket size of minute' do
+    let(:body) { { options: { bucket_size: 'minute' }, filter: {} } }
+    let(:interval) { { bucket_size: Api::Reporting::TagDielActivity::INTERVALS['minute'], buckets: 1440 } }
+
+    # with no shift in minutes/hours we expect to see all events end up in the same minute bucket
+    let(:period) { 1.day }
+    let(:result_buckets) do
+      {
+        25_620 => array_including(
+          a_hash_including(tag_id: tags[0].id, events: 3),
+          a_hash_including(tag_id: tags[1].id, events: 1),
+          a_hash_including(tag_id: tags[2].id, events: 2)
+        )
+      }
+    end
+
+    it 'returns the correct buckets and tag frequency arrays' do
+      post '/reports/tag_diel_activity', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match(expected_data)
+    end
+  end
+end

--- a/spec/requests/reports/tag_frequency_spec.rb
+++ b/spec/requests/reports/tag_frequency_spec.rb
@@ -72,7 +72,8 @@ describe 'reports/tag_frequency' do
       }
 
       let(:final_bucket_array) {
-        [a_hash_including(tag_id: tags[2].id, events: 2), a_hash_including(tag_id: new_tagging.tag.id, events: 1)]
+        array_including(a_hash_including(tag_id: tags[2].id, events: 2),
+          a_hash_including(tag_id: new_tagging.tag.id, events: 1))
       }
 
       it 'counts unique tags correctly' do

--- a/spec/routing/reports_routing_spec.rb
+++ b/spec/routing/reports_routing_spec.rb
@@ -13,5 +13,11 @@ RSpec.describe ReportsController, type: :routing do
         route_to('reports#tag_frequency', format: 'json')
       )
     }
+
+    it {
+      expect(post('/reports/tag_diel_activity')).to(
+        route_to('reports#tag_diel_activity', format: 'json')
+      )
+    }
   end
 end


### PR DESCRIPTION
# feat: add reports/tag_diel_activity endpoint

Add a new `/reports/tag_diel_activity` endpoint that calculates tag frequencies
aggregated by time-of-day using a fixed 24-hour axis (00:00–24:00) and a
configurable bucket size: :minute, :half-hour, or :hour. Can power plots such as
radial histograms.

# Changes

- Add `tag_diel_activity` route and action to the `ReportsController`
- Add `Api::Reporting::TagDielActivity` - report query template that produces frequency of tags per time bucket
- Add request specs for tag_diel_activity 
- Update report permission spec with custom action for tag_diel_activity 

TODO In progress: add api specs

## Problems

No problems identified.

## Visual Changes

No visual changes.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing
