### PR TITLE
feat: add reports/recording_coverage, reports/analysis_coverage endpoints; upgrade db image to postgres:18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We're working on that.
 
 ## Development requirements
 
-Docker and docker-compose are required to run this application.
+Docker and docker compose are required to run this application.
 
 ### Windows
 
@@ -53,7 +53,7 @@ Install docker as normal.
 
 Clone this repo, then change directory to your cloned directory and on your **host** machine run
 
-	$ docker-compose up
+	$ docker compose up
 
 This will prepare a complete development environment. To see what is involved in
 the setup, look at the  [`Dockerfile`](./Dockerfile) and [`bin/setup`](bin/setup) files.
@@ -79,12 +79,15 @@ the following.
 
 To start from scratch by **removing all containers, images, and volumes**:
 
-    $ docker-compose down --remove-orphans --volumes --rmi local
+    $ docker compose down --remove-orphans --volumes --rmi local
+
+Removing existing volumes in particular may be required when changing the
+Postgres image major version.
 
 To rebuild the `web` service / `baw-server` image (e.g. to update dependencies)
 but keep state from our volume:
 
-    $ docker-compose build
+    $ docker compose build
 
 
 ## IDE
@@ -102,7 +105,7 @@ start the web server. See the command below.
 
 Otherwise, Start by running, on your **host** machine:
 
-    $ docker-compose up
+    $ docker compose up
 
 
 ### Web server
