### PR TITLE
feat: add reports/event_summaries endpoint

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,8 +1,44 @@
 # frozen_string_literal: true
 
+# Provides reporting endpoints for audio event analysis
 class ReportsController < ApplicationController
   include Api::ControllerHelper
   include Api::Reporting
+  include ResultFormatters
+
+  # POST /reports/event_summaries
+  # Returns a structured report of event summaries per tag and provenance groupings.
+  # Accepts a filter object where:
+  #  the `filter` is applied to audio events
+  #  the `paging`, `sort` and `projection` options are invalid
+  def event_summaries
+    do_authorize_class(:filter, AudioEvent)
+
+    base_query = Access::ByPermissionTable.audio_events(current_user, level: Access::Permission::READER)
+
+    event_summaries_template = EventSummaries.new
+
+    projections = {
+      summary: event_summaries_template.event_summary
+    }
+
+    results, opts = execute_report(
+      base_query:,
+      template: event_summaries_template,
+      projections:
+    )
+
+    score_keys = [:score_mean, :score_stddev, :score_minimum, :score_maximum, :score_histogram]
+
+    results.map do |row|
+      row => { summary:, **rest }
+
+      histogram = extract_histogram(summary, histogram_key: :score_histogram)
+      rest.merge(ensure_columns(score_keys, histogram))
+    end => results
+
+    respond_report(results, opts)
+  end
 
   # POST /reports/tag_diel_activity
   # Returns a structured report of tag frequencies over diel time buckets.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -47,7 +47,7 @@ class ApplicationRecord < ActiveRecord::Base
       # in rows of untyped results and column types turns them into model objects.
       columns = result.columns.map(&:to_sym)
       result.cast_values.map do |row|
-        columns.zip(row).to_h
+        columns.zip(Array(row)).to_h
       end
     end
   end

--- a/app/modules/api/reporting.rb
+++ b/app/modules/api/reporting.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Api
+  # Utilities for building, executing and rendering report queries within controllers.
   module Reporting
     # Applies request filters to base_query, passes the filtered relation
     # through a report template, then applies projections to the resulting
@@ -34,6 +35,7 @@ module Api
       query.project(*projections.map { |name, expression| expression.as(name.to_s) })
 
       results = AudioEvent.exec_query_casted(query)
+
       [results, opts]
     end
 

--- a/app/modules/api/reporting/event_summaries.rb
+++ b/app/modules/api/reporting/event_summaries.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Report template with the required CTEs and joins to produce a report of
+    # event summaries per groupings (tag, provenance). Includes event score
+    # summary statistics, and a score histogram with event counts per bucket,
+    # calculated as the relative position of the score between the histogram's
+    # minimum and maximum score.
+    #
+    # Implements #call(query) for use as a template in execute_report.
+    class EventSummaries
+      include CteHelper
+
+      EVENTS = Arel::Table.new(:filtered_events)
+      STATS = Arel::Table.new(:stats)
+      BIN_EVENTS = Arel::Table.new(:bin_events)
+      BIN_COUNTS = Arel::Table.new(:bin_counts)
+      BIN_SERIES = Arel::Table.new(:bin_series)
+      COUNTS_SERIES = Arel::Table.new(:counts_series)
+
+      NUMBER_OF_BINS = 50
+      UNDERFLOW_BIN_INDEX = -1
+
+      BUCKET_INDEX = :bucket_index
+      HISTOGRAM_MINIMUM = :histogram_minimum
+      HISTOGRAM_MAXIMUM = :histogram_maximum
+
+      # @param query [ActiveRecord::Relation] base query
+      # @return [Arel::SelectManager]
+      def call(query)
+        query = query.joins(joins).left_outer_joins(:provenance)
+
+        STATS
+          .project(
+            STATS[:tag_id],
+            STATS[:provenance_id],
+            STATS[:events]
+          )
+          .with(*ctes(query:))
+          .join(COUNTS_SERIES, Arel::Nodes::OuterJoin)
+          .on(group_join_condition(STATS, COUNTS_SERIES))
+      end
+
+      # Primary projection for an event summaries report
+      #
+      # Projects a json sub-object called `summary` containing score summary
+      # statistics fields and histogram fields. In the case where a summary
+      # shouldn't be shown (null provenance or all null scores), summary is set
+      # to null. Necessary because of edge cases where a field has a value but
+      # shouldn't be shown (e.g. a mean score when provenance is null). The
+      # nested structure allows to conditionally show/hide the set of
+      # conditional fields based on one conditional gate, instead of gating each
+      # individual field, with no difference in query execution time.
+      def event_summary
+        Arel::Nodes::Case.new.when(summary_available).then(summary_json)
+      end
+
+      private
+
+      def joins = { taggings: [:tag] }
+
+      def ctes(query:)
+        [
+          cte(EVENTS, events_cte(query)),
+          cte(STATS, stats_cte),
+          cte(BIN_EVENTS, bin_events_cte),
+          cte(BIN_COUNTS, bin_counts_cte),
+          cte(BIN_SERIES, bin_series_cte),
+          cte(COUNTS_SERIES, counts_series_cte)
+        ]
+      end
+
+      def events_cte(query)
+        query
+          .except(:select, :order, :limit, :offset)
+          .reselect(
+            Tagging.arel_table[:tag_id].as('tag_id'),
+            AudioEvent.arel_table[:provenance_id].as('provenance_id'),
+            AudioEvent.arel_table[:score].as('score'),
+            Provenance.arel_table[:score_minimum].as('prov_score_min'),
+            Provenance.arel_table[:score_maximum].as('prov_score_max')
+          ).arel
+      end
+
+      def stats_cte
+        EVENTS
+          .project(
+            EVENTS[:tag_id],
+            EVENTS[:provenance_id],
+            Arel.star.count.as('events'),
+            EVENTS[:score].minimum.as('score_minimum'),
+            EVENTS[:score].maximum.as('score_maximum'),
+            EVENTS[:score].average.as('score_mean'),
+            EVENTS[:score].std.as('score_stddev'),
+            *histogram_bounds_from_events
+          ).group(
+            *group_columns(EVENTS),
+            EVENTS[:prov_score_min],
+            EVENTS[:prov_score_max]
+          )
+      end
+
+      # Assign event scores a bucket index
+      def bin_events_cte
+        EVENTS
+          .project(
+            EVENTS[:tag_id],
+            EVENTS[:provenance_id],
+            score_bucket_index.as(BUCKET_INDEX.to_s)
+          )
+          .join(STATS, Arel::Nodes::OuterJoin)
+          .on(group_join_condition(EVENTS, STATS))
+      end
+
+      # Count the number of events in each bucket per group
+      def bin_counts_cte
+        BIN_EVENTS
+          .project(
+            Arel.star,
+            BIN_EVENTS[BUCKET_INDEX].count
+          )
+          .group(*group_columns(BIN_EVENTS), BIN_EVENTS[BUCKET_INDEX])
+      end
+
+      # Generate NUMBER_OF_BINS + 2 indices for groups that can have a summary:
+      # -1 (underflow), 0..NUMBER_OF_BINS-1 (in-range), NUMBER_OF_BINS (overflow)
+      def bin_series_cte
+        STATS
+          .project(
+            STATS[:tag_id],
+            STATS[:provenance_id],
+            Arel.generate_series(-1, NUMBER_OF_BINS, 1).as(BUCKET_INDEX.to_s)
+          )
+          .where(summary_available)
+      end
+
+      # Join the bin counts with the full series of bins to get a count for every bucket
+      def counts_series_cte
+        coalesce_count = Arel.coalesce(BIN_COUNTS[:count], 0)
+        bucket_index_ascending = BIN_SERIES[BUCKET_INDEX].asc
+
+        # jsonb_agg supports ORDER BY inline to guarantee element order in the output array
+        scores_binned = Arel.sql(
+          <<~SQL.squish
+            jsonb_agg(
+               #{coalesce_count.to_sql}
+                ORDER BY #{bucket_index_ascending.to_sql}
+             ) AS "scores_binned"
+          SQL
+        )
+
+        BIN_SERIES
+          .project(
+            BIN_SERIES[:tag_id],
+            BIN_SERIES[:provenance_id],
+            scores_binned
+          )
+          .join(BIN_COUNTS, Arel::Nodes::OuterJoin)
+          .on(group_join_condition(BIN_SERIES, BIN_COUNTS)
+                .and(BIN_SERIES[BUCKET_INDEX].eq(BIN_COUNTS[BUCKET_INDEX])))
+          .group(*group_columns(BIN_SERIES))
+          .order(*group_columns(BIN_SERIES))
+      end
+
+      def group_columns(table) = [table[:tag_id], table[:provenance_id]]
+
+      def group_join_condition(left, right)
+        left[:tag_id].eq(right[:tag_id]).and(left[:provenance_id].eq(right[:provenance_id]))
+      end
+
+      # To scale the histogram, use the provenance's indicative minimum and
+      # maximum if set, else fall back to the group's actual minimum and maximum score.
+      def histogram_bounds_from_events
+        [
+          Arel.coalesce(EVENTS[:prov_score_min], EVENTS[:score].minimum).as(HISTOGRAM_MINIMUM.to_s),
+          Arel.coalesce(EVENTS[:prov_score_max], EVENTS[:score].maximum).as(HISTOGRAM_MAXIMUM.to_s)
+        ]
+      end
+
+      # Assigns each event score to one of NUMBER_OF_BINS buckets (with an inclusive
+      # upper bound on the final bucket), or an underflow / overflow bucket.
+      #
+      # NOTE: Tried using BETWEEN + LEAST, but when all scores are equal (e.g. all 0.5)
+      # the bucket formula divides by (max - min) = 0. Keeping score == maximum as its own
+      # branch avoids the division-by-zero error.
+      def score_bucket_index
+        Arel::Nodes::Case.new
+          .when(score_gteq_histogram_min.and(score_lt_histogram_max)).then(calculate_bucket_index)
+          .when(score_eq_histogram_max).then(NUMBER_OF_BINS - 1)
+          .when(score_lt_histogram_min).then(UNDERFLOW_BIN_INDEX)
+          .when(score_gt_histogram_max).then(NUMBER_OF_BINS)
+          .else(Arel.null)
+      end
+
+      def score_gteq_histogram_min = EVENTS[:score].gteq(STATS[HISTOGRAM_MINIMUM])
+      def score_lt_histogram_max = EVENTS[:score].lt(STATS[HISTOGRAM_MAXIMUM])
+      def score_eq_histogram_max = EVENTS[:score].eq(STATS[HISTOGRAM_MAXIMUM])
+      def score_lt_histogram_min = EVENTS[:score].lt(STATS[HISTOGRAM_MINIMUM])
+      def score_gt_histogram_max = EVENTS[:score].gt(STATS[HISTOGRAM_MAXIMUM])
+
+      # Calculate the bucket index as the relative position of the score between
+      # the histogram minimum and maximum, multiplied by the number of bins.
+      def calculate_bucket_index
+        # ! TODO: Division/Multiplcation when arel-extensions is removed. See https://github.com/QutEcoacoustics/baw-server/issues/966
+        ratio = Arel::Nodes::Division.new(
+          subtract_histogram_minimum(from: EVENTS[:score]),
+          subtract_histogram_minimum(from: STATS[HISTOGRAM_MAXIMUM])
+        )
+
+        Arel::Nodes::Multiplication.new(ratio, NUMBER_OF_BINS).floor.cast('int')
+      end
+
+      # Translating the score range to start at 0 is necessary to handle negative scores
+      def subtract_histogram_minimum(from:)
+        # ! TODO: remove Subtraction.new when arel-extensions is removed. See https://github.com/QutEcoacoustics/baw-server/issues/966
+        Arel.grouping(Arel::Nodes::Subtraction.new(from, STATS[HISTOGRAM_MINIMUM]))
+      end
+
+      # Skip summary and histogram if no provenance or all scores are null
+      # (score_minimum guards against zero-filled arrays from null-only groups)
+      def summary_available
+        STATS[:provenance_id].is_not_null.and(STATS[:score_minimum].is_not_null)
+      end
+
+      def summary_json
+        Arel.json(
+          **score_summary_statistics,
+          **score_histogram
+        )
+      end
+
+      def score_summary_statistics
+        {
+          score_minimum: STATS[:score_minimum],
+          score_maximum: STATS[:score_maximum],
+          score_mean: STATS[:score_mean],
+          score_stddev: STATS[:score_stddev]
+        }
+      end
+
+      def score_histogram
+        {
+          HISTOGRAM_MINIMUM => STATS[HISTOGRAM_MINIMUM],
+          HISTOGRAM_MAXIMUM => STATS[HISTOGRAM_MAXIMUM],
+          :histogram_bins => Arel.coalesce(COUNTS_SERIES[:scores_binned], Arel.sql("'[]'"))
+        }
+      end
+    end
+  end
+end