@@ -223,7 +226,7 @@ Create staging settings file `config/settings/staging.yml` based on `config/sett
 We deploy using Ansible.
 
 If you want to use background workers, you'll need to set up [Redis](http://redis.io/).
-A basic redis setup is included with the docker-compose file.
+A basic redis setup is included with the docker compose file.
 
 ## Creating a release
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,6 +6,60 @@ class ReportsController < ApplicationController
   include Api::Reporting
   include ResultFormatters
 
+  # POST /reports/recording_coverage
+  # Returns a structured report of recording coverage
+  # Accepts a filter object where:
+  #  the `filter` is applied to audio recordings
+  #  the `paging`, `sort` and `projection` options are invalid
+  def recording_coverage
+    do_authorize_class(:filter, AudioRecording)
+
+    base_query = Access::ByPermissionTable.audio_recordings(current_user, level: Access::Permission::READER)
+
+    partition_columns = [AudioRecording.arel_table[:site_id]]
+
+    recording_coverage_template = Coverage.new(partition_columns: partition_columns, options: coverage_report_options)
+
+    results, opts = execute_report(
+      base_query:,
+      model: AudioRecording,
+      template: recording_coverage_template,
+      projections: { density: Coverage.coverage_density }
+    )
+
+    respond_report(results, opts)
+  end
+
+  # POST /reports/analysis_coverage
+  # Returns a structured report of recording analysis coverage
+  # Accepts a filter object where:
+  #  the `filter` is applied to audio recordings
+  #  the `paging`, `sort` and `projection` options are invalid
+  def analysis_coverage
+    do_authorize_class(:filter, AudioRecording)
+
+    base_query = Access::ByPermissionTable.audio_recordings(current_user, level: Access::Permission::READER)
+
+    partition_columns = [AudioRecording.arel_table[:site_id], AnalysisJobsItem.arel_table[:result]]
+    joins = AudioRecording.arel_table
+      .join(AnalysisJobsItem.arel_table)
+      .on(AnalysisJobsItem.arel_table[:audio_recording_id].eq(AudioRecording.arel_table[:id])
+      .and(AnalysisJobsItem.arel_table[:result].is_not_null))
+      .join_sources
+
+    analysis_coverage_template = Coverage.new(partition_columns: partition_columns, joins: joins,
+      options: coverage_report_options)
+
+    results, opts = execute_report(
+      base_query:,
+      model: AudioRecording,
+      template: analysis_coverage_template,
+      projections: { density: Coverage.coverage_density }
+    )
+
+    respond_report(results, opts)
+  end
+
   # POST /reports/event_summaries
   # Returns a structured report of event summaries per tag and provenance groupings.
   # Accepts a filter object where:
@@ -24,6 +78,7 @@ class ReportsController < ApplicationController
 
     results, opts = execute_report(
       base_query:,
+      model: AudioEvent,
       template: event_summaries_template,
       projections:
     )
@@ -58,6 +113,7 @@ class ReportsController < ApplicationController
 
     results, opts = execute_report(
       base_query:,
+      model: AudioEvent,
       template: TagDielActivity.new(report_options),
       projections:
     )
@@ -83,6 +139,7 @@ class ReportsController < ApplicationController
 
     results, opts = execute_report(
       base_query:,
+      model: AudioEvent,
       template: TagFrequency.new(report_options),
       projections:
     )
@@ -109,6 +166,7 @@ class ReportsController < ApplicationController
 
     results, opts = execute_report(
       base_query:,
+      model: AudioEvent,
       template: TagAccumulation.new(report_options),
       projections:
     )
@@ -117,6 +175,12 @@ class ReportsController < ApplicationController
   end
 
   private
+
+  def coverage_report_options
+    options = api_options_params
+    options.require(:bucket_count)
+    options.permit(:bucket_count).to_h
+  end
 
   # @return [Hash]
   def report_options

--- a/app/modules/access/by_permission_table.rb
+++ b/app/modules/access/by_permission_table.rb
@@ -41,8 +41,6 @@ module Access
     # Returns a query for audio events the user has at least the given level of permission for.
     # Audio events are accessible if the user has permission on the project that contains the
     # audio recording's site, OR if the audio event is a reference event.
-    # ! currently not used (I thought it was needed for another task but it wasn't)
-    # ! but it's a good implementation and is tested so keeping it for now.
     # @param user [User]
     # @param level [Symbol] the minimum permission level (see Permission levels)
     # @param levels [Array<Symbol>] alternative to level, an array of specific permission levels (see Permission levels)
@@ -58,6 +56,20 @@ module Access
 
         predicate.or(reference_predicate)
       }
+    end
+
+    # Returns a query for audio recordings the user has at least the given level of permission for.
+    # Audio recordings are accessible if the user has permission on the project that contains the
+    # audio recording's site.
+    # @param user [User]
+    # @param level [Symbol] the minimum permission level (see Permission levels)
+    # @param levels [Array<Symbol>] alternative to level, an array of specific permission levels (see Permission levels)
+    # @param project_ids [Array<Integer>] optional list of project IDs to reduce the scale of permissions joined
+    # @return [ActiveRecord::Relation<AudioRecording>] the approved audio recordings
+    def audio_recordings(user, level: nil, levels: nil, project_ids: nil)
+      query = AudioRecording.joins(site: :projects)
+
+      apply(user, query, level:, levels:, project_ids:)
     end
 
     def apply(user, query, level:, levels: nil, project_ids: nil)

--- a/app/modules/api/reporting.rb
+++ b/app/modules/api/reporting.rb
@@ -14,14 +14,14 @@ module Api
     # @param projections [Hash{Symbol => Arel::Nodes::Node}] alias: expression
     #   pairs to project from template
     # @return [Array(Array<Hash>, Hash)] the query result and filter options
-    def execute_report(base_query:, template:, projections: {})
+    def execute_report(base_query:, model:, template:, projections: {})
       raise ArgumentError, 'template must respond to #call' unless template.respond_to?(:call)
 
       filter = Filter::Query.new(
         api_filter_params_filter_only!,
         base_query,
-        AudioEvent,
-        AudioEvent.filter_settings
+        model,
+        model.filter_settings
       )
 
       # Preserving the supplied filter to later return in the response
@@ -34,7 +34,7 @@ module Api
       query = template.call(query)
       query.project(*projections.map { |name, expression| expression.as(name.to_s) })
 
-      results = AudioEvent.exec_query_casted(query)
+      results = model.exec_query_casted(query)
 
       [results, opts]
     end

--- a/app/modules/api/reporting/bucketer.rb
+++ b/app/modules/api/reporting/bucketer.rb
@@ -73,8 +73,8 @@ module Api
         lower = series.right
         upper = Arel::Nodes::InfixOperation.new('+', lower, interval_arel)
 
-        # Without `.on` Arel generates INNER JOIN LATERAL (not CROSS JOIN LATERAL?)
-        # which causes a syntax error
+        # The SQL generated here is INNER JOIN LATERAL, not CROSS JOIN LATERAL,
+        # and it requires an ON true condition to achieve the same effect.
         BOUNDS
           .project(Arel.tsrange(lower, upper).as('bucket'))
           .join(Arel::Nodes::Lateral.new(series))

--- a/app/modules/api/reporting/coverage.rb
+++ b/app/modules/api/reporting/coverage.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Api
+  module Reporting
+    # Coverage periods are calculated as the contiguous ranges formed by a sequence
+    # of overlapping or neighbouring recordings (within a gap threshold), per
+    # customisable partitions (e.g. by site).
+    #
+    # Implements #call(query) for use as a template in execute_report.
+    class Coverage
+      include CteHelper
+
+      RECORDINGS = Arel::Table.new(:filtered_recordings)
+      ISLANDS    = Arel::Table.new(:islands)
+
+      RECORDING_RANGE = 'recording_range'
+
+      # @param partition_columns [Array<Arel::Attributes::Attribute>] columns to partition and group by
+      # @param joins [Array<Arel::Nodes::Join>] optional; any joins needed by `partition_columns`; applied to the base query
+      # @param options [Hash] configuration options
+      # @option options [Integer] :bucket_count required; divisor for gap threshold calculation
+      def initialize(partition_columns: [], joins: nil, options: {})
+        @partition_columns = partition_columns
+        @joins = joins
+        @bucket_count = validate_bucket_count!(options)
+      end
+
+      # @param table [Arel::Table]
+      # @return [Array<Arel::Attributes>] Return the partition columns as attributes for the given table
+      def partition_columns(table)
+        @partition_columns.map { |attribute| table[attribute.name] }
+      end
+
+      # @param query [ActiveRecord::Relation] base query
+      # @return [Arel::SelectManager]
+      def call(query)
+        ISLANDS
+          .project(
+            *partition_columns(ISLANDS),
+            Arel.tsrange(
+              ISLANDS[:recording_range].lower.minimum,
+              ISLANDS[:recording_range].upper.maximum
+            ).as('coverage'),
+            ISLANDS[:gap_threshold]
+          )
+          .group(
+            ISLANDS[:island_id],
+            ISLANDS[:gap_threshold],
+            *partition_columns(ISLANDS)
+          )
+          .order(*partition_columns(ISLANDS), ISLANDS[:recording_range].lower.minimum)
+          .with(*ctes(query:))
+      end
+
+      # Arel expression for coverage density; calculated as the ratio of actual covered seconds within a coverage span to the spans total duration
+      def self.coverage_density
+        # ! TODO: When arel-extensions is removed. See https://github.com/QutEcoacoustics/baw-server/issues/966
+        coverage_span = Arel::Nodes::Subtraction.new(
+          ISLANDS[:recording_range].upper.maximum,
+          ISLANDS[:recording_range].lower.minimum
+        ).extract('epoch')
+
+        # We calculate the actual covered seconds by using range_agg to union any overlapping tsranges within each island,
+        # and use our custom PostgreSQL function to get the total seconds covered by the resulting multirange.
+        Arel::Nodes::Division.new(
+          Arel.tsmultirange_total_seconds(ISLANDS[:recording_range].range_agg),
+          Arel::Nodes::NamedFunction.new('NULLIF', [coverage_span, Arel.sql('0')])
+        )
+      end
+
+      private
+
+      def ctes(query:)
+        [
+          cte(RECORDINGS, recordings_cte(query)),
+          cte(ISLANDS, islands_cte)
+        ]
+      end
+
+      def recordings_cte(query)
+        query = query.joins(@joins) if @joins
+        query
+          .except(:select, :order, :limit, :offset)
+          .reselect(
+            recording_range_arel.as('recording_range'),
+            *@partition_columns
+          ).arel
+      end
+
+      def recording_range_arel
+        Arel.tsrange(AudioRecording.arel_table[:recorded_date], AudioRecording.arel_recorded_end_date)
+      end
+
+      # Dynamically calculate a gap threshold as 1/bucket_count-th of the total span of all recordings in the query
+      # We don't want to render spans that are so short that they would occupy less than 1px on the screen.
+      # Thus, this option allows us to emit the least number of spans possible, that will actually be renderable.
+      def threshold_cte
+        # ! TODO: Division when arel-extensions is removed. See https://github.com/QutEcoacoustics/baw-server/issues/966
+        span = Arel::Nodes::Subtraction.new(
+          RECORDINGS[:recording_range].upper.maximum,
+          RECORDINGS[:recording_range].lower.minimum
+        )
+        RECORDINGS.project(Arel.seconds(Arel::Nodes::Division.new(span.extract('epoch'), @bucket_count)).as('val'))
+      end
+
+      def gap_threshold_table_alias = Arel::Nodes::TableAlias.new(threshold_cte, 'gap_threshold')
+
+      def islands_cte
+        window = Arel::Nodes::Window.new
+          .partition(*partition_columns(RECORDINGS))
+          .order(RECORDINGS[:recording_range].lower)
+
+        # Using a custom PostgreSQL aggregate function to assign numbers to distinct islands (groups separated by > gap_threshold)
+        # (see AddContiguousRangeNumberFunction migration)
+        island_id = Arel::Nodes::NamedFunction
+          .new('contiguous_range_number', [RECORDINGS[:recording_range], gap_threshold_table_alias[:val]])
+          .over(window)
+
+        RECORDINGS
+          .project(
+            RECORDINGS[:recording_range],
+            island_id.as('island_id'),
+            *partition_columns(RECORDINGS),
+            gap_threshold_table_alias[:val].as('gap_threshold')
+          )
+          .join(Arel::Nodes::Lateral.new(gap_threshold_table_alias))
+          .on(Arel.sql('true'))
+      end
+
+      def validate_bucket_count!(options)
+        bucket_count = options.fetch(:bucket_count)
+        unless bucket_count.is_a?(Integer) && bucket_count > 0
+          raise ArgumentError, "bucket_count must be a positive integer, got #{bucket_count.inspect}"
+        end
+
+        bucket_count
+      end
+    end
+  end
+end

--- a/app/modules/api/schema/helpers.rb
+++ b/app/modules/api/schema/helpers.rb
@@ -186,6 +186,70 @@ module Api
           required: [:bucket_size]
         }
       end
+
+      def coverage_report_options
+        {
+          type: 'object',
+          properties: {
+            bucket_count: {
+              type: 'integer',
+              description: 'The number of buckets to divide the total span of all recordings into for the purposes of calculating the gap threshold.',
+              minimum: 1
+            }
+          },
+          required: [:bucket_count]
+        }
+      end
+
+      def recording_coverage(include_result: false)
+        properties = {
+          site_id: id,
+          coverage: {
+            type: 'array',
+            items: { type: 'string', format: 'date-time' },
+            minItems: 2,
+            maxItems: 2,
+            additionalItems: false,
+            description: 'The inclusive start and exclusive end of the contiguous coverage span'
+          },
+          density: {
+            type: 'number',
+            description: 'The ratio of covered seconds to the total duration of the coverage span',
+            minimum: 0.0,
+            maximum: 1.0
+          },
+          gap_threshold: {
+            type: 'number',
+            description: 'The maximum number of seconds between neighbouring recordings before a new coverage span begins ' \
+                         'Calculated dynamically as 1/bucket_count of the total span of all recordings in the query'
+          }
+        }
+
+        if include_result
+          properties[:result] = {
+            type: 'string',
+            enum: AnalysisJobsItem::ALLOWED_RESULTS,
+            description: 'The analysis job item result type that the coverage was calculated for'
+          }
+        end
+
+        {
+          type: 'object',
+          additionalProperties: false,
+          properties: properties,
+          readOnly: true,
+          required: if include_result
+                      [:site_id, :result, :coverage, :density,
+                       :gap_threshold]
+                    else
+                      [:site_id, :coverage, :density, :gap_threshold]
+                    end
+        }
+      end
+
+      def coverage_report(include_result: false)
+        standard_array_response(recording_coverage(include_result: include_result))
+      end
     end
   end
 end

--- a/app/modules/baw/arel.rb
+++ b/app/modules/baw/arel.rb
@@ -50,6 +50,13 @@ module Baw
       ::Arel::Nodes::NamedFunction.new('tsrange', [lower, upper, ::Arel::Nodes.build_quoted(bounds)])
     end
 
+    # Custom PostgreSQL function to get the total sum of the seconds for each tsrange in the multirange
+    # (see AddTsmultirangeTotalSecondsFunction migration)
+    # @return [::Arel::Nodes::NamedFunction]
+    def tsmultirange_total_seconds(multirange)
+      ::Arel::Nodes::NamedFunction.new('tsmultirange_total_seconds', [multirange])
+    end
+
     module NodeExtensions
       # Treat this node as an array.
       # Has no effect other than to allow array-like methods to be called on this node.
@@ -70,6 +77,11 @@ module Baw
       # @return [Baw::Arel::Nodes::MakeInterval]
       def seconds
         Nodes::MakeInterval.new(seconds: self)
+      end
+
+      # Returns the upper bound of a range attribute; Arel already provides `lower`.
+      def upper
+        ::Arel::Nodes::NamedFunction.new('upper', [self])
       end
     end
 
@@ -99,6 +111,10 @@ module Baw
 
       def row_to_json
         Baw::Arel::Nodes::RowToJson.new([self])
+      end
+
+      def range_agg
+        Baw::Arel::Nodes::RangeAgg.new([self])
       end
     end
 

--- a/app/modules/baw/arel/nodes.rb
+++ b/app/modules/baw/arel/nodes.rb
@@ -86,8 +86,15 @@ module Baw
       end
 
       class ArrayAgg < ::Arel::Nodes::NamedFunction
+        attr_reader :order_expressions
+
         def initialize(expr)
           super('array_agg', expr)
+        end
+
+        def order(*exprs)
+          @order_expressions = exprs.flatten
+          self # chainable
         end
       end
 
@@ -106,6 +113,12 @@ module Baw
       class JsonAgg < ::Arel::Nodes::NamedFunction
         def initialize(expr)
           super('json_agg', expr)
+        end
+      end
+
+      class RangeAgg < ::Arel::Nodes::NamedFunction
+        def initialize(expr)
+          super('range_agg', expr)
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -864,6 +864,8 @@ Rails.application.routes.draw do
   post 'reports/tag_frequency(.:format)', to: 'reports#tag_frequency', defaults: { format: 'json' }
   post 'reports/tag_diel_activity(.:format)', to: 'reports#tag_diel_activity', defaults: { format: 'json' }
   post 'reports/event_summaries(.:format)', to: 'reports#event_summaries', defaults: { format: 'json' }
+  post 'reports/recording_coverage(.:format)', to: 'reports#recording_coverage', defaults: { format: 'json' }
+  post 'reports/analysis_coverage(.:format)', to: 'reports#analysis_coverage', defaults: { format: 'json' }
 
   # route to the home page of site
   root to: 'public#index'

--- a/db/migrate/20260507052638_add_contiguous_range_number_function.rb
+++ b/db/migrate/20260507052638_add_contiguous_range_number_function.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+# Adds the `contiguous_range_number` aggregate function to PostgreSQL.
+#
+# Objects created (in dependency order):
+#   1. Type      contiguous_range_state        – accumulator state
+#   2. Function  contiguous_range_transition   – aggregate step function
+#   3. Function  contiguous_range_final        – aggregate final function
+#   4. Aggregate contiguous_range_number       – the public aggregate
+class AddContiguousRangeNumberFunction < ActiveRecord::Migration[8.0]
+  def up
+    execute(
+      <<~SQL
+        -- 1. Accumulator state type
+        CREATE TYPE contiguous_range_state AS (
+            prev_range_upper timestamp,
+            sequence_number bigint,
+            threshold interval
+        );
+
+        COMMENT ON TYPE contiguous_range_state IS '
+        Accumulator state for contiguous_range_number.
+
+        Fields:
+          prev_range_upper - The greatest upper bound seen in the current contiguous block.
+          sequence_number  - Zero-based label for the current contiguous block.
+          threshold        - Maximum allowed gap before starting a new block.
+        ';
+
+        -- 2. Step function: advances the accumulator for each input range
+        CREATE OR REPLACE FUNCTION contiguous_range_transition (
+            state contiguous_range_state,
+            current_range tsrange,
+            threshold interval
+        )
+            RETURNS contiguous_range_state
+            LANGUAGE plpgsql
+            IMMUTABLE
+            AS $$
+        BEGIN
+            IF state IS NULL THEN
+                RETURN ROW (upper(current_range),
+                    0,
+                    threshold)::contiguous_range_state;
+
+            END IF;
+
+            IF lower(current_range) > state.prev_range_upper + state.threshold THEN
+                RETURN ROW (upper(current_range),
+                    state.sequence_number + 1,
+                    state.threshold)::contiguous_range_state;
+
+            ELSE
+                RETURN ROW (GREATEST (upper(current_range), state.prev_range_upper),
+                    state.sequence_number,
+                    state.threshold)::contiguous_range_state;
+
+            END IF;
+
+        END;
+
+        $$;
+
+        COMMENT ON FUNCTION contiguous_range_transition (contiguous_range_state, tsrange, interval) IS '
+        Aggregate transition function for contiguous_range_number.
+
+        Parameters:
+          state         - Current accumulator state, or NULL for the first row.
+          current_range - Current tsrange input value.
+          threshold     - Maximum allowed gap between adjacent ranges.
+
+        Returns:
+          Updated contiguous_range_state with incremented sequence_number when the
+          gap from the previous block exceeds threshold.
+        ';
+
+        -- 3. Final function: extracts the sequence number from the accumulator
+        CREATE OR REPLACE FUNCTION contiguous_range_final (
+            state contiguous_range_state
+        )
+            RETURNS bigint
+            LANGUAGE sql
+            IMMUTABLE
+            AS $$
+            SELECT
+                state.sequence_number;
+        $$;
+
+        COMMENT ON FUNCTION contiguous_range_final (contiguous_range_state) IS '
+        Aggregate final function for contiguous_range_number.
+
+        Parameters:
+          state - Final accumulator state after processing all rows.
+
+        Returns:
+          sequence_number from the final state.
+        ';
+
+        -- 4. Aggregate: groups tsranges into contiguous blocks by threshold
+        CREATE OR REPLACE AGGREGATE contiguous_range_number (tsrange, interval) (
+            SFUNC = contiguous_range_transition,
+            STYPE = contiguous_range_state,
+            FINALFUNC = contiguous_range_final
+        );
+
+        COMMENT ON AGGREGATE contiguous_range_number (tsrange, interval) IS '
+        This aggregate assigns a monotonically increasing sequence number to each
+        contiguous group of tsranges.
+
+        Two ranges are considered contiguous (part of the same group) when the gap
+        between them does not exceed a caller-supplied interval threshold.
+        Whenever a gap exceeds the threshold the sequence number is incremented,
+        effectively labelling each distinct contiguous block.
+
+        This aggregate should be used in conjunction with an ORDER BY clause to ensure
+        meaningful results.
+
+        Parameters:
+          tsrange  - Input range values, expected in ascending order
+          interval - Gap threshold that defines contiguity.
+
+        Returns:
+          bigint zero-based contiguous block number for each aggregate group.
+        ';
+      SQL
+    )
+  end
+
+  def down
+    execute(
+      <<~SQL
+        DROP AGGREGATE IF EXISTS contiguous_range_number (tsrange, interval);
+        DROP FUNCTION IF EXISTS contiguous_range_final (contiguous_range_state);
+        DROP FUNCTION IF EXISTS contiguous_range_transition (contiguous_range_state, tsrange, interval);
+        DROP TYPE IF EXISTS contiguous_range_state;
+      SQL
+    )
+  end
+end

--- a/db/migrate/20260507061809_add_tsmultirange_total_seconds_function.rb
+++ b/db/migrate/20260507061809_add_tsmultirange_total_seconds_function.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Adds a PostgreSQL function `tsmultirange_total_seconds`
+class AddTsmultirangeTotalSecondsFunction < ActiveRecord::Migration[8.0]
+  def up
+    execute(
+      <<~SQL
+        CREATE OR REPLACE FUNCTION tsmultirange_total_seconds (
+            multirange tsmultirange
+        )
+            RETURNS double precision
+            LANGUAGE sql
+            IMMUTABLE
+            PARALLEL SAFE
+            AS $$
+            SELECT
+                extract(epoch FROM sum(upper(time_range) - lower(time_range)))
+            FROM
+                unnest(multirange) AS time_range
+        $$;
+
+        COMMENT ON FUNCTION tsmultirange_total_seconds (tsmultirange) IS '
+        Given a `tsmultirange`, return the sum of each constituent `tsrange`''s duration in
+        seconds as a double precision value.
+
+        Example use case is to input the tsmultirange returned by ''range_agg'', to get
+        the total non-overlapping seconds covered by the tsmultirange. This is useful
+        because it saves having to handle unnesting the tsmultirange and simplifies the query.
+
+        Returns:
+          Total duration in seconds for a given tsmultirange.
+        ';
+      SQL
+    )
+  end
+
+  def down
+    execute('DROP FUNCTION IF EXISTS tsmultirange_total_seconds(tsmultirange)')
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,11 +1,7 @@
-\restrict jzUK2mhBd3HZ3j09bN1hc82RQAyK6Aj6F6hwglOJtjRJrVBroYysWpZs9blP6wm
-
--- Dumped from database version 14.22 (Debian 14.22-1.pgdg13+1)
--- Dumped by pg_dump version 14.22 (Debian 14.22-1.pgdg11+1)
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -114,6 +110,17 @@ CREATE TYPE public.consent AS ENUM (
 
 
 --
+-- Name: contiguous_range_state; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.contiguous_range_state AS (
+	prev_range_upper timestamp without time zone,
+	sequence_number bigint,
+	threshold interval
+);
+
+
+--
 -- Name: basename(text); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -137,6 +144,50 @@ BEGIN
 
   RETURN segments[length];
 END;
+$$;
+
+
+--
+-- Name: contiguous_range_final(public.contiguous_range_state); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.contiguous_range_final(state public.contiguous_range_state) RETURNS bigint
+    LANGUAGE sql IMMUTABLE
+    AS $$
+    SELECT
+        state.sequence_number;
+$$;
+
+
+--
+-- Name: contiguous_range_transition(public.contiguous_range_state, tsrange, interval); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.contiguous_range_transition(state public.contiguous_range_state, current_range tsrange, threshold interval) RETURNS public.contiguous_range_state
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+BEGIN
+    IF state IS NULL THEN
+        RETURN ROW (upper(current_range),
+            0,
+            threshold)::contiguous_range_state;
+
+    END IF;
+
+    IF lower(current_range) > state.prev_range_upper + state.threshold THEN
+        RETURN ROW (upper(current_range),
+            state.sequence_number + 1,
+            state.threshold)::contiguous_range_state;
+
+    ELSE
+        RETURN ROW (GREATEST (upper(current_range), state.prev_range_upper),
+            state.sequence_number,
+            state.threshold)::contiguous_range_state;
+
+    END IF;
+
+END;
+
 $$;
 
 
@@ -207,6 +258,31 @@ BEGIN
   RETURN array_to_string(segments[1:(query_length + 1)],'/');
 END;
 $$;
+
+
+--
+-- Name: tsmultirange_total_seconds(tsmultirange); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.tsmultirange_total_seconds(multirange tsmultirange) RETURNS double precision
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$
+    SELECT
+        extract(epoch FROM sum(upper(time_range) - lower(time_range)))
+    FROM
+        unnest(multirange) AS time_range
+$$;
+
+
+--
+-- Name: contiguous_range_number(tsrange, interval); Type: AGGREGATE; Schema: public; Owner: -
+--
+
+CREATE AGGREGATE public.contiguous_range_number(tsrange, interval) (
+    SFUNC = public.contiguous_range_transition,
+    STYPE = public.contiguous_range_state,
+    FINALFUNC = public.contiguous_range_final
+);
 
 
 SET default_tablespace = '';
@@ -4538,11 +4614,11 @@ ALTER TABLE ONLY public.tags
 -- PostgreSQL database dump complete
 --
 
-\unrestrict jzUK2mhBd3HZ3j09bN1hc82RQAyK6Aj6F6hwglOJtjRJrVBroYysWpZs9blP6wm
-
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507061809'),
+('20260507052638'),
 ('20260306070000'),
 ('20260216000000'),
 ('20260203031109'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,9 @@ services:
       - baw_network
 
   db:
-    image: postgres:14
+    image: postgres:18.3
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
       - type: bind
         source: ./provision/db
         target: /docker-entrypoint-initdb.d

--- a/provision/web/install_postgresql_client.sh
+++ b/provision/web/install_postgresql_client.sh
@@ -12,4 +12,4 @@ echo "deb http://apt.postgresql.org/pub/repos/apt/ $VERSION_CODENAME-pgdg main" 
 
 apt-get update
 
-apt-get install -y --no-install-recommends libpq-dev postgresql-client-14
+apt-get install -y --no-install-recommends libpq-dev postgresql-client-18

--- a/spec/api/reports/coverage_spec.rb
+++ b/spec/api/reports/coverage_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'reports', type: :request do
+  create_entire_hierarchy
+
+  sends_json_and_expects_json
+  with_authorization
+
+  let(:skip_automatic_description) { true }
+  let(:request_body) { { filter: {}, options: { bucket_count: 1920 } } }
+
+  before do
+    script = create(:script, creator: writer_user, provenance:)
+    analysis_job = create(:analysis_job, project:, creator: writer_user, scripts: [script])
+
+    create(
+      :analysis_jobs_item,
+      analysis_job:,
+      script:,
+      result: AnalysisJobsItem::RESULT_SUCCESS,
+      audio_recording:
+    )
+  end
+
+  def self.request_body_schema
+    Api::Schema.filter_payload(
+      filter: true, sorting: false, paging: false, projection: false, options: Api::Schema.coverage_report_options
+    )
+  end
+
+  path '/reports/recording_coverage' do
+    post 'Gets contiguous recording coverage spans per site' do
+      tags 'reports'
+      consumes 'application/json'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns contiguous recording coverage spans grouped by site.
+        The optional `filter` parameter is applied to audio recordings.
+        Results only include audio recordings the user has reader access to.
+      DESCRIPTION
+
+      parameter name: :request_body, in: :body, required: true,
+        schema: request_body_schema
+
+      response '200', 'recording coverage report retrieved' do
+        schema(**Api::Schema.coverage_report)
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '200', 'filters audio recordings by site' do
+        let(:request_body) { super().merge(filter: { site_id: { eq: site.id } }) }
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '422', 'rejects paging parameters' do
+        let(:request_body) { super().merge(paging: { items: 10 }) }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects sort parameters' do
+        let(:request_body) { super().merge(sort: { order_by: 'id' }) }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects projection parameters' do
+        let(:request_body) { super().merge(projection: { only: [:id] }) }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+    end
+  end
+
+  path '/reports/analysis_coverage' do
+    post 'Gets contiguous analysis coverage spans per site and result' do
+      tags 'reports'
+      consumes 'application/json'
+      produces 'application/json'
+
+      description <<~DESCRIPTION
+        Returns contiguous analysis coverage spans grouped by site and analysis job item result.
+        The optional `filter` parameter is applied to audio recordings.
+        Results only include audio recordings the user has reader access to.
+      DESCRIPTION
+
+      parameter name: :request_body, in: :body, required: true,
+        schema: request_body_schema
+
+      response '200', 'analysis coverage report retrieved' do
+        schema(**Api::Schema.coverage_report(include_result: true))
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '200', 'filters audio recordings by site' do
+        let(:request_body) { super().merge(filter: { site_id: { eq: site.id } }) }
+
+        run_test! do
+          expect_at_least_one_item
+        end
+      end
+
+      response '422', 'rejects paging parameters' do
+        let(:request_body) { super().merge(paging: { items: 10 }) }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects sort parameters' do
+        let(:request_body) { super().merge(sort: { order_by: 'id' }) }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+
+      response '422', 'rejects projection parameters' do
+        let(:request_body) { super().merge(projection: { only: [:id] }) }
+
+        run_test! do
+          expect_error(
+            :unprocessable_content,
+            'The request could not be understood: Paging, sorting, and projection parameters are not allowed in group by or reporting requests.'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/permissions/reports_spec.rb
+++ b/spec/permissions/reports_spec.rb
@@ -2,6 +2,13 @@
 
 describe 'Reports permissions' do
   create_entire_hierarchy
+  before do
+    script = create(:script, creator: writer_user, provenance: create(:provenance, creator: writer_user))
+    analysis_job = create(:analysis_job, project: project, creator: writer_user, scripts: [script])
+
+    # Add an analysis job items to the original recording
+    create(:analysis_jobs_item, analysis_job:, script:, result: AnalysisJobsItem::RESULT_SUCCESS, audio_recording:)
+  end
 
   given_the_route '/reports' do
     {
@@ -19,8 +26,45 @@ describe 'Reports permissions' do
 
   let(:day) { audio_recording.recorded_date.utc.at_beginning_of_day }
 
+  with_custom_action(:recording_coverage, path: 'recording_coverage', verb: :post,
+    body: -> { [{ filter: {}, options: { bucket_count: 1920 } }, :json] },
+    expect: lambda { |user, _action|
+      if user == :no_access
+        expect(api_result[:data].length).to eq(0)
+      else
+        expect(api_data).to match([
+          { site_id: site.id,
+            coverage: [
+              audio_recording.recorded_date.utc.as_json,
+              (audio_recording.recorded_date.utc + audio_recording.duration_seconds.seconds).as_json
+            ],
+            density: 1.0,
+            gap_threshold: 31 }
+        ])
+      end
+    })
+
+  with_custom_action(:analysis_coverage, path: 'analysis_coverage', verb: :post,
+    body: -> { [{ filter: {}, options: { bucket_count: 1920 } }, :json] },
+    expect: lambda { |user, _action|
+      if user == :no_access
+        expect(api_result[:data].length).to eq(0)
+      else
+        expect(api_data).to match([
+          { site_id: site.id,
+            result: AnalysisJobsItem::RESULT_SUCCESS,
+            coverage: [
+              audio_recording.recorded_date.utc.as_json,
+              (audio_recording.recorded_date.utc + audio_recording.duration_seconds.seconds).as_json
+            ],
+            density: 1.0,
+            gap_threshold: 31 }
+        ])
+      end
+    })
+
   with_custom_action(:tag_accumulation, path: 'tag_accumulation', verb: :post,
-    body: -> { { options: { bucket_size: 'day' }, filter: {} } },
+    body: -> { [{ options: { bucket_size: 'day' }, filter: {} }, :json] },
     expect: lambda { |user, _action|
       if user == :no_access
         expect(api_result[:data].length).to eq(0)
@@ -30,7 +74,7 @@ describe 'Reports permissions' do
     })
 
   with_custom_action(:tag_frequency, path: 'tag_frequency', verb: :post,
-    body: -> { { options: { bucket_size: 'day' }, filter: {} } },
+    body: -> { [{ options: { bucket_size: 'day' }, filter: {} }, :json] },
     expect: lambda { |user, _action|
       if user == :no_access
         expect(api_result[:data].length).to eq(0)
@@ -40,7 +84,7 @@ describe 'Reports permissions' do
     })
 
   with_custom_action(:tag_diel_activity, path: 'tag_diel_activity', verb: :post,
-    body: -> { { options: { bucket_size: 'hour' }, filter: {} } },
+    body: -> { [{ options: { bucket_size: 'hour' }, filter: {} }, :json] },
     expect: lambda { |user, _action|
       if user == :no_access
         expect(api_data).to match((0..23).map { |i| { bucket: [i * 3600, (i + 1) * 3600], tags: [] } })
@@ -56,7 +100,7 @@ describe 'Reports permissions' do
     })
 
   with_custom_action(:event_summaries, path: 'event_summaries', verb: :post,
-    body: -> { { options: {}, filter: {} } },
+    body: -> { [{ options: {}, filter: {} }, :json] },
     expect: lambda { |user, _action|
       if user == :no_access
         expect(api_result[:data].length).to eq(0)
@@ -74,21 +118,23 @@ describe 'Reports permissions' do
       end
     })
 
-  # Any authenticated user with at least reader access can use the reports/tag_* endpoints
+  # Any authenticated user with at least reader access can use the reports/* endpoints
   ensures :admin, :owner, :writer, :reader,
-    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
+    can: [:recording_coverage, :analysis_coverage, :tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
     cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: :not_found
 
   # Users without project access can call these endpoints, but receive no visible tag results
   ensures :no_access,
-    can: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
+    can: [:recording_coverage, :analysis_coverage, :tag_accumulation, :tag_frequency, :tag_diel_activity,
+          :event_summaries],
     cannot: [:index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: :not_found
 
   # Harvester cannot access the endpoint
   ensures :harvester,
-    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
+    cannot: [:recording_coverage, :analysis_coverage, :tag_accumulation, :tag_frequency, :tag_diel_activity,
+             :event_summaries],
     fails_with: :forbidden
 
   ensures :harvester,
@@ -97,7 +143,8 @@ describe 'Reports permissions' do
 
   # Anonymous users cannot access the endpoint
   ensures :anonymous,
-    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries],
+    cannot: [:recording_coverage, :analysis_coverage, :tag_accumulation, :tag_frequency, :tag_diel_activity,
+             :event_summaries],
     fails_with: :unauthorized
 
   ensures :anonymous,
@@ -106,7 +153,7 @@ describe 'Reports permissions' do
 
   # Invalid tokens cannot access the endpoint
   ensures :invalid,
-    cannot: [:tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries, :index, :show, :create, :update, :destroy, :new,
-             :filter],
+    cannot: [:recording_coverage, :analysis_coverage, :tag_accumulation, :tag_frequency, :tag_diel_activity, :event_summaries,
+             :index, :show, :create, :update, :destroy, :new, :filter],
     fails_with: [:unauthorized, :not_found]
 end

--- a/spec/requests/reports/analysis_coverage_spec.rb
+++ b/spec/requests/reports/analysis_coverage_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+describe 'reports/analysis_coverage' do
+  create_entire_hierarchy
+  let(:start_date) { audio_recording.recorded_date.utc }
+  let(:duration_seconds) { audio_recording.duration_seconds }
+  let(:end_date) { start_date + 7.days }
+  let(:gap_threshold) { (end_date - start_date) / 1920 }
+  let(:gap_below_threshold) { 5.minutes }
+  let(:gap_above_threshold) { 10.minutes }
+  let(:params) {
+    {
+      filter: {},
+      options: { bucket_count: 1920 }
+    }
+  }
+
+  let(:expected_data) do
+    cancelled_block_start = start_date + 1.day
+    cancelled_block_end = cancelled_block_start + 20.minutes + 5.minutes
+    cancelled_density = (3 * 5.minutes) / (cancelled_block_end - cancelled_block_start).seconds
+
+    [{ site_id: site.id,
+       result: AnalysisJobsItem::RESULT_SUCCESS,
+       coverage: [start_date, start_date + duration_seconds],
+       density: 1.0,
+       gap_threshold: },
+
+     { site_id: site.id,
+       result: AnalysisJobsItem::RESULT_SUCCESS,
+       coverage: [end_date - duration_seconds, end_date],
+       density: 1.0,
+       gap_threshold: },
+
+     { site_id: site.id,
+       result: AnalysisJobsItem::RESULT_CANCELLED,
+       coverage: [cancelled_block_start, cancelled_block_end],
+       gap_threshold:,
+       density: cancelled_density }]
+  end
+
+  before do
+    script = create(:script, creator: writer_user, provenance: create(:provenance, creator: writer_user))
+    analysis_job = create(:analysis_job, project: project, creator: writer_user, scripts: [script])
+
+    # Add an analysis job items to the original recording
+    create(:analysis_jobs_item, analysis_job:, script:, result: AnalysisJobsItem::RESULT_SUCCESS, audio_recording:)
+
+    # Create a cancelled block with a density of 3/5
+    cancelled_block_start = start_date + 1.day
+    [cancelled_block_start, cancelled_block_start + 10.minutes,
+     cancelled_block_start + 20.minutes].each do |recorded_date|
+      create(:audio_recording, creator: writer_user, site:, recorded_date:, duration_seconds: 5.minutes) { |rec|
+        create(:analysis_jobs_item, analysis_job:, script:, result: AnalysisJobsItem::RESULT_CANCELLED, audio_recording: rec) #nolint
+      }
+    end
+
+    # Make a recording that will act as the upper for the entire set of audio recordings;
+    # ending exactly 1 week after the first audio_recording starts, resulting in a known gap threshold of 5 minutes 15 seconds
+    (end_date - duration_seconds)
+      .then { |recorded_date| create(:audio_recording, creator: writer_user, site:, recorded_date:, duration_seconds:) }
+      .then { |rec| create(:analysis_jobs_item, analysis_job:, script:, result: AnalysisJobsItem::RESULT_SUCCESS, audio_recording: rec) }
+
+    # Create a recording with no analysis job item, to prove it is not included in the coverage
+    create(:audio_recording, creator: writer_user, site:, recorded_date: start_date, duration_seconds: 600_000)
+
+    # Create a recording that writer_user has no access to, to prove it is not included in the coverage
+    create(:audio_recording, recorded_date: start_date, duration_seconds: 600_000) { |rec|
+      create(:analysis_jobs_item, analysis_job:, script:, result: AnalysisJobsItem::RESULT_SUCCESS,
+        audio_recording: rec)
+    }
+  end
+
+  it 'returns the correct coverage values, partitioned by analysis jobs item result' do
+    post '/reports/analysis_coverage', params: params, **api_headers(writer_token)
+
+    expect_success
+    expect(api_data).to match_array(expected_data)
+  end
+
+  context 'with > 1 analysis job result on a recording' do
+    before do
+      analysis_job_2 = create(:analysis_job, project: project, creator: writer_user, scripts: [script])
+      create(:analysis_jobs_item, analysis_job: analysis_job_2, script:, result: AnalysisJobsItem::RESULT_FAILED,
+        audio_recording:)
+    end
+
+    it 'returns separate coverage entries for each analysis job result' do
+      post '/reports/analysis_coverage', params: params, **api_headers(writer_token)
+
+      expect_success
+      expect(api_data).to match_array(expected_data + [
+        { site_id: site.id,
+          result: AnalysisJobsItem::RESULT_FAILED,
+          coverage: [start_date, start_date + duration_seconds],
+          density: 1.0,
+          gap_threshold: }
+      ])
+    end
+  end
+
+  context 'with multiple sites' do
+    let(:another_site) { create(:site, creator: writer_user, region: region, projects: [project]) }
+
+    before do
+      create(:audio_recording, creator: writer_user, site: another_site, recorded_date: start_date, duration_seconds:) {
+        create(:analysis_jobs_item,
+          analysis_job:, script:, result: AnalysisJobsItem::RESULT_SUCCESS, audio_recording: _1)
+      }
+    end
+
+    it 'partitions by site and analysis jobs item result' do
+      post '/reports/analysis_coverage', params: params, **api_headers(writer_token)
+
+      expect_success
+      expect(api_data).to match_array(expected_data + [
+        { site_id: another_site.id,
+          result: AnalysisJobsItem::RESULT_SUCCESS,
+          coverage: [start_date, start_date + duration_seconds],
+          density: 1.0,
+          gap_threshold: }
+      ])
+    end
+
+    context 'with filters' do
+      it 'returns the correct coverage values, excluding filtered recordings' do
+        filter = { filter: { site_id: { not_eq: another_site.id } } }
+        post '/reports/analysis_coverage', params: params.merge(filter), **api_headers(writer_token)
+
+        expect_success
+        expect(api_data).to match_array(expected_data)
+      end
+    end
+  end
+end

--- a/spec/requests/reports/recording_coverage_spec.rb
+++ b/spec/requests/reports/recording_coverage_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+describe 'reports/recording_coverage' do
+  create_entire_hierarchy
+  let(:start_date) { audio_recording.recorded_date.utc }
+  let(:duration_seconds) { audio_recording.duration_seconds }
+  let(:end_date) { start_date + 7.days }
+  let(:gap_threshold) { (end_date - start_date) / 1920 }
+  let(:gap_below_threshold) { 5.minutes }
+  let(:gap_above_threshold) { 10.minutes }
+  let(:params) {
+    {
+      filter: {},
+      options: { bucket_count: 1920 }
+    }
+  }
+
+  let(:expected_data) do
+    # density calculation for two recordings of same length, separated by `gap_below_threshold`:
+    density = (duration_seconds + duration_seconds).seconds /
+              ((duration_seconds + duration_seconds).seconds + gap_below_threshold)
+
+    [{ site_id: site.id,
+       coverage: [
+         start_date,
+         start_date + duration_seconds + gap_below_threshold + duration_seconds
+       ],
+       density: be_within(0.0001).of(density),
+       gap_threshold: },
+
+     { site_id: site.id,
+       coverage: [end_date - duration_seconds, end_date],
+       density: 1.0,
+       gap_threshold: }]
+  end
+
+  before do
+    # Start 5 minutes after the first recording ends (i.e. within the gap threshold), so they group together
+    create(:audio_recording,
+      creator: writer_user, site:, recorded_date: recording_end_date(audio_recording) + gap_below_threshold, duration_seconds:)
+
+    # Make a recording that will act as the upper for the entire set of audio recordings;
+    # ending exactly 1 week after the first audio_recording starts, resulting in a known gap threshold of 5 minutes 15 seconds
+    create(:audio_recording, creator: writer_user, site:, recorded_date: end_date - duration_seconds, duration_seconds:)
+
+    # Create a recording that writer_user has no access to, to prove it is not included in the coverage
+    create(:audio_recording, recorded_date: start_date, duration_seconds: 600_000)
+  end
+
+  it 'returns the correct coverage values' do
+    post '/reports/recording_coverage', params: params, **api_headers(writer_token)
+
+    expect_success
+    expect(api_data).to match_array(expected_data)
+  end
+
+  it 'returns the correct coverage with a different bucket_count' do
+    params_new = params.merge({ options: { bucket_count: 1 } })
+
+    post '/reports/recording_coverage', params: params_new, **api_headers(writer_token)
+    expect_success
+
+    density = (duration_seconds * 3) / 1.week.seconds
+    expected_data = [{
+      site_id: site.id,
+      coverage: [start_date, end_date],
+      density: be_within(0.0001).of(density),
+      gap_threshold: 1.week.seconds.to_i
+    }]
+
+    expect(api_data).to match_array(expected_data)
+  end
+
+  context 'with bucket_count < 1' do
+    let(:params) { super().merge({ options: { bucket_count: 0 } }) }
+
+    it 'returns an ArgumentError' do
+      expect {
+        post '/reports/recording_coverage', params: params, **api_headers(writer_token)
+      }.to raise_error(ArgumentError, 'bucket_count must be a positive integer, got 0')
+    end
+  end
+
+  context 'with non-integer bucket_count' do
+    let(:params) { super().merge({ options: { bucket_count: 1.5 } }) }
+
+    it 'returns an ArgumentError' do
+      expect {
+        post '/reports/recording_coverage', params: params, **api_headers(writer_token)
+      }.to raise_error(ArgumentError, 'bucket_count must be a positive integer, got 1.5')
+    end
+  end
+
+  context 'with multiple sites' do
+    let(:another_site) { create(:site, creator: writer_user, region: region, projects: [project]) }
+
+    # recordings separated by > gap threshold
+    before do
+      create(:audio_recording,
+        creator: writer_user, site: another_site, recorded_date: start_date, duration_seconds: 5.minutes) => another_site_recording
+      create(:audio_recording,
+        creator: writer_user, site: another_site, recorded_date: recording_end_date(another_site_recording) + gap_above_threshold, duration_seconds: 5.minutes)
+    end
+
+    let!(:additional_site_expected_data) do
+      [*expected_data,
+       { site_id: another_site.id, coverage: [start_date, start_date + 5.minutes], density: 1.0, gap_threshold: },
+       { site_id: another_site.id,
+         coverage: [
+           start_date + 5.minutes + gap_above_threshold,
+           start_date + 5.minutes + gap_above_threshold + 5.minutes
+         ],
+         density: 1.0,
+         gap_threshold: }]
+    end
+
+    it 'returns the correct coverage values, partitioned by site' do
+      post '/reports/recording_coverage', params: params, **api_headers(writer_token)
+
+      expect_success
+      expect(api_data).to match_array(additional_site_expected_data)
+    end
+
+    context 'with filters' do
+      let(:params) {
+        {
+          filter: { site_id: { not_eq: another_site.id } },
+          options: { bucket_count: 1920 }
+        }
+      }
+
+      it 'returns the correct coverage values, excluding filtered recordings' do
+        post '/reports/recording_coverage', params: params, **api_headers(writer_token)
+
+        expect_success
+        expect(api_data).to match_array(expected_data)
+      end
+    end
+  end
+
+  def recording_end_date(recording) = recording.recorded_date.utc + recording.duration_seconds.seconds
+end

--- a/spec/routing/reports_routing_spec.rb
+++ b/spec/routing/reports_routing_spec.rb
@@ -25,5 +25,17 @@ RSpec.describe ReportsController, type: :routing do
         route_to('reports#event_summaries', format: 'json')
       )
     }
+
+    it {
+      expect(post('/reports/recording_coverage')).to(
+        route_to('reports#recording_coverage', format: 'json')
+      )
+    }
+
+    it {
+      expect(post('/reports/analysis_coverage')).to(
+        route_to('reports#analysis_coverage', format: 'json')
+      )
+    }
   end
 end

--- a/spec/unit/modules/access/by_permission_table_spec.rb
+++ b/spec/unit/modules/access/by_permission_table_spec.rb
@@ -89,6 +89,53 @@ describe Access::ByPermissionTable do
     end
   end
 
+  context 'with audio_recordings it works as expected' do
+    def common(user)
+      Access::ByPermissionTable
+        .audio_recordings(user, level: Access::Permission::READER)
+        .order(:id)
+        .pluck(:id)
+    end
+
+    example 'for admin' do
+      expect(common(admin_user)).to eq([audio_recording.id, site_anon.id])
+    end
+
+    example 'for owner' do
+      expect(common(owner_user)).to eq([audio_recording.id, site_anon.id])
+    end
+
+    example 'for writer' do
+      expect(common(writer_user)).to eq([audio_recording.id, site_anon.id])
+    end
+
+    example 'for reader' do
+      expect(common(reader_user)).to eq([audio_recording.id, site_anon.id])
+    end
+
+    example 'for anonymous' do
+      expect(common(nil)).to eq([audio_recording_anon.id])
+    end
+
+    example 'with project_ids filter' do
+      expect(
+        Access::ByPermissionTable
+          .audio_recordings(reader_user, level: Access::Permission::READER, project_ids: [project.id])
+          .order(:id)
+          .pluck(:id)
+      ).to eq([audio_recording.id])
+    end
+
+    example 'with project_ids filter excluding all' do
+      expect(
+        Access::ByPermissionTable
+          .audio_recordings(reader_user, level: Access::Permission::READER, project_ids: [another_project.id])
+          .order(:id)
+          .pluck(:id)
+      ).to eq([])
+    end
+  end
+
   context 'with audio_events it works as expected' do
     # audio_event comes from create_entire_hierarchy (in the permissioned project)
 
@@ -203,6 +250,22 @@ describe Access::ByPermissionTable do
 
           by_permission_table_result = Access::ByPermissionTable
             .sites(user, levels: Access::Permission::READER_OR_ABOVE)
+            .order(:id)
+            .pluck(:id)
+
+          expect(by_permission_table_result).to eq(by_permission_result)
+        end
+
+        example 'for audio_recordings' do
+          user = user_name.nil? ? nil : send(user_name)
+
+          by_permission_result = Access::ByPermission
+            .audio_recordings(user, levels: Access::Permission::READER_OR_ABOVE)
+            .order(:id)
+            .pluck(:id)
+
+          by_permission_table_result = Access::ByPermissionTable
+            .audio_recordings(user, levels: Access::Permission::READER_OR_ABOVE)
             .order(:id)
             .pluck(:id)
 


### PR DESCRIPTION
# feat: add reports/recording_coverage, reports/analysis_coverage endpoints; upgrade db image to postgres:18.3

The purpose is to add coverage reporting endpoints for recordings and recording analysis results.  

The db version is also updated to 18.3, which allows using the range_agg function (simplifies the coverage query), and CTE heavy queries run ~4x faster.

## Changes

- Add `POST /reports/recording_coverage` and `POST /reports/analysis_coverage` to `ReportsController`, with routing, permissions, request specs, routing specs, and api specs.
- Add `Api::Reporting::Coverage` to calculate contiguous coverage spans per configurable partition 
- Update `Api::Reporting.execute_report` to accept the report model explicitly so coverage reports can reuse the existing reporting pipeline with `AudioRecording` filters and query casting.

- Add custom Arel helpers and SQL visitor support for ordered `array_agg`, `range_agg`, range upper bounds, and `tsmultirange_total_seconds` so the coverage queries can be composed cleanly in Ruby.
- Add the `contiguous_range_number` PostgreSQL aggregate migration to assign island numbers to contiguous `tsrange` groups.
- Add the `tsmultirange_total_seconds` PostgreSQL function migration to sum covered seconds in multiranges.

- Upgrade the database container to PostgreSQL 18.3.
- Update the Postgres volume mount location for the newer image layout and install the PostgreSQL 18 client in the web container.

## Problems

- db major version jump?

## Visual Changes

No visual changes.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [x] Ensure CI build is passing