--- a/app/modules/api/reporting/result_formatters.rb
+++ b/app/modules/api/reporting/result_formatters.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Mixin providing helpers for formatting report results
+    module ResultFormatters
+      # Ensure the resulting hash contains only `keys`, sourced from `row`.
+      #
+      # Missing keys are initialized to `nil`.
+      #
+      # @param keys [Array<Symbol | String>]
+      # @param row [Hash]
+      # @return [Hash]
+      def ensure_columns(keys, row)
+        keys.index_with { |key| row.fetch(key, nil) }
+      end
+
+      # Extract histogram data from `summary` and format it under the specified key; set key to nil if histogram data absent.
+      # @param summary [Hash]
+      # @param histogram_key [Symbol | String]
+      # @return [Hash]
+      def extract_histogram(summary, histogram_key:)
+        summary = summary ? summary.symbolize_keys : {}
+
+        other_keys = summary.except(:histogram_bins, :histogram_minimum, :histogram_maximum)
+        other_keys[histogram_key] =
+          if summary[:histogram_bins]
+            {
+              bins: summary[:histogram_bins][1...-1],
+              maximum: summary[:histogram_maximum],
+              minimum: summary[:histogram_minimum],
+              underflow: summary[:histogram_bins].first,
+              overflow: summary[:histogram_bins].last
+            }
+          else
+            nil
+          end
+
+        other_keys
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -863,6 +863,7 @@ Rails.application.routes.draw do
   post 'reports/tag_accumulation(.:format)', to: 'reports#tag_accumulation', defaults: { format: 'json' }
   post 'reports/tag_frequency(.:format)', to: 'reports#tag_frequency', defaults: { format: 'json' }
   post 'reports/tag_diel_activity(.:format)', to: 'reports#tag_diel_activity', defaults: { format: 'json' }
+  post 'reports/event_summaries(.:format)', to: 'reports#event_summaries', defaults: { format: 'json' }
 
   # route to the home page of site
   root to: 'public#index'

--- a/spec/api/reports/event_summaries_spec.rb
+++ b/spec/api/reports/event_summaries_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'reports', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+
+  let(:skip_automatic_description) { true }
+
+  before do
+    provenance = create(:provenance, creator: writer_user)
+
+    create(
+      :audio_event_using_tag,
+      audio_recording:,
+      creator: writer_user,
+      tag:,
+      score: 1,
+      provenance:
+    )
+  end
+
+  def self.response_body_schema
+    Api::Schema.standard_array_response(
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          tag_id: Api::Schema.id,
+          provenance_id: Api::Schema.id(nullable: true),
+          events: {
+            type: 'integer',
+            description: 'The number of events in the tag and provenance grouping'
+          },
+          score_mean: {
+            type: ['number', 'null'],
+            description: 'Mean score, null when summary statistics are unavailable'
+          },
+          score_stddev: {
+            type: ['number', 'null'],
+            description: 'Sample standard deviation of scores, null when summary statistics are unavailable'
+          },
+          score_minimum: {
+            type: ['number', 'null'],
+            description: 'Minimum score, null when summary statistics are unavailable'
+          },
+          score_maximum: {
+            type: ['number', 'null'],
+            description: 'Maximum score, null when summary statistics are unavailable'
+          },
+          score_histogram: {
+            type: ['object', 'null'],
+            additionalProperties: false,
+            properties: {
+              bins: {
+                type: 'array',
+                items: { type: 'integer' },
+                description: 'A 50-bin histogram of in-range event scores for the grouping'
+              },
+              maximum: {
+                type: 'number',
+                description: 'The maximum score included in the histogram bins (inclusive). ' \
+                             'The provenance maximum is used if set; otherwise, the maximum score in the group is used.'
+              },
+              minimum: {
+                type: 'number',
+                description: 'The minimum score included in the histogram bins (inclusive). ' \
+                             'The provenance minimum is used if set; otherwise, the minimum score in the group is used.'
+              },
+              underflow: {
+                type: 'integer',
+                description: 'The count of events with scores below the histogram minimum'
+              },
+              overflow: {
+                type: 'integer',
+                description: 'The count of events with scores above the histogram maximum'
+              }
+            },
+            required: [:bins, :maximum, :minimum, :underflow, :overflow],
+            description: 'Score histogram, null when summary statistics are unavailable'
+          },
+          readOnly: true
+        },
+        required: [:tag_id, :provenance_id, :events]
+      }
+    )
+  end
+
+  def self.request_body_schema
+    Api::Schema.filter_payload(filter: true, sorting: false, paging: false, projection: false)
+  end
+
+  path '/reports/event_summaries' do
+    post 'Gets event summary statistics per tag and provenance grouping' do
+      tags 'reports'
+      consumes 'application/json'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns event summary statistics grouped by tag and provenance.
+        The optional `filter` parameter is applied to audio events.
+        Results only include audio events the user has reader access to.
+      DESCRIPTION
+
+      parameter name: :request_body, in: :body, required: true,
+        schema: request_body_schema
+
+      response '200', 'event summaries report retrieved' do
+        schema(**response_body_schema)
+
+        let(:request_body) { { filter: {} } }
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '200', 'filters audio events by tag' do
+        let(:request_body) do
+          {
+
+            filter: { 'tags.id': { eq: tag.id } }
+          }
+        end
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '422', 'rejects paging parameters' do
+        let(:request_body) { { paging: { items: 10 } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects sort parameters' do
+        let(:request_body) { { sort: { order_by: 'id' } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects projection parameters' do
+        let(:request_body) { { projection: { only: [:id] } } }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/permissions/reports_spec.rb
+++ b/spec/permissions/reports_spec.rb
@@ -55,21 +55,40 @@ describe 'Reports permissions' do
       end
     })
 
+  with_custom_action(:event_summaries, path: 'event_summaries', verb: :post,
+    body: -> { { options: {}, filter: {} } },
+    expect: lambda { |user, _action|
+      if user == :no_access
+        expect(api_result[:data].length).to eq(0)
+      else
+        expect(api_data).to match([
+          { tag_id: tag.id,
+            provenance_id: nil,
+            events: 1,
+            score_mean: nil,
+            score_stddev: nil,
+            score_minimum: nil,
+            score_maximum: nil,
+            score_histogram: nil }
+        ])
+      end
+    })
+
   # Any authenticated user with at least reader access can use the reports/tag_* endpoints
   ensures :admin, :owner, :writer, :reader,
-    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
+    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
     cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: :not_found
 
   # Users without project access can call these endpoints, but receive no visible tag results
   ensures :no_access,
-    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
+    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
     cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: :not_found
 
   # Harvester cannot access the endpoint
   ensures :harvester,
-    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
+    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
     fails_with: :forbidden
 
   ensures :harvester,
@@ -78,7 +97,7 @@ describe 'Reports permissions' do
 
   # Anonymous users cannot access the endpoint
   ensures :anonymous,
-    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity],
+    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
     fails_with: :unauthorized
 
   ensures :anonymous,
@@ -87,7 +106,7 @@ describe 'Reports permissions' do
 
   # Invalid tokens cannot access the endpoint
   ensures :invalid,
-    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :index, :show, :create, :update, :destroy, :new,
+    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries, :index, :show, :create, :update, :destroy, :new,
              :filter],
     fails_with: [:unauthorized, :not_found]
 end

--- a/spec/requests/reports/event_summaries_spec.rb
+++ b/spec/requests/reports/event_summaries_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+describe 'reports/event_summaries' do
+  create_audio_recordings_hierarchy
+
+  let(:tags) { create_list(:tag, 4, creator: writer_user) }
+  let(:provenances) {
+    [create(:provenance, creator: writer_user, score_minimum: 0, score_maximum: 1),
+     create(:provenance, creator: writer_user, score_minimum: nil, score_maximum: nil)]
+  }
+
+  # Each object in represents a set of events for a specific tag/provenance group
+  let!(:records) {
+    [
+      # expect 1 count in underflow and overflow; expect inclusive upper final bin works
+      { tag_ids: [0, 0, 0, 0, 0, 0],
+        scores: [-1, 0, 0.5, 0.51, 1, 2],
+        provenances: [0, 0, 0, 0, 0, 0] },
+
+      # when all scores are nil for a group (t, p): scores_binned: [], summary statistics: nil
+      { tag_ids: [1, 1],
+        scores: [nil, nil],
+        provenances: [0, 0] },
+
+      # when provenance has no min/max, a min/max is calculated from the scores in the group (t, p)
+      { tag_ids: [2, 2, 2, 2, 2],
+        scores: [-0.4, -0.1, 0, 0.2, 0.3],
+        provenances: [1, 1, 1, 1, 1] },
+
+      # when all scores in group are equal and provenance has no min/max set, expect all scores in last bin
+      { tag_ids: [3, 3, 3],
+        scores: [0.5, 0.5, 0.5],
+        provenances: [1, 1, 1] },
+
+      # when provenance is nil, (t, p): scores_binned: [], summary statistics: nil
+      { tag_ids: [0, 0],
+        scores: [0.1, 0.2],
+        provenances: [nil, nil] }
+    ]
+  }
+
+  let(:nil_result) do
+    {
+      score_mean: nil,
+      score_stddev: nil,
+      score_minimum: nil,
+      score_maximum: nil,
+      score_histogram: nil
+    }
+  end
+
+  let(:expected_data) do
+    [
+      {
+        tag_id: tags[0].id,
+        provenance_id: provenances[0].id,
+        events: 6,
+        score_mean: 0.5016666666666667,
+        score_stddev: 1.0000083332986114,
+        score_minimum: -1.0,
+        score_maximum: 2.0,
+        score_histogram:
+       {
+         bins: sparse_bins(0 => 1, 25 => 2, 49 => 1),
+         maximum: 1.0,
+         minimum: 0.0,
+         underflow: 1,
+         overflow: 1
+       }
+      },
+      { tag_id: tags[0].id, provenance_id: nil, events: 2, **nil_result },
+      { tag_id: tags[1].id, provenance_id: provenances[0].id, events: 2, **nil_result },
+      {
+        tag_id: tags[2].id,
+        provenance_id: provenances[1].id,
+        events: 5,
+        score_mean: 0.0,
+        score_stddev: 0.27386127875258304,
+        score_minimum: -0.4,
+        score_maximum: 0.3,
+        score_histogram:
+        {
+          bins: sparse_bins(0 => 1, 21 => 1, 28 => 1, 42 => 1, 49 => 1),
+          maximum: 0.3,
+          minimum: -0.4,
+          underflow: 0,
+          overflow: 0
+        }
+      },
+      {
+        tag_id: tags[3].id,
+        provenance_id: provenances[1].id,
+        events: 3,
+        score_mean: 0.5,
+        score_stddev: 0,
+        score_minimum: 0.5,
+        score_maximum: 0.5,
+        score_histogram:
+        {
+          bins: sparse_bins(49 => 3),
+          maximum: 0.5,
+          minimum: 0.5,
+          underflow: 0,
+          overflow: 0
+        }
+      }
+    ]
+  end
+
+  before do
+    records.each do |rec|
+      recording = create(:audio_recording, site: site, creator: writer_user)
+
+      rec[:tag_ids]&.zip(rec[:scores], rec[:provenances])&.each do |tag_index, score, provenance_index|
+        create(
+          :audio_event_using_tag,
+          audio_recording: recording,
+          creator: writer_user,
+          tag: tags[tag_index],
+          score: score,
+          provenance: provenance_index ? provenances[provenance_index] : nil
+        )
+      end
+    end
+
+    # create an audio_event that writer_user has no access to, to prove it is not included in the counts
+    create(:audio_event_with_tags)
+  end
+
+  it 'returns the correct summary data' do
+    post '/reports/event_summaries', params: { filter: {} }, **api_headers(writer_token)
+    expect_success
+
+    expect(api_data).to match(array_including(expected_data))
+  end
+
+  context 'with filter by tag' do
+    it 'returns the correct summary data, excluding the filtered tag id' do
+      body = { filter: { 'tags.id': { not_eq: tags[3].id } } }
+
+      post '/reports/event_summaries', params: body, **api_headers(writer_token)
+      expect_success
+
+      expect(api_data).to match(array_including(expected_data[0..3]))
+    end
+  end
+
+  # Build a 50-element bins array from a sparse {index => count} hash
+  def sparse_bins(index_values)
+    Array.new(50, 0).tap { |bins| index_values.each { |index, count| bins[index] = count } }
+  end
+end

--- a/spec/routing/reports_routing_spec.rb
+++ b/spec/routing/reports_routing_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe ReportsController, type: :routing do
         route_to('reports#tag_diel_activity', format: 'json')
       )
     }
+
+    it {
+      expect(post('/reports/event_summaries')).to(
+        route_to('reports#event_summaries', format: 'json')
+      )
+    }
   end
 end


### PR DESCRIPTION
# feat: add reports/event_summaries endpoint

Add a new `POST /reports/event_summaries` endpoint that returns a structured
report of audio event summaries grouped by tag and provenance. Each group
includes score summary statistics (mean, stddev, min, max), a 50-bin score
histogram, plus underflow/overflow counts. Can power visualisations such as score
histogram plots per grouping.

# Changes

- Add `event_summaries` route and action to `ReportsController`
- Add `Api::Reporting::EventSummaries` - report query template that produces event counts, score statistics, and a score histogram per tag/provenance grouping using a series of CTEs
- Add `Api::Reporting::ResultFormatters` - mixin providing `format_score_histogram`, a result-row transformer that reshapes the summary JSON from the query into a structured `score_histogram` key alongside top-level score stats
- Add `execute_report` block argument support in `Api::Reporting` so result rows can be mapped through a formatter
- Add API specs and request specs for `event_summaries`
- Update report permissions spec with custom action for `event_summaries`
- Update routing spec for `event_summaries`

## Problems

No problems identified.

## Visual Changes

No visual changes.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [x] Ensure CI build is passing