### PR TITLE
feat: add camtrap-dp export module 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,6 +215,10 @@ gem 'mini_magick', '>= 4.9.5'
 # -------------------------------------
 gem 'rubyzip', '>= 3.0.0.alpha'
 
+# Data package support
+# -------------------------------------
+gem 'datapackage', '~> 1.1'
+
 # gems that are only required on development machines or for testings
 group :development do
   # allow debugging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
     cancancan (3.6.1)
     climate_control (1.2.0)
     coderay (1.1.3)
+    colorize (1.1.0)
     comfy_bootstrap_form (4.0.9)
       rails (>= 5.0.0)
     concurrent-ruby (1.3.5)
@@ -243,6 +244,12 @@ GEM
     database_cleaner-redis (2.0.0)
       database_cleaner-core (~> 2.0.0)
       redis
+    datapackage (1.1.1)
+      colorize
+      json-schema
+      ruby_dig
+      rubyzip
+      tableschema
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -406,9 +413,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.2)
-    json-schema (5.1.0)
-      addressable (~> 2.8)
+    json (2.19.7)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     json_schemer (2.3.0)
       bigdecimal
       hana (~> 1.3)
@@ -454,6 +461,8 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -461,14 +470,12 @@ GEM
       net-smtp
     mapping (1.1.1)
     marcel (1.0.4)
-    mcp (0.9.2)
-      json-schema (>= 4.1)
     memoist (0.16.2)
     metrics (0.12.0)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0708)
+    mime-types-data (3.2026.0414)
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
@@ -683,12 +690,11 @@ GEM
     rswag-ui (2.16.0)
       actionpack (>= 5.2, < 8.1)
       railties (>= 5.2, < 8.1)
-    rubocop (1.85.1)
+    rubocop (1.87.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      mcp (~> 0.6)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
@@ -721,6 +727,7 @@ GEM
       ffi (~> 1.12)
       logger
     ruby2_keywords (0.0.5)
+    ruby_dig (0.0.2)
     rubyzip (3.0.0.alpha)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
@@ -807,6 +814,12 @@ GEM
       diff-lcs
       patience_diff
     sync (0.5.0)
+    systemu (2.6.5)
+    tableschema (1.0.4)
+      activesupport
+      json-schema (~> 2.8.0)
+      tod (~> 2.1.0)
+      uuid (~> 2.3.8)
     temping (4.3.0)
       activerecord (>= 6.0, < 8.1)
       activesupport (>= 6.0, < 8.1)
@@ -826,6 +839,7 @@ GEM
     tins (1.36.1)
       bigdecimal
       sync
+    tod (2.1.1)
     traces (0.13.1)
     tsort (0.2.0)
     typeprof (0.21.11)
@@ -840,6 +854,8 @@ GEM
     uniform_notifier (1.17.0)
     uri (1.1.1)
     useragent (0.16.11)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
     uuidtools (2.1.5)
     validates_timeliness (8.0.0)
       activemodel (>= 8.0.0, < 9)
@@ -890,6 +906,7 @@ DEPENDENCIES
   csv
   database_cleaner-active_record
   database_cleaner-redis
+  datapackage (~> 1.1)
   debug
   deep_sort
   descriptive-statistics

--- a/app/models/audio_event.rb
+++ b/app/models/audio_event.rb
@@ -118,6 +118,14 @@ class AudioEvent < ApplicationRecord
     )
   })
 
+  def start_date
+    audio_recording.recorded_date + start_time_seconds.seconds
+  end
+
+  def end_date
+    audio_recording.recorded_date + end_time_seconds.seconds
+  end
+
   def self.start_date_arel
     Arel.grouping(
       AudioRecording.arel_table[:recorded_date] +

--- a/app/models/audio_recording.rb
+++ b/app/models/audio_recording.rb
@@ -552,6 +552,14 @@ class AudioRecording < ApplicationRecord
     result
   end
 
+  def recorded_end_date
+    recorded_date + duration_seconds
+  end
+
+  def global_identifier
+    Api::UrlHelpers.global_identifier(:audio_recording_path, id: id)
+  end
+
   private
 
   def missing_hash_value?

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -48,6 +48,12 @@ class Permission < ApplicationRecord
     { id: l, name: Access::Core.get_level_name(l) }
   }
 
+  # Returns true when this permission grants access to anonymous or logged-in users.
+  # @return [Boolean]
+  def public_access?
+    (allow_anonymous || allow_logged_in) && Access::Core.levels.include?(level&.to_sym)
+  end
+
   # association validations
   # these validations are now redundant i think
   #validates_associated :project

--- a/app/models/provenance.rb
+++ b/app/models/provenance.rb
@@ -46,6 +46,11 @@ class Provenance < ApplicationRecord
 
   renders_markdown_for :description
 
+  # Provenances are currently assumed to be algorithms, but if that changes, we can add the needed logic here.
+  def machine_generated?
+    true
+  end
+
   # Define filter api settings
   def self.filter_settings
     fields = [

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -81,6 +81,17 @@ class Site < ApplicationRecord
   # Don't allow values that are too close to the original location
   JITTER_EXCLUSION_RANGE = JITTER_RANGE * JITTER_EXCLUSION
 
+  # Conservative estimate: approximate distance in meters for 1 degree of longitude at the equator
+  METERS_PER_DEGREE = 111_319.5
+
+  # When coordinate measurement uncertainty is not provided, assume measurement
+  # taken using a GPS with uncertainty of 30 meters. This aligns with the
+  # camtrapdp R package default.
+  # See also:
+  # - https://dwc.tdwg.org/terms/#dwc:coordinateUncertaintyInMeters
+  # - https://github.com/tdwg/camtrap-dp/issues/467
+  ASSUMED_UNCERTAINTY_METERS = 30
+
   # add deleted_at and deleter_id
   acts_as_discardable
   also_discards :audio_recordings, batch: true
@@ -191,40 +202,34 @@ class Site < ApplicationRecord
   renders_markdown_for :description
 
   # Replaces `custom_latitude`. Returns obfuscated latitude if location is obfuscated.
-  def public_latitude
-    if location_obfuscated
-      obfuscated_latitude
-    else
-      latitude
-    end
+  # @param user [User, nil] the user to check permissions for. If nil, uses Current.user.
+  # @param should_obfuscate [Boolean, nil] optional override to force obfuscation or not.
+  def public_latitude(user: nil, should_obfuscate: nil)
+    return obfuscated_latitude if location_obfuscated(user:, should_obfuscate:)
+
+    latitude
   end
 
   # Replaces `custom_longitude`. Returns obfuscated longitude if location is obfuscated.
-  def public_longitude
-    if location_obfuscated
-      obfuscated_longitude
-    else
-      longitude
-    end
+  # @param user [User, nil] the user to check permissions for. If nil, uses Current.user.
+  # @param should_obfuscate [Boolean, nil] optional override to force obfuscation or not.
+  def public_longitude(user: nil, should_obfuscate: nil)
+    return obfuscated_longitude if location_obfuscated(user:, should_obfuscate:)
+
+    longitude
   end
 
-  # This method is a little funny.
-  # If `location_obfuscated` was returned in a query, then that value is used.
-  # Otherwise, the obfuscation is calculated with another query.
-  def location_obfuscated
-    return self['location_obfuscated'] if has_attribute?('location_obfuscated')
+  # Returns true when any project this site belongs to grants broad access (anonymous or logged-in users)
+  # @return [Boolean]
+  def public_site?
+    projects.any? { |project|
+      project.permissions.any?(&:public_access?)
+    }
+  end
 
-    return true if Current.user.nil?
-
-    return false if Current.user.admin?
-
-    # if no associated projects, we can't determine permissions, so obfuscate
-    return true if projects.empty?
-
-    is_owner = Access::Core.can_any?(Current.user, Access::Permission::OWNER, projects)
-
-    # obfuscate if level is less than owner
-    !is_owner
+  # @return [Boolean] true if both latitude and longitude are provided, false otherwise
+  def coordinates_provided?
+    latitude.present? && longitude.present?
   end
 
   def location_jitter_seed
@@ -259,7 +264,7 @@ class Site < ApplicationRecord
     # add in an exclusion buffer
     # the addition pushes the jitter away from the mid point
     # we push out by 10% of the jitter range, so for 0.003° ≈ 333m the push range is +- 33m
-    jitter += ((jitter >= 0 ? 1 : -1) * (Site::JITTER_RANGE * 0.1))
+    jitter += ((jitter >= 0 ? 1 : -1) * Site::JITTER_EXCLUSION_RANGE)
 
     # finally augment the input value
     # rounding just to produce a neat value
@@ -322,21 +327,128 @@ class Site < ApplicationRecord
     )
   end
 
-  private
+  def global_identifier
+    Api::UrlHelpers.global_identifier(:shallow_site_path, id: id)
+  end
 
-  # Determines if the obfuscated location should be auto-updated
-  # Only update if:
-  # - The obfuscated location is system-generated (not user-provided), AND
-  # - Either latitude or longitude has changed (for existing records)
-  def should_update_obfuscated_location?
-    # Never auto-update if custom obfuscation is enabled
-    return false if custom_obfuscated_location
+  # TODO: remove when closed https://github.com/QutEcoacoustics/baw-server/issues/1023.
+  # Future DB column placeholder - We do not currently store this.
+  def measurement_uncertainty_meters
+    nil
+  end
 
-    # For new records, always generate if not using custom obfuscation
-    return true if new_record?
+  # Used to determine whether to use the stored measurement uncertainty or the assumed fallback uncertainty.
+  # @return [Boolean] true if measurement uncertainty has been provided, false otherwise.
+  def measurement_uncertainty_provided?
+    measurement_uncertainty_meters.present?
+  end
 
-    # For existing records, only update if coordinates changed
-    latitude_changed? || longitude_changed?
+  # Returns the effective measurement uncertainty in meters, using the stored
+  # value when available or the assumed fallback otherwise.
+  # @return [Integer, nil] the effective measurement uncertainty in meters, or
+  #   nil if coordinates are not provided.
+  def effective_measurement_uncertainty_meters
+    return nil unless coordinates_provided?
+    return measurement_uncertainty_meters if measurement_uncertainty_provided?
+
+    ASSUMED_UNCERTAINTY_METERS
+  end
+
+  # @return [Integer, nil] the obfuscation uncertainty in meters, or nil if
+  #   coordinates are not provided or if the obfuscation uncertainty cannot be
+  #   determined.
+  def effective_obfuscation_uncertainty_meters
+    return nil unless coordinates_provided?
+    return nil if obfuscated_latitude.nil? || obfuscated_longitude.nil?
+
+    # TODO: remove when closed https://github.com/QutEcoacoustics/baw-server/issues/1025.
+    return nil if custom_obfuscated_location
+
+    # For our default obfuscation, we use the theoretical maximum distance that
+    # the obfuscation could have moved the coordinates.
+    (JITTER_RANGE + JITTER_EXCLUSION_RANGE) * METERS_PER_DEGREE
+  end
+
+  # Total coordinate uncertainty includes both measurement and obfuscation
+  # uncertainty when applicable.
+  #
+  # @param user [User, nil] the user to check permissions for. If nil, uses Current.user.
+  # @param should_obfuscate [Boolean, nil] optional override to force obfuscation or not.
+  # @return [Float, nil] the total coordinate uncertainty in meters, or nil if
+  #   unknown or cannot be determined.
+  def total_coordinate_uncertainty_meters(user: nil, should_obfuscate: nil)
+    obfuscated = location_obfuscated(user:, should_obfuscate:)
+    measurement_uncertainty = effective_measurement_uncertainty_meters
+
+    return measurement_uncertainty unless obfuscated
+
+    obfuscation_uncertainty = effective_obfuscation_uncertainty_meters
+
+    return nil if measurement_uncertainty.nil? || obfuscation_uncertainty.nil?
+
+    measurement_uncertainty + obfuscation_uncertainty
+  end
+
+  # Returns a human-readable string describing the measurement uncertainty, or nil if it cannot be determined.
+  #
+  # @param user [User, nil] the user to check permissions for. If nil, uses Current.user.
+  # @param should_obfuscate [Boolean, nil] optional override to force obfuscation or not.
+  # @return [String, nil]
+  def measurement_uncertainty_text(user: nil, should_obfuscate: nil)
+    return nil unless coordinates_provided?
+    return nil if effective_measurement_uncertainty_meters.nil?
+    return 'coordinates are intentionally hidden' if public_location_hidden?(user:, should_obfuscate:)
+
+    uncertainty_type = measurement_uncertainty_provided? ? 'a' : 'an assumed'
+    "coordinates have #{uncertainty_type} measurement uncertainty of #{effective_measurement_uncertainty_meters} meters"
+  end
+
+  # Returns a human-readable string describing the obfuscation uncertainty, or nil if it cannot be determined.
+  #
+  # @param user [User, nil] the user to check permissions for. If nil, uses Current.user.
+  # @param should_obfuscate [Boolean, nil] optional override to force obfuscation or not.
+  # @return [String, nil]
+  def obfuscation_uncertainty_text(user: nil, should_obfuscate: nil)
+    return nil unless coordinates_provided? && location_obfuscated(user:, should_obfuscate:)
+
+    return 'coordinates are intentionally hidden' if public_location_hidden?(user:, should_obfuscate:)
+    return 'coordinates have an unknown obfuscation uncertainty' if custom_obfuscated_location
+
+    obfuscation_uncertainty = effective_obfuscation_uncertainty_meters
+    return nil if obfuscation_uncertainty.nil?
+
+    "coordinates have an obfuscation uncertainty of #{obfuscation_uncertainty} meters"
+  end
+
+  # True when public location is intentionally hidden: obfuscation is enabled,
+  # custom obfuscation is active, and the obfuscated coordinates are nil.
+  def public_location_hidden?(user: nil, should_obfuscate: nil)
+    obfuscated = location_obfuscated(user:, should_obfuscate:)
+    obfuscated && custom_obfuscated_location && (obfuscated_latitude.nil? || obfuscated_longitude.nil?)
+  end
+
+  # Should the location be obfuscated?
+  # Use the `should_obfuscate` override if provided, else check permissions for the user.
+  #
+  # @param user [User, nil] the user to check permissions for. If nil, uses Current.user.
+  # @param should_obfuscate [Boolean, nil] optional override to force obfuscation or not.
+  # @return [Boolean] true if the location should be obfuscated, false otherwise.
+  def location_obfuscated(user: nil, should_obfuscate: nil)
+    return self['location_obfuscated'] if has_attribute?('location_obfuscated')
+    return should_obfuscate unless should_obfuscate.nil?
+
+    user ||= Current.user
+    return true if user.nil?
+
+    return false if user.admin?
+
+    # if no associated projects, we can't determine permissions, so obfuscate
+    return true if projects.empty?
+
+    is_owner = Access::Core.can_any?(user, Access::Permission::OWNER, projects)
+
+    # obfuscate if level is less than owner
+    !is_owner
   end
 
   # Define filter api settings
@@ -359,22 +471,22 @@ class Site < ApplicationRecord
                       :obfuscated_latitude, :obfuscated_longitude, :custom_obfuscated_location],
       text_fields: [:description, :name],
       custom_fields: lambda { |item, _user|
-                       # item can be nil or a new record
-                       is_new_record = item.nil? || item.new_record?
-                       fresh_site = is_new_record ? nil : Site.find(item.id)
-                       site_hash = {}
+        # item can be nil or a new record
+        is_new_record = item.nil? || item.new_record?
+        fresh_site = is_new_record ? nil : Site.find(item.id)
+        site_hash = {}
 
-                       unless fresh_site.nil?
-                         site_hash = {
-                           project_ids: fresh_site.projects.pluck(:id).flatten,
-                           timezone_information: fresh_site.timezone,
-                           image_urls: Api::Image.image_urls(fresh_site.image),
-                           **item.render_markdown_for_api_for(:description)
-                         }
-                       end
+        unless fresh_site.nil?
+          site_hash = {
+            project_ids: fresh_site.projects.pluck(:id).flatten,
+            timezone_information: fresh_site.timezone,
+            image_urls: Api::Image.image_urls(fresh_site.image),
+            **item.render_markdown_for_api_for(:description)
+          }
+        end
 
-                       [item, site_hash]
-                     },
+        [item, site_hash]
+      },
       custom_fields2: {
         # latitude and longitude return obfuscated values for non-owners
         # custom_latitude and custom_longitude are kept for backwards compatibility
@@ -440,15 +552,15 @@ class Site < ApplicationRecord
         }
       },
       new_spec_fields: lambda { |user| # rubocop:disable Lint/UnusedBlockArgument
-                         {
-                           longitude: nil,
-                           latitude: nil,
-                           notes: nil,
-                           image: nil,
-                           tzinfo_tz: nil,
-                           rails_tz: nil
-                         }
-                       },
+        {
+          longitude: nil,
+          latitude: nil,
+          notes: nil,
+          image: nil,
+          tzinfo_tz: nil,
+          rails_tz: nil
+        }
+      },
       controller: :sites,
       action: :filter,
       defaults: {
@@ -500,7 +612,8 @@ class Site < ApplicationRecord
         latitude: { type: ['number', 'null'], minimum: -90, maximum: 90 },
         longitude: { type: ['number', 'null'], minimum: -180, maximum: 180 },
         custom_latitude: { type: ['number', 'null'], minimum: -90, maximum: 90, deprecated: true, read_only: true },
-        custom_longitude: { type: ['number', 'null'], minimum: -180, maximum: 180, deprecated: true, read_only: true },
+        custom_longitude: { type: ['number', 'null'], minimum: -180, maximum: 180, deprecated: true,
+                            read_only: true },
         obfuscated_latitude: { type: ['number', 'null'], minimum: -90, maximum: 90, readOnly: false },
         obfuscated_longitude: { type: ['number', 'null'], minimum: -180, maximum: 180, readOnly: false },
         custom_obfuscated_location: { type: 'boolean' },
@@ -515,5 +628,22 @@ class Site < ApplicationRecord
         :longitude, :timezone_information, :image_urls, :region_id
       ]
     }.freeze
+  end
+
+  private
+
+  # Determines if the obfuscated location should be auto-updated
+  # Only update if:
+  # - The obfuscated location is system-generated (not user-provided), AND
+  # - Either latitude or longitude has changed (for existing records)
+  def should_update_obfuscated_location?
+    # Never auto-update if custom obfuscation is enabled
+    return false if custom_obfuscated_location
+
+    # For new records, always generate if not using custom obfuscation
+    return true if new_record?
+
+    # For existing records, only update if coordinates changed
+    latitude_changed? || longitude_changed?
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -31,8 +31,8 @@ class Tagging < ApplicationRecord
   # relations
   belongs_to :audio_event, inverse_of: :taggings # inverse_of allows CanCan to make permissions work properly
   belongs_to :tag, inverse_of: :taggings # inverse_of allows CanCan to make permissions work properly
-  belongs_to :creator, class_name: 'User', foreign_key: :creator_id, inverse_of: :created_taggings
-  belongs_to :updater, class_name: 'User', foreign_key: :updater_id, inverse_of: :updated_taggings, optional: true
+  belongs_to :creator, class_name: 'User', inverse_of: :created_taggings
+  belongs_to :updater, class_name: 'User', inverse_of: :updated_taggings, optional: true
 
   # accepts_nested_attributes_for :audio_event
   # accepts_nested_attributes_for :tag
@@ -44,11 +44,21 @@ class Tagging < ApplicationRecord
   #validates_associated :creator
 
   # attribute validations
-  validates_uniqueness_of :audio_event_id, scope: [:tag_id],
-    message: 'audio_event_id %<value>s must be unique within tag_id and audio_event_id'
+  validates :audio_event_id,
+    uniqueness: { scope: [:tag_id],
+                  message: 'audio_event_id %<value>s must be unique within tag_id and audio_event_id' }
 
   # postgres-specific
   scope :count_unique, -> { Tagging.select(:tag_id).distinct.count }
+
+  def global_identifier
+    Api::UrlHelpers.global_identifier(
+      :audio_recording_audio_event_tagging_path,
+      audio_recording_id: audio_event.audio_recording_id,
+      audio_event_id: audio_event_id,
+      id: id
+    )
+  end
 
   # Define filter api settings
   def self.filter_settings

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,6 +271,12 @@ class User < ApplicationRecord
       .delete_suffix('-')
   end
 
+  # Returns the full_name of user if available, else falls back to user_name.
+  # If we add names to user profiles, we can return them here.
+  def full_name
+    user_name
+  end
+
   # Get the last time this user was seen.
   # @return [DateTime] Date this user was last seen
   def get_last_seen

--- a/app/modules/api/global_identifiers.rb
+++ b/app/modules/api/global_identifiers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  # A mixin to provide global identifiers for resources using a configured authority and a path.
+  # Included in Api::UrlHelpers::Base.
+  module GlobalIdentifiers
+    # @param method [Symbol] the path helper method to generate the path for the resource
+    # @param [...] arguments to be forwarded to the path helper method
+    # @return [String] the global identifier for the resource, combining the authority and the path
+    # @example
+    #   Api::UrlHelpers.global_identifier(:audio_recording_path, id: 123) # => "example.org/audio_recordings/123"
+    def global_identifier(method, ...)
+      path = send(method, ...)
+      "#{Settings.global_identifiers.authority}#{path}"
+    end
+  end
+end

--- a/app/modules/api/url_helpers.rb
+++ b/app/modules/api/url_helpers.rb
@@ -15,6 +15,7 @@ module Api
       include Rails.application.routes.url_helpers
 
       include Api::CustomUrlHelpers
+      include Api::GlobalIdentifiers
 
       def default_url_options
         Rails.configuration.action_mailer.default_url_options

--- a/app/modules/audio_recording_overlap.rb
+++ b/app/modules/audio_recording_overlap.rb
@@ -17,7 +17,7 @@ class AudioRecordingOverlap
       result = {
         id: audio_recording.id,
         recorded_date: audio_recording.recorded_date,
-        end_date: get_end_date(audio_recording),
+        end_date: audio_recording.recorded_end_date,
         duration_sec: audio_recording.duration_seconds,
         site_id: audio_recording.site_id,
         overlap: {
@@ -67,7 +67,7 @@ class AudioRecordingOverlap
       result = {
         id: audio_recording.id,
         recorded_date: audio_recording.recorded_date,
-        end_date: get_end_date(audio_recording),
+        end_date: audio_recording.recorded_end_date,
         duration_sec: audio_recording.duration_seconds,
         site_id: audio_recording.site_id,
         max_overlap_sec: max_overlap_seconds,
@@ -132,9 +132,9 @@ class AudioRecordingOverlap
       start_b_lt_end_a = audio_recordings_arel[:recorded_date].lt(get_end_date_simple(recorded_date, duration_seconds))
 
       query = AudioRecording
-              .where(site_id:)
-              .where(end_b_gt_start_a)
-              .where(start_b_lt_end_a)
+        .where(site_id:)
+        .where(end_b_gt_start_a)
+        .where(start_b_lt_end_a)
 
       query = query.where(audio_recordings_arel[:id].not_eq(id)) if id.present?
 
@@ -147,10 +147,10 @@ class AudioRecordingOverlap
     # @return [Hash] overlap info
     def get_overlap_info(new_recording, existing_recording, max_overlap_amount)
       recording_new_start = new_recording.recorded_date
-      recording_new_end = get_end_date(new_recording)
+      recording_new_end = new_recording.recorded_end_date
 
       recording_existing_start = existing_recording.recorded_date
-      recording_existing_end = get_end_date(existing_recording)
+      recording_existing_end = existing_recording.recorded_end_date
 
       can_fix = false
 
@@ -214,7 +214,7 @@ class AudioRecordingOverlap
       end
 
       # calculate information needed later
-      earlier_end = get_end_date(earlier)
+      earlier_end = earlier.recorded_end_date
       later_start = later.recorded_date
       overlap_amount = earlier_end - later_start
 
@@ -265,13 +265,6 @@ class AudioRecordingOverlap
         new_duration:,
         other_uuid:
       }
-    end
-
-    # Get the end date for an audio recording.
-    # @param [AudioRecording] audio_recording
-    # @return [ActiveSupport::TimeWithZone] end date
-    def get_end_date(audio_recording)
-      audio_recording.recorded_date.dup.advance(seconds: audio_recording.duration_seconds)
     end
 
     # Get the end date for an audio recording.

--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -330,3 +330,7 @@ client:
   host: localhost
   port: 4000
   protocol: http
+# Used by Api::GlobalIdentifiers, this is a custom authority that we can use to 
+# make global identifiers for resources.
+global_identifiers:
+  authority: "ecosounds.org"

--- a/lib/gems/baw-workers/lib/baw_workers/dry/ordered_struct.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/dry/ordered_struct.rb
@@ -1,0 +1,17 @@
+module BawWorkers
+  module Dry
+    # A Dry::Struct for when ordered attributes are needed.
+    #
+    # Attributes should be defined in the order they are expected to be returned by `ordered_values`.
+    # Used by table resources in Camtrap Data Package exports, where the length and order of CSV row values must match
+    # the table schema's field order for validation.
+    class OrderedStruct < ::Dry::Struct
+      # Return an array of attribute values in schema order, including nil values for optional attributes.
+      # @return [Array]
+      def ordered_values
+        # Use attributes[key.name] over self[key.name] to safely return nil for missing keys, instead of Dry::Struct::MissingAttributeError.
+        self.class.schema.map { |key| attributes[key.name] }
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      DATAPACKAGE_FILENAME = Pathname.new('datapackage.json')
+      OBSERVATIONS_FILENAME = Pathname.new('observations.csv')
+      DEPLOYMENTS_FILENAME = Pathname.new('deployments.csv')
+      MEDIA_FILENAME = Pathname.new('media.csv')
+
+      PACKAGE_PATH = Pathname.new('dp')
+      ZIP_PATH = PACKAGE_PATH.sub_ext('.zip')
+
+      PACKAGE_FILENAMES = {
+        deployments: DEPLOYMENTS_FILENAME,
+        media: MEDIA_FILENAME,
+        observations: OBSERVATIONS_FILENAME,
+        datapackage: DATAPACKAGE_FILENAME
+      }
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/deployment_accumulator.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/deployment_accumulator.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      # Accumulate deployment related metadata for taggings.
+      #
+      # We use Site as a proxy for a deployment, and calculate deployment start and end time based on all audio
+      # recordings at the site, because we don't track deployments in the database.
+      class DeploymentAccumulator
+        # The caller can provide a timezone override. If provided, all timestamps in the export will use this timezone.
+        # You can even provide a custom timezone, e.g.: `ActiveSupport::TimeZone.create('Fixed', 600, TZInfo::Timezone.get('GMT'))`
+        #
+        # @param forced_timezone [ActiveSupport::TimeZone, TZInfo::Timezone, nil] optional timezone
+        def initialize(forced_timezone: nil)
+          @deployments = {}
+
+          if forced_timezone && !(forced_timezone.is_a?(ActiveSupport::TimeZone) || forced_timezone.is_a?(TZInfo::Timezone))
+            raise ArgumentError, "forced_timezone: got #{forced_timezone.class}, expected ActiveSupport::TimeZone or TZInfo::Timezone"
+          end
+
+          @forced_timezone = forced_timezone
+        end
+
+        # Deployment metadata accumulated for a site.
+        #
+        # @!attribute [r] site
+        #   @return [Site]
+        # @!attribute [r] start
+        #   @return [Time] earliest recording start time for the deployment.
+        # @!attribute [r] end
+        #   @return [Time] latest recording end time for the deployment.
+        # @!attribute [r] file_public
+        #   @return [Boolean] whether media files for the deployment are publicly accessible.
+        # @!attribute [r] timezone
+        #   @return [TZInfo::Timezone, ActiveSupport::TimeZone] the timezone to use for timestamps in this deployment
+        Deployment = Data.define(:site, :start, :end, :file_public, :timezone) {
+          # Ensures all times in a deployment are in a uniform Timezone for exporting.
+          #
+          # @param time [Time, ActiveSupport::TimeWithZone, nil] timestamp to export.
+          # @return [Time, ActiveSupport::TimeWithZone, nil] timestamp converted to the deployment's timezone,
+          #   ready for Camtrap-DP ISO 8601 serialization.
+          def ensure_timezone(time)
+            return nil if time.blank?
+
+            time.in_time_zone(timezone)
+          end
+        }
+
+        # Add a deployment for the tagging's site if it doesn't exist. Initialize the deployment's timezone based on the
+        # site's timezone, unless a forced_timezone was provided to the accumulator.
+        #
+        # This isn't a problem now, but it's worth noting: deployments are keyed by site_id, and site is cached the
+        # first time seen. So when using find_each in batches, the same site from a later batch will have a different
+        # object_id than the cached site object.
+        #
+        # @param tagging [Tagging] the tagging for the deployment
+        # @return [Deployment] the new or updated deployment for the tagging's site
+        def add_or_update(tagging)
+          audio_recording = tagging.audio_event.audio_recording
+          @deployments[audio_recording.site_id] ||= build_deployment(audio_recording.site)
+        end
+
+        def values = @deployments.values
+
+        private
+
+        # Build a deployment for a site, calculating the start and end time
+        # based on all audio recordings at the site.
+        # @param site [Site] the site for which to build a deployment
+        # @return [Deployment] the deployment for the site
+        def build_deployment(site)
+          timezone = @forced_timezone || site_timezone(site)
+          recording_bounds = AudioRecording.pick_hash({
+            start: AudioRecording.arel_table[:recorded_date].minimum,
+            end: AudioRecording.arel_recorded_end_date.maximum
+          }, scope: site.audio_recordings)
+
+          Deployment.new(
+            site: site,
+            start: recording_bounds[:start]&.in_time_zone(timezone),
+            end: recording_bounds[:end]&.in_time_zone(timezone),
+            file_public: site.public_site?,
+            timezone: timezone
+          )
+        end
+
+        # @param site [Site] site whose timezone should be used for export timestamps.
+        # @return [TZInfo::Timezone, ActiveSupport::TimeZone] timezone of site or UTC fallback if site has no timezone.
+        def site_timezone(site)
+          return ActiveSupport::TimeZone['UTC'] if site.timezone.blank?
+
+          TimeZoneHelper.tzinfo_class(site.tzinfo_tz)
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/base.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        class Base < ::Dry::Struct
+          Types = BawWorkers::Export::CamtrapDp::Types
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/contributor.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/contributor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/contributors/items
+        class Contributor < Base
+          # name/title of the person or organisation
+          attribute :title, Types::String
+          attribute :role, Types::Role
+
+          attribute? :email, Types::String
+          attribute? :path, Types::Url
+          attribute? :organization, Types::String
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/license.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/license.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/licenses/items
+        class License < Base
+          attribute :name, Types::String
+          attribute? :path, Types::UrlOrPath
+          attribute? :title, Types::String
+          attribute :scope, Types::String.enum('data', 'media')
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/package.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/package.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties
+        class Package < Base
+          attribute :profile, Types::Url
+          attribute :resources, Types::Array.of(Resource)
+          attribute :created, Types::UtcTimeSeconds
+          attribute :contributors, Types::Array.of(Contributor)
+          attribute :project, Project
+          attribute :spatial, Types::GeoJSON
+          attribute :temporal, Temporal
+          attribute :taxonomic, Types::Array.of(Taxonomic)
+
+          attribute? :name, Types::String
+          attribute? :id, Types::String
+          attribute? :title, Types::String
+          attribute? :description, Types::String
+          attribute? :version, Types::String
+          attribute? :keywords, Types::Array.of(Types::String)
+          attribute? :image, Types::String
+          attribute? :homepage, Types::String
+          attribute? :sources, Types::Array.of(Source)
+          attribute? :licenses, Types::Array.of(License)
+          attribute? :bibliographicCitation, Types::String
+          attribute? :coordinatePrecision, Types::Float
+          attribute? :relatedIdentifiers, Types::Array.of(RelatedIdentifier)
+          attribute? :references, Types::Array.of(Types::String)
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/project.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/project.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/project
+        class Project < Base
+          attribute :title, Types::String
+          attribute :samplingDesign, Types::SamplingDesign
+          attribute :captureMethod, Types::Array.of(Types::CaptureMethod)
+          attribute :individualAnimals, Types::Bool.default(false)
+          attribute :observationLevel, Types::Array.of(Types::String.default('media').enum('media', 'event'))
+
+          attribute? :id, Types::String
+          attribute? :acronym, Types::String
+          attribute? :description, Types::String
+          attribute? :path, Types::String
+          attribute? :protocolType, Types::String.default('acoustic').enum('camera-trapping', 'acoustic')
+          attribute? :classificationEffort, Types::String
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/related_identifier.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/related_identifier.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/relatedIdentifiers/items
+        class RelatedIdentifier < Base
+          attribute :relationType, Types::String
+          attribute :relatedIdentifier, Types::String
+          attribute :relatedIdentifierType, Types::String
+          attribute? :resourceTypeGeneral, Types::String
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/resource.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/resource.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/resources/items/oneOf/0
+        class Resource < Base
+          attribute :name, Types::String
+          attribute :path, Types::UrlOrPath
+
+          # The resources in camtrap-dp are tabular-data-resources, so this is a fixed value.
+          attribute :profile, Types::String.default('tabular-data-resource')
+          attribute :format, Types::String.default('csv')
+          attribute :mediatype, Types::String.default('text/csv')
+          attribute :encoding, Types::String.default('utf-8')
+
+          # The raw parsed JSON table schema or url-or-path to the schema
+          attribute :schema, Types::Schema
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/source.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/source.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # Represents a source of the package, e.g. a data source. Can be a data management platform from which the
+        # package was derived.
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/sources/items
+        class Source < Base
+          attribute? :title, Types::String
+          attribute? :path, Types::UrlOrPath
+          attribute? :email, Types::String
+          attribute? :version, Types::String
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/taxonomic.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/taxonomic.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/taxonomic
+        class Taxonomic < Base
+          attribute :scientificName, Types::String
+          attribute? :taxonID, Types::String
+          attribute? :taxonRank, Types::TaxonRank
+          attribute? :kingdom, Types::String
+          attribute? :phylum, Types::String
+          attribute? :class, Types::String
+          attribute? :order, Types::String
+          attribute? :family, Types::String
+          attribute? :genus, Types::String
+          attribute? :vernacularNames, Types::Hash
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/temporal.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/descriptor/temporal.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Descriptor
+        # implements: camtrap-dp-profile-acoustic.json#/allOf/1/properties/temporal
+        class Temporal < Base
+          attribute :start, Types::UtcTimeSeconds
+          attribute :end, Types::UtcTimeSeconds
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/errors/camtrap_dp_error.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/errors/camtrap_dp_error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Errors
+        # Base class for Camtrap DP export errors.
+        class CamtrapDpError < StandardError; end
+
+        class ProjectLicenseError < CamtrapDpError; end
+        class ValidationError < CamtrapDpError; end
+
+        class PackageLoadError < ValidationError; end
+        class DescriptorValidationError < ValidationError; end
+        class CsvValidationError < ValidationError; end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/exporter.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/exporter.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require_relative 'errors/camtrap_dp_error'
+module BawWorkers
+  module Export
+    module CamtrapDp
+      # NOTE: ALA exports will be limited to a single project, enforced upstream, not in this module.
+      # NOTE: :should_obfuscate option is respected by this module; the ability will be enforced in the controller
+      #
+      # The exporter orchestrates a Camtrap Data Package export from a given filter of taggings.
+      # It generates a zip file containing the CSV tables and the datapackage.json file describing the package.
+      class Exporter
+        BATCH_SIZE = 1000
+
+        # Options required to build a complete Camtrap Data Package export.
+        #
+        # @!attribute [r] user
+        #   @return [User, nil] optional user requesting the export, to check permissions against
+        #     (e.g. public_latitude, public_longitude).
+        # @!attribute [r] should_obfuscate
+        #   @return [Boolean, nil] optional, override the default obfuscation behaviour and indicate whether
+        #     or not to obfuscate locations.
+        # @!attribute [r] contributors
+        #   @return [Array<Hash>] descriptor-compatible package contributors.
+        # @!attribute [r] project_capture_method
+        #   @return [Array<String>] project-level Camtrap DP captureMethod values (see Types::CaptureMethod).
+        # @!attribute [r] project_sampling_design
+        #   @return [String] project-level Camtrap DP samplingDesign value (see Types::SamplingDesign).
+        # @!attribute [r] package_title
+        #   @return [String] Optional title for this specific package, different from the project title
+        # @!attribute [r] emit_project_license
+        #   @return [Boolean] whether to include project license metadata in the package descriptor.
+        # @!attribute [r] forced_timezone
+        #   @return [ActiveSupport::TimeZone, TZInfo::Timezone, nil] optional timezone to apply to every
+        #     exported recording, event, deployment, and temporal coverage timestamp. When omitted, each
+        #     deployment uses its site's timezone; sites with no timezone or a zero UTC offset export in UTC.
+        RequiredExporterOptions = Data.define(
+          :user,
+          :should_obfuscate,
+          :contributors,
+          :project_capture_method,
+          :project_sampling_design,
+          :package_title,
+          :emit_project_license,
+          :forced_timezone
+        )
+
+        # @param filter [ActiveRecord::Relation<Tagging>] a filter of taggings to export
+        # @param exporter_options [RequiredExporterOptions] options required to build a complete Camtrap Data Package
+        def initialize(filter, exporter_options)
+          validate_filter(filter)
+          validate_exporter_options(exporter_options)
+
+          @filter = filter
+          @options = exporter_options
+        end
+
+        # Generates the export and yields a manifest of metadata about the generated export to the provided block.
+        #
+        # The manifest's `package_path` points to the directory containing the unpacked Camtrap Data Package, while
+        # `zip_path` points to an archive containing the same files. The parent temporary directory is deleted when the
+        # block returns, so the archive should be copied before then.
+        #
+        # The generated files have this layout:
+        #
+        #   tmp/exporter_<timestamp>-<random>/
+        #   ├── dp/
+        #   │   ├── datapackage.json
+        #   │   ├── deployments.csv
+        #   │   ├── media.csv
+        #   │   └── observations.csv
+        #   └── dp.zip
+        #
+        # @yield [PackageManifest] export metadata:
+        #   - `package_path` [Pathname] directory containing the package files
+        #   - `zip_path` [Pathname] path to the zip archive
+        #   - `file_stats` [Hash<Symbol, Hash>] size and modification time for each package file
+        # @return the result of the block is returned to the caller
+        def call(&block)
+          raise ArgumentError, 'block is required' unless block_given?
+
+          # Bullet doesn't see the associations being used below and wrongly raises an UnoptimizedQueryError:
+          # avoid eager loading.
+          bullet_active = defined?(Bullet) && Bullet.enabled?
+          Bullet.enable = false if bullet_active
+
+          Rails.logger.info('Starting Camtrap DP export')
+          rows_processed = 0
+
+          scientific_names = Set.new
+          audio_recordings = Set.new
+
+          deployments = DeploymentAccumulator.new(forced_timezone: @options.forced_timezone)
+
+          # Using find_each with default batch size to avoid pulling all records into memory at once.
+          included.find_each(batch_size: BATCH_SIZE) do |tagging|
+            deployment = deployments.add_or_update(tagging)
+            first_media = audio_recordings.add?(tagging.audio_event.audio_recording_id)
+
+            observation = Table::Observation.mapping(tagging, deployment)
+            scientific_names << observation.scientificName if observation.scientificName.present?
+            table_writers.observations << observation.ordered_values
+
+            if first_media
+              table_writers.media << Table::Media.mapping(tagging.audio_event.audio_recording,
+                deployment).ordered_values
+            end
+
+            rows_processed += 1
+            Rails.logger.info("Processed #{rows_processed} rows") if rows_processed % BATCH_SIZE == 0
+          end
+
+          raise ArgumentError, 'Filter returned no data, cannot export' if rows_processed.zero?
+
+          write_deployments(table_writers.deployments, deployments.values)
+          package = PackageMetadata.build(
+            deployments: deployments.values,
+            scientific_names: scientific_names,
+            options: @options
+          )
+
+          close_table_writers
+
+          validate_package(package)
+          write_datapackage_file(package)
+
+          manifest = zip_package
+
+          Rails.logger.info('Finished Camtrap DP export')
+
+          result = block.call(manifest)
+          result
+        ensure
+          cleanup
+          Bullet.enable = bullet_active if bullet_active
+        end
+
+        TableWriters = Data.define(:observations, :deployments, :media)
+
+        # @!attribute [r] package_path
+        #   @return [Pathname] path to the directory containing the unpacked Camtrap Data Package
+        # @!attribute [r] zip_path
+        #   @return [Pathname] path to the zip archive containing the Camtrap Data Package
+        # @!attribute [r] file_stats
+        #   @return [Hash<Symbol, Hash>] size and modification time for each package file
+        PackageManifest = Data.define(:package_path, :zip_path, :file_stats)
+
+        private
+
+        def validate_filter(filter)
+          message = 'Expected filter to be '
+          raise ArgumentError, "#{message}ActiveRecord::Relation" unless filter.is_a?(::ActiveRecord::Relation)
+          raise ArgumentError, "#{message}Tagging relation" unless filter.klass == Tagging
+        end
+
+        def validate_exporter_options(exporter_options)
+          return if exporter_options.is_a?(RequiredExporterOptions)
+
+          raise ArgumentError, 'exporter_options must be a RequiredExporterOptions object'
+        end
+
+        # Eager load audio_events because each audio_event usually has one tagging, so a join avoids
+        # repeated queries, and audio_event columns are mostly small scalars, so the joined rows stay cheap.
+        # Then preload recording and site to avoid duplicating their larger JSON blobs across tagging rows.
+        def included
+          @filter
+            .eager_load(:audio_event)
+            .preload(:tag, :creator, audio_event: [:provenance, { audio_recording: :site }])
+        end
+
+        # @param writer [CSV] a CSV writer for the deployments table
+        # @param deployments [Array<DeploymentAccumulator::Deployment>] the deployments to write
+        # @return [void]
+        def write_deployments(writer, deployments)
+          deployments.each do |deployment|
+            writer << Table::Deployment.mapping(deployment, user: @options.user,
+              should_obfuscate: @options.should_obfuscate).ordered_values
+          end
+        end
+
+        # @param package [Descriptor::Package] the package descriptor to write
+        # @return [void]
+        def write_datapackage_file(package)
+          package_files[:datapackage].write(JSON.pretty_generate(package.to_h))
+        end
+
+        def validate_package(package)
+          Validator.validate_package(package, package_path:)
+        end
+
+        def table_writers
+          @table_writers ||= TableWriters.new(
+            observations: open_table_csv(package_files[:observations], headers: Table::Observation.attribute_names),
+            deployments: open_table_csv(package_files[:deployments], headers: Table::Deployment.attribute_names),
+            media: open_table_csv(package_files[:media], headers: Table::Media.attribute_names)
+          )
+        end
+
+        # @return [CSV] an open CSV IO object in write-only mode
+        def open_table_csv(path, headers:)
+          CSV.open(path, 'w', write_headers: true, headers: headers, force_quotes: true)
+        end
+
+        def close_table_writers
+          return if @table_writers.nil?
+
+          @table_writers.deconstruct.each { |writer| writer.close unless writer.nil? || writer.closed? }
+        end
+
+        def exporter_temp_dir
+          @exporter_temp_dir ||= Pathname.new(Dir.mktmpdir('exporter_', BawWorkers::Config.temp_dir))
+        end
+
+        def package_path
+          @package_path ||= (exporter_temp_dir / PACKAGE_PATH).mkpath
+        end
+
+        def package_files
+          @package_files ||= PACKAGE_FILENAMES.transform_values { |filename| package_path / filename }
+        end
+
+        def zip_path
+          @zip_path ||= exporter_temp_dir / ZIP_PATH
+        end
+
+        # Create a zip archive of the package files and return a manifest of metadata about the generated export.
+        # Uses Zlib::DEFAULT_COMPRESSION which is equivalent to a 6 (valid values from 0 to 9).
+        # @return [PackageManifest]
+        def zip_package
+          Zip::File.open(zip_path, create: true) do |zip|
+            package_files.each_value { |path| zip.add(path.basename.to_s, path) }
+          end
+
+          PackageManifest.new(
+            package_path: package_path,
+            zip_path: zip_path,
+            file_stats: package_files.transform_values { |path| { size: path.size, mtime: path.mtime } }
+          )
+        end
+
+        def cleanup
+          close_table_writers
+          FileUtils.rm_rf(@exporter_temp_dir) if @exporter_temp_dir&.exist?
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/package_metadata.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/package_metadata.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require_relative 'errors/camtrap_dp_error'
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      # Responsible for generating the package descriptor and associated metadata including spatial, temporal, and
+      # taxonomic coverage.
+      class PackageMetadata
+        # @param deployments [Array<DeploymentAccumulator::Deployment>] the deployments included in the package
+        # @param scientific_names [Array<String>] the scientific names included in the package
+        # @param options [ExportOptions] the export options
+        # @return [Descriptor::Package] the package descriptor
+        def self.build(deployments:, scientific_names:, options:)
+          temporal = temporal_coverage(deployments)
+          project = get_project(deployments)
+          licenses = options.emit_project_license ? project_license(project) : nil
+
+          project = Descriptor::Project.new(
+            title: project.name,
+            description: project.description,
+            path: Api::UrlHelpers.project_url(id: project.id),
+            samplingDesign: options.project_sampling_design,
+            captureMethod: options.project_capture_method,
+            individualAnimals: individual_animals,
+            observationLevel: observation_level,
+            licenses: licenses
+          )
+
+          # TODO: fill name and id fields when closed: https://github.com/QutEcoacoustics/baw-server/issues/1021
+          # TODO: add generated contributors when closed: https://github.com/QutEcoacoustics/baw-server/issues/1022
+          Descriptor::Package.new(
+            profile: Profile::PROFILE_SOURCE_URL.to_s,
+            #name:,
+            #id:,
+            created: Time.current.utc.iso8601,
+            title: options.package_title,
+            contributors: options.contributors,
+            project: project,
+            spatial: spatial_coverage(deployments, options),
+            temporal: Descriptor::Temporal.new(
+              start: temporal[:start],
+              end: temporal[:end]
+            ),
+            taxonomic: taxonomic_coverage(scientific_names),
+            sources: sources,
+            resources: [
+              BawWorkers::Export::CamtrapDp::Descriptor::Resource.new(name: 'deployments', path: DEPLOYMENTS_FILENAME.to_s,
+                schema: load_table_schema(:deployments)),
+              BawWorkers::Export::CamtrapDp::Descriptor::Resource.new(name: 'media', path: MEDIA_FILENAME.to_s,
+                schema: load_table_schema(:media)),
+              BawWorkers::Export::CamtrapDp::Descriptor::Resource.new(name: 'observations', path: OBSERVATIONS_FILENAME.to_s,
+                schema: load_table_schema(:observations))
+            ]
+          )
+        end
+
+        def self.load_table_schema(name)
+          path = Profile::DIRECTORY / Profile::ASSET_FILES[name]
+          JSON.parse(path.read, symbolize_names: true)
+        end
+
+        # Use the host name and client URL as a package source.
+        def self.sources
+          [Descriptor::Source.new(title: Settings.client.host.titlecase, path: Settings.client_routes.home_url)]
+        end
+
+        # We don't support identifying individual animals currently, so this will always be false. In future, if we
+        # add a platform feature to support this, we can make this configurable.
+        def self.individual_animals = false
+
+        # We don't distinguish currently, so default to media. In the future, we might be able to merge our 'media'
+        # observations (audio_events) into an 'event' observation level, to reduce duplication.
+        def self.observation_level = ['media']
+
+        # Return the first project in the deployments, under the assumption packages are scoped to a single project.
+        # @param deployments [Array<DeploymentAccumulator::Deployment>]
+        # @return [Project]
+        def self.get_project(deployments)
+          deployments.first&.site&.projects&.first
+        end
+
+        # Generate the licenses descriptor from the first project found
+        #
+        # In the database, existing project licenses are SPDX identifiers. But it's currently a free text field, so we
+        # will use string length as a proxy for being an identifier, and raise an error if we encounter something longer
+        # than 32 characters. We only store one license per project, so we use the same license for both required
+        # scopes: data and media.
+        def self.project_license(project)
+          project_license = project&.license
+
+          if project_license.nil?
+            nil
+          elsif project_license.length <= 32
+            [Descriptor::License.new(name: project_license, scope: 'data'),
+             Descriptor::License.new(name: project_license, scope: 'media')]
+          else
+            raise Errors::ProjectLicenseError, "Found unsupported custom license (>32 chars): #{project_license}"
+          end
+        end
+
+        # Calculate descriptor-level temporal coverage from the deployment bounds.
+        #
+        # Rails TimeWithZone comparisons are based on the UTC instant, but the offset is preserved in the output, so
+        # it's possible to have a start / end in different timezones.
+        #
+        # @param deployments [Array<DeploymentAccumulator::Deployment>]
+        # @return [Hash] with `:start` and `:end` keys containing ISO 8601 timestamps
+        def self.temporal_coverage(deployments)
+          return { start: '', end: '' } if deployments.empty?
+
+          {
+            start: deployments.map(&:start).min,
+            end: deployments.map(&:end).max
+          }
+        end
+
+        def self.spatial_coverage(deployments, options)
+          return {} if deployments.empty?
+
+          coords = deployments.map { |deployment|
+            site = deployment.site
+            lat = site.public_latitude(user: options.user, should_obfuscate: options.should_obfuscate)
+            lon = site.public_longitude(user: options.user, should_obfuscate: options.should_obfuscate)
+            [lon, lat]
+          }
+
+          return { type: 'Point', coordinates: coords.first } if coords.size == 1
+
+          lons = coords.map(&:first)
+          lats = coords.map(&:last)
+          min_lon, max_lon = lons.minmax
+          min_lat, max_lat = lats.minmax
+
+          if has_zero_area?(min_lon, max_lon, min_lat, max_lat)
+            { type: 'MultiPoint', coordinates: coords.uniq }
+          else
+            {
+              type: 'Polygon',
+              coordinates: [[
+                [min_lon, min_lat],
+                [max_lon, min_lat],
+                [max_lon, max_lat],
+                [min_lon, max_lat],
+                [min_lon, min_lat]
+              ]]
+            }
+          end
+        end
+
+        def self.has_zero_area?(min_lon, max_lon, min_lat, max_lat)
+          min_lon == max_lon || min_lat == max_lat
+        end
+
+        def self.taxonomic_coverage(scientific_names)
+          scientific_names.sort.map { |name| Descriptor::Taxonomic.new(scientificName: name) }
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Profile
+        SOURCE_URL = 'https://raw.githubusercontent.com/camera-traps/bioacoustics/e4b4722fb453f5ca39c39ea3c4f348e9953f0084/camtrap-dp/1.0.2/'
+        ASSET_FILES = {
+          profile: 'camtrap-dp-profile-acoustic.json',
+          deployments: 'deployments-table-schema-acoustic.json',
+          media: 'media-table-schema-acoustic.json',
+          observations: 'observations-table-schema-acoustic.json'
+        }
+
+        DIRECTORY = Pathname(__dir__) / 'profile_assets'
+        README_PATH = DIRECTORY / 'README.md'
+        PROFILE_PATH = DIRECTORY / ASSET_FILES[:profile]
+        LOCAL_VALIDATION_PROFILE_PATH = PROFILE_PATH.sub_ext('.local.json')
+
+        # Used in the output package descriptor to indicate the profile used for validation.
+        PROFILE_SOURCE_URL = URI.join(SOURCE_URL, ASSET_FILES[:profile])
+
+        # References in the camtrap-dp-profile-acoustic.json to be resolved
+        EXTERNAL_SCHEMA_REFS = [
+          'http://json.schemastore.org/geojson.json',
+          'https://specs.frictionlessdata.io/schemas/data-package.json',
+          'https://geojson.org/schema/GeoJSON.json'
+        ]
+
+        # Download the Profile::ASSET_FILES into the Profile::DIRECTORY
+        # @return [Hash] manifest including the downloaded assets with their local paths.
+        def self.download
+          FileUtils.mkdir_p(DIRECTORY)
+
+          ASSET_FILES.each_with_object({}) do |(key, value), hash|
+            hash[key] = download_fixture(value)
+          end => downloaded_assets
+
+          {
+            source_url: SOURCE_URL,
+            downloaded_assets: downloaded_assets,
+            completed_at: Time.current
+          }
+        end
+
+        # Download files from Profile::SOURCE_URL into the Profile::DIRECTORY.
+        # @param name [String] the filename to download; a value in Profile::ASSET_FILES
+        # @return [String] the file path of the downloaded file relative to the application root
+        def self.download_fixture(name)
+          data = URI.open(URI.join(SOURCE_URL, name)).read
+          path = DIRECTORY / name
+          path.write(data)
+          path.relative_path_from(BawApp.root).to_s
+        end
+
+        # Create a local version of the profile with known external $ref schemas inlined, for use in tests without network access.
+        # The return manifest includes whether each reference was successfully inlined, which can be used to detect
+        # profile changes that require an update to EXTERNAL_SCHEMA_REFS.
+        def self.create_local_validation_profile
+          root_profile = JSON.parse(PROFILE_PATH.read, symbolize_names: false)
+
+          # Fetch the external schemas in EXTERNAL_SCHEMA_REFS and store them in a hash keyed by their URI, with the
+          # $schema field removed since it can cause JSON validation issues in the DataPackage gem.
+          resolved_refs = EXTERNAL_SCHEMA_REFS.index_with { |ref|
+            JSON.parse(URI.open(ref).read, symbolize_names: false)
+          }
+          resolved_refs.each_value { |schema| schema.delete('$schema') }
+
+          successfully_inlined = {}
+          inlined_profile = inline_known_refs(root_profile, resolved_refs) { |ref| successfully_inlined[ref] = true }
+          inlined_profile.delete('$schema')
+
+          LOCAL_VALIDATION_PROFILE_PATH.write(JSON.pretty_generate(inlined_profile))
+          {
+            local_validation_profile: LOCAL_VALIDATION_PROFILE_PATH.relative_path_from(BawApp.root).to_s,
+            external_references_inlined: successfully_inlined,
+            completed_at: Time.current
+          }
+        end
+
+        # Recursively traverse the profile and inline any $ref's that match a key in resolved_refs, replacing it with
+        # the corresponding value.
+        #
+        # @param value [Object] the current value to check for $ref; can be a Hash, Array, or other
+        # @param resolved_refs [Hash] a hash of known $ref URIs to their resolved schema objects
+        # @return [Hash] the profile with known $ref values inlined
+        # @yield [ref] an optional block that is called with each successfully inlined $ref URI
+        def self.inline_known_refs(value, resolved_refs, &block)
+          # If the value is a hash, check if it has a $ref key that matches a key in resolved_refs
+          if value.is_a?(Hash) && value.key?('$ref') && resolved_refs.key?(value['$ref'])
+            fetched = resolved_refs.fetch(value['$ref'])
+            if fetched
+              yield value['$ref'] if block_given?
+              return inline_known_refs(fetched, resolved_refs, &block)
+            end
+          end
+
+          return value.transform_values { |child| inline_known_refs(child, resolved_refs, &block) } if value.is_a?(Hash)
+          return value.map { |child| inline_known_refs(child, resolved_refs, &block) } if value.is_a?(Array)
+
+          value
+        end
+
+        def self.build_readme(download_result, validation_result)
+          assets = download_result[:downloaded_assets]
+          local_profile = validation_result[:local_validation_profile]
+          references = validation_result[:external_references_inlined].keys.map { |reference|
+            "  - #{reference}"
+          }.join("\n")
+
+          <<~MARKDOWN
+            # CamTrap DP Bioacoustics Downloaded profile assets
+
+            The files in this directory (including this readme) are generated with the `baw:camtrap_dp:update` rake task. Do not edit these files manually.
+
+            Generation date: #{Time.current.utc.strftime('%Y-%m-%d %H:%M:%S UTC')}
+            Source: #{SOURCE_URL}
+
+            ---
+
+            ## Downloaded profile assets
+
+            - Profile: ./#{Pathname(assets[:profile]).basename}
+            - Deployments: ./#{Pathname(assets[:deployments]).basename}
+            - Media: ./#{Pathname(assets[:media]).basename}
+            - Observations: ./#{Pathname(assets[:observations]).basename}
+
+            ## Local validation profile
+
+            - Profile: ./#{Pathname(local_profile).basename}
+            - External references inlined:
+            #{references}
+          MARKDOWN
+        end
+
+        def self.write_readme(readme)
+          File.write(README_PATH, readme)
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/README.md
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/README.md
@@ -1,0 +1,23 @@
+# CamTrap DP Bioacoustics Downloaded profile assets
+
+The files in this directory (including this readme) are generated with the `baw:camtrap_dp:update` rake task. Do not edit these files manually.
+
+Generation date: 2026-07-29 06:40:48 UTC
+Source: https://raw.githubusercontent.com/camera-traps/bioacoustics/e4b4722fb453f5ca39c39ea3c4f348e9953f0084/camtrap-dp/1.0.2/
+
+---
+
+## Downloaded profile assets
+
+- Profile: ./camtrap-dp-profile-acoustic.json
+- Deployments: ./deployments-table-schema-acoustic.json
+- Media: ./media-table-schema-acoustic.json
+- Observations: ./observations-table-schema-acoustic.json
+
+## Local validation profile
+
+- Profile: ./camtrap-dp-profile-acoustic.local.json
+- External references inlined:
+  - https://specs.frictionlessdata.io/schemas/data-package.json
+  - http://json.schemastore.org/geojson.json
+  - https://geojson.org/schema/GeoJSON.json

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/camtrap-dp-profile-acoustic.json
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/camtrap-dp-profile-acoustic.json
@@ -1,0 +1,501 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Camera Trap Data Package",
+  "description": "Data exchange format for camera trap data. <https://camtrap-dp.tdwg.org>",
+  "type": "object",
+  "$defs": {
+    "version": {
+      "pattern": "1\\.0\\.1"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://specs.frictionlessdata.io/schemas/data-package.json"
+    },
+    {
+      "required": [
+        "resources",
+        "profile",
+        "created",
+        "contributors",
+        "project",
+        "spatial",
+        "temporal",
+        "taxonomic"
+      ],
+      "properties": {
+        "resources": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#resource-information). Camtrap DP further requires each object to be a [Tabular Data Resource](https://specs.frictionlessdata.io/tabular-data-resource/) with a specific `name` and `schema`. See [Data](https://camtrap-dp.tdwg.org/data) for the requirements for those resources.",
+          "minItems": 3,
+          "items": {
+            "oneOf": [
+              {
+                "required": [
+                  "name",
+                  "path",
+                  "profile",
+                  "schema"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Identifier of the resource.",
+                    "enum": [
+                      "deployments",
+                      "media",
+                      "observations"
+                    ]
+                  },
+                  "path": {
+                    "description": "Path or URL to the data file."
+                  },
+                  "profile": {
+                    "description": "[Profile](https://specs.frictionlessdata.io/profiles/) of the resource.",
+                    "enum": [
+                      "tabular-data-resource"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "not": {
+                      "enum": [
+                        "deployments",
+                        "media",
+                        "observations"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "profile": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#profile). Camtrap DP further requires this to be the URL of the used Camtrap DP Profile version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/camtrap-dp-profile.json`).",
+          "format": "uri"
+        },
+        "name": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#name)."
+        },
+        "id": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#id)."
+        },
+        "created": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#created). Camtrap DP makes this a required property."
+        },
+        "title": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#title). Not to be confused with the title of the project that originated the package (`package.project.title`)."
+        },
+        "contributors": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#contributors). Camtrap DP makes this a required property and restricts `role` values. Can include people and organizations.",
+          "items": {
+            "properties": {
+              "role": {
+                "description": "Role of the contributor. Defaults to `contributor`.",
+                "enum": [
+                  "contact",
+                  "principalInvestigator",
+                  "rightsHolder",
+                  "publisher",
+                  "contributor"
+                ]
+              }
+            }
+          }
+        },
+        "description": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#description). Not to be confused with the description of the project that originated the package (`package.project.description`)."
+        },
+        "version": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#version)."
+        },
+        "keywords": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#keywords)."
+        },
+        "image": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#image)."
+        },
+        "homepage": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#homepage)."
+        },
+        "sources": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#sources). Can include the data management platform from which the package was derived (e.g. Agouti, Trapper, Wildlife Insights).",
+          "items": {
+            "properties": {
+              "version": {
+                "description": "Version of the source.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "licenses": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#licenses). If provided, Camtrap DP further requires at least a license for the content of the package and one for the media files.",
+          "minItems": 2,
+          "items": {
+            "required": [
+              "scope"
+            ],
+            "properties": {
+              "scope": {
+                "description": "Scope of the license. `data` applies to the content of the package and resources, `media` to the (locally or externally hosted) media files referenced in `media.filePath`.",
+                "type": "string",
+                "enum": [
+                  "data",
+                  "media"
+                ]
+              }
+            }
+          }
+        },
+        "bibliographicCitation": {
+          "description": "Bibliographic/recommended citation for the package.",
+          "skos:exactMatch": "http://purl.org/dc/terms/bibliographicCitation",
+          "type": "string"
+        },
+        "project": {
+          "description": "Camera trap project or study that originated the package.",
+          "type": "object",
+          "required": [
+            "title",
+            "samplingDesign",
+            "captureMethod",
+            "individualAnimals",
+            "observationLevel"
+          ],
+          "properties": {
+            "id": {
+              "description": "Unique identifier of the project.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Title of the project. Not to be confused with the title of the package (`package.title`).",
+              "type": "string"
+            },
+            "acronym": {
+              "description": "Project acronym.",
+              "type": "string"
+            },
+            "description": {
+              "description": "Description of the project. Preferably formatted as [Markdown](http://commonmark.org/). Not to be confused with the description of the package (`package.description`).",
+              "type": "string"
+            },
+            "path": {
+              "description": "Project website.",
+              "type": "string",
+              "format": "uri"
+            },
+            "protocolType": {
+              "description": "Recording type.",
+              "type": "string",
+              "enum": [
+                "camera-trapping",
+                "acoustic"
+              ]
+            },
+            "samplingDesign": {
+              "description": "Type of a sampling design/layout. The values are based on [Wearn & Glover-Kapfer (2017)](https://doi.org/10.13140/RG.2.2.23409.17767), pages 80-82: `simple random`: random distribution of sampling locations; `systematic random`: random distribution of sampling locations, but arranged in a regular pattern; `clustered random`: random distribution of sampling locations, but clustered in arrays; `experimental`: non-random distribution aimed to study an effect, including the before-after control-impact (BACI) design; `targeted`: non-random distribution optimized for capturing specific target species (often using various bait types); `opportunistic`: opportunistic camera trapping (usually with a small number of cameras).",
+              "skos:broadMatch": "http://rs.tdwg.org/eco/terms/inventoryTypes",
+              "type": "string",
+              "enum": [
+                "simpleRandom",
+                "systematicRandom",
+                "clusteredRandom",
+                "experimental",
+                "targeted",
+                "opportunistic"
+              ]
+            },
+            "captureMethod": {
+              "description": "Method(s) used to capture the media files.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "activityDetection",
+                  "continuous",
+                  "recordingSchedule"
+                ]
+              },
+              "uniqueItems": true,
+              "minItems": 1
+            },
+            "classificationEffort": {
+              "description": "To what extent the media have been classified.",
+              "type": "string"
+            },
+            "individualAnimals": {
+              "description": "`true` if the project includes marked or recognizable individuals. See also `observations.individualID`.",
+              "type": "boolean"
+            },
+            "observationLevel": {
+              "description": "Level at which observations are provided. See also `observations.observationLevel`.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "media",
+                  "event"
+                ]
+              }
+            }
+          }
+        },
+        "coordinatePrecision": {
+          "description": "Least precise coordinate precision of the `deployments.latitude` and `deployments.longitude` (e.g. `0.01` for coordinates with a precision of 0.01 and 0.001 degree). Especially relevant when coordinates have been rounded to protect sensitive species.",
+          "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/coordinatePrecision",
+          "type": "number",
+          "example": 0.001
+        },
+        "spatial": {
+          "description": "Spatial coverage of the package, expressed as GeoJSON.",
+          "skos:exactMatch": "http://purl.org/dc/terms/spatial",
+          "type": "object",
+          "$ref": "http://json.schemastore.org/geojson.json"
+        },
+        "temporal": {
+          "description": "Temporal coverage of the package.",
+          "skos:exactMatch": "http://purl.org/dc/terms/temporal",
+          "type": "object",
+          "required": [
+            "start",
+            "end"
+          ],
+          "properties": {
+            "start": {
+              "description": "Start date of the first deployment. Formatted as an ISO 8601 string (`YYYY-MM-DD`).",
+              "type": "string",
+              "format": "date"
+            },
+            "end": {
+              "description": "End date of the last (completed) deployment. Formatted as an ISO 8601 string (`YYYY-MM-DD`).",
+              "type": "string",
+              "format": "date"
+            }
+          }
+        },
+        "taxonomic": {
+          "description": "Taxonomic coverage of the package, based on the unique `observations.scientificName`.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "scientificName"
+            ],
+            "properties": {
+              "scientificName": {
+                "description": "Scientific name of the taxon.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/scientificName",
+                "type": "string",
+                "example": "Canis lupus"
+              },
+              "taxonID": {
+                "description": "Unique identifier of the taxon. Preferably a global unique identifier issued by an authoritative checklist.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/taxonID",
+                "type": "string",
+                "example": "https://www.checklistbank.org/dataset/COL2023/taxon/QLXL"
+              },
+              "taxonRank": {
+                "description": "Taxonomic rank of the scientific name.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/taxonRank",
+                "type": "string",
+                "enum": [
+                  "kingdom",
+                  "phylum",
+                  "class",
+                  "order",
+                  "family",
+                  "genus",
+                  "species",
+                  "subspecies"
+                ],
+                "example": "species"
+              },
+              "kingdom": {
+                "description": "Kingdom in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/kingdom",
+                "type": "string",
+                "example": "Animalia"
+              },
+              "phylum": {
+                "description": "Phylum or division in which the taxon is classified",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/phylum",
+                "type": "string",
+                "example": "Chordata"
+              },
+              "class": {
+                "description": "Class in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/class",
+                "type": "string",
+                "example": "Mammalia"
+              },
+              "order": {
+                "description": "Order in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/order",
+                "type": "string",
+                "example": "Carnivora"
+              },
+              "family": {
+                "description": "Family in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/family",
+                "type": "string",
+                "example": "Canidae"
+              },
+              "genus": {
+                "description": "Genus in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/genus",
+                "type": "string",
+                "example": "Canis"
+              },
+              "vernacularNames": {
+                "description": "Common or vernacular names of the taxon, as `languageCode: vernacular name` pairs. Language codes should follow ISO 693-3 (e.g. `eng` for English).",
+                "type": "object",
+                "patternProperties": {
+                  "^[a-z]{3}$": {
+                    "description": "Common or vernacular name of the taxon in that language.",
+                    "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/vernacularName",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "example": "{'eng': 'wolf', 'fra': 'loup gris'}"
+              }
+            }
+          }
+        },
+        "relatedIdentifiers": {
+          "description": "Identifiers of resources related to the package (e.g. papers, project pages, derived datasets, APIs, etc.).",
+          "type": "array",
+          "items": {
+            "description": "Related identifier.",
+            "required": [
+              "relationType",
+              "relatedIdentifier",
+              "relatedIdentifierType"
+            ],
+            "properties": {
+              "relationType": {
+                "description": "Description of the relationship between the resource (the package) and the related resource.",
+                "skos:exactMatch": "https://schema.datacite.org/meta/kernel-4.4/include/datacite-relationType-v4.xsd",
+                "type": "string",
+                "enum": [
+                  "IsCitedBy",
+                  "Cites",
+                  "IsSupplementTo",
+                  "IsSupplementedBy",
+                  "IsContinuedBy",
+                  "Continues",
+                  "IsNewVersionOf",
+                  "IsPreviousVersionOf",
+                  "IsPartOf",
+                  "HasPart",
+                  "IsPublishedIn",
+                  "IsReferencedBy",
+                  "References",
+                  "IsDocumentedBy",
+                  "Documents",
+                  "IsCompiledBy",
+                  "Compiles",
+                  "IsVariantFormOf",
+                  "IsOriginalFormOf",
+                  "IsIdenticalTo",
+                  "HasMetadata",
+                  "IsMetadataFor",
+                  "Reviews",
+                  "IsReviewedBy",
+                  "IsDerivedFrom",
+                  "IsSourceOf",
+                  "Describes",
+                  "IsDescribedBy",
+                  "HasVersion",
+                  "IsVersionOf",
+                  "Requires",
+                  "IsRequiredBy",
+                  "Obsoletes",
+                  "IsObsoletedBy"
+                ]
+              },
+              "relatedIdentifier": {
+                "description": "Unique identifier of the related resource (e.g. a DOI or URL).",
+                "type": "string"
+              },
+              "resourceTypeGeneral": {
+                "description": "General type of the related resource.",
+                "skos:exactMatch": "https://schema.datacite.org/meta/kernel-4.4/include/datacite-resourceType-v4.xsd",
+                "type": "string",
+                "enum": [
+                  "Audiovisual",
+                  "Book",
+                  "BookChapter",
+                  "Collection",
+                  "ComputationalNotebook",
+                  "ConferencePaper",
+                  "ConferenceProceeding",
+                  "DataPaper",
+                  "Dataset",
+                  "Dissertation",
+                  "Event",
+                  "Image",
+                  "InteractiveResource",
+                  "Journal",
+                  "JournalArticle",
+                  "Model",
+                  "OutputManagementPlan",
+                  "PeerReview",
+                  "PhysicalObject",
+                  "Preprint",
+                  "Report",
+                  "Service",
+                  "Software",
+                  "Sound",
+                  "Standard",
+                  "Text",
+                  "Workflow",
+                  "Other"
+                ]
+              },
+              "relatedIdentifierType": {
+                "description": "Type of the `RelatedIdentifier`.",
+                "skos:exactMatch": "https://schema.datacite.org/meta/kernel-4.4/include/datacite-relatedIdentifierType-v4.xsd",
+                "type": "string",
+                "enum": [
+                  "ARK",
+                  "arXiv",
+                  "bibcode",
+                  "DOI",
+                  "EAN13",
+                  "EISSN",
+                  "Handle",
+                  "IGSN",
+                  "ISBN",
+                  "ISSN",
+                  "ISTC",
+                  "LISSN",
+                  "LSID",
+                  "PMID",
+                  "PURL",
+                  "UPC",
+                  "URL",
+                  "URN",
+                  "w3id"
+                ]
+              }
+            }
+          }
+        },
+        "references": {
+          "description": "List of references related to the package (e.g. references cited in `package.project.description`). References preferably include a DOI.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/camtrap-dp-profile-acoustic.local.json
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/camtrap-dp-profile-acoustic.local.json
@@ -1,0 +1,2559 @@
+{
+  "title": "Camera Trap Data Package",
+  "description": "Data exchange format for camera trap data. <https://camtrap-dp.tdwg.org>",
+  "type": "object",
+  "$defs": {
+    "version": {
+      "pattern": "1\\.0\\.1"
+    }
+  },
+  "allOf": [
+    {
+      "title": "Data Package",
+      "description": "Data Package is a simple specification for data access and delivery.",
+      "type": "object",
+      "required": [
+        "resources"
+      ],
+      "properties": {
+        "profile": {
+          "default": "data-package",
+          "propertyOrder": 10,
+          "title": "Profile",
+          "description": "The profile of this descriptor.",
+          "context": "Every Package and Resource descriptor has a profile. The default profile, if none is declared, is `data-package` for Package and `data-resource` for Resource.",
+          "type": "string",
+          "examples": [
+            "{\n  \"profile\": \"tabular-data-package\"\n}\n",
+            "{\n  \"profile\": \"http://example.com/my-profiles-json-schema.json\"\n}\n"
+          ]
+        },
+        "name": {
+          "propertyOrder": 20,
+          "title": "Name",
+          "description": "An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.",
+          "type": "string",
+          "pattern": "^([-a-z0-9._/])+$",
+          "context": "This is ideally a url-usable and human-readable name. Name `SHOULD` be invariant, meaning it `SHOULD NOT` change when its parent descriptor is updated.",
+          "examples": [
+            "{\n  \"name\": \"my-nice-name\"\n}\n"
+          ]
+        },
+        "id": {
+          "propertyOrder": 30,
+          "title": "ID",
+          "description": "A property reserved for globally unique identifiers. Examples of identifiers that are unique include UUIDs and DOIs.",
+          "context": "A common usage pattern for Data Packages is as a packaging format within the bounds of a system or platform. In these cases, a unique identifier for a package is desired for common data handling workflows, such as updating an existing package. While at the level of the specification, global uniqueness cannot be validated, consumers using the `id` property `MUST` ensure identifiers are globally unique.",
+          "type": "string",
+          "examples": [
+            "{\n  \"id\": \"b03ec84-77fd-4270-813b-0c698943f7ce\"\n}\n",
+            "{\n  \"id\": \"http://dx.doi.org/10.1594/PANGAEA.726855\"\n}\n"
+          ]
+        },
+        "title": {
+          "propertyOrder": 40,
+          "title": "Title",
+          "description": "A human-readable title.",
+          "type": "string",
+          "examples": [
+            "{\n  \"title\": \"My Package Title\"\n}\n"
+          ]
+        },
+        "description": {
+          "propertyOrder": 50,
+          "format": "textarea",
+          "title": "Description",
+          "description": "A text description. Markdown is encouraged.",
+          "type": "string",
+          "examples": [
+            "{\n  \"description\": \"# My Package description\\nAll about my package.\"\n}\n"
+          ]
+        },
+        "homepage": {
+          "propertyOrder": 60,
+          "title": "Home Page",
+          "description": "The home on the web that is related to this data package.",
+          "type": "string",
+          "format": "uri",
+          "examples": [
+            "{\n  \"homepage\": \"http://example.com/\"\n}\n"
+          ]
+        },
+        "created": {
+          "propertyOrder": 70,
+          "title": "Created",
+          "description": "The datetime on which this descriptor was created.",
+          "context": "The datetime must conform to the string formats for datetime as described in [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6)",
+          "type": "string",
+          "format": "date-time",
+          "examples": [
+            "{\n  \"created\": \"1985-04-12T23:20:50.52Z\"\n}\n"
+          ]
+        },
+        "contributors": {
+          "propertyOrder": 80,
+          "title": "Contributors",
+          "description": "The contributors to this descriptor.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Contributor",
+            "description": "A contributor to this descriptor.",
+            "properties": {
+              "title": {
+                "title": "Title",
+                "description": "A human-readable title.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"title\": \"My Package Title\"\n}\n"
+                ]
+              },
+              "path": {
+                "title": "Path",
+                "description": "A fully qualified URL, or a POSIX file path.",
+                "type": "string",
+                "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                "examples": [
+                  "{\n  \"path\": \"file.csv\"\n}\n",
+                  "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                ],
+                "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+              },
+              "email": {
+                "title": "Email",
+                "description": "An email address.",
+                "type": "string",
+                "format": "email",
+                "examples": [
+                  "{\n  \"email\": \"example@example.com\"\n}\n"
+                ]
+              },
+              "organization": {
+                "title": "Organization",
+                "description": "An organizational affiliation for this contributor.",
+                "type": "string"
+              },
+              "role": {
+                "type": "string",
+                "default": "contributor"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "context": "Use of this property does not imply that the person was the original creator of, or a contributor to, the data in the descriptor, but refers to the composition of the descriptor itself."
+          },
+          "examples": [
+            "{\n  \"contributors\": [\n    {\n      \"title\": \"Joe Bloggs\"\n    }\n  ]\n}\n",
+            "{\n  \"contributors\": [\n    {\n      \"title\": \"Joe Bloggs\",\n      \"email\": \"joe@example.com\",\n      \"role\": \"author\"\n    }\n  ]\n}\n"
+          ]
+        },
+        "keywords": {
+          "propertyOrder": 90,
+          "title": "Keywords",
+          "description": "A list of keywords that describe this package.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            "{\n  \"keywords\": [\n    \"data\",\n    \"fiscal\",\n    \"transparency\"\n  ]\n}\n"
+          ]
+        },
+        "image": {
+          "propertyOrder": 100,
+          "title": "Image",
+          "description": "A image to represent this package.",
+          "type": "string",
+          "examples": [
+            "{\n  \"image\": \"http://example.com/image.jpg\"\n}\n",
+            "{\n  \"image\": \"relative/to/image.jpg\"\n}\n"
+          ]
+        },
+        "licenses": {
+          "propertyOrder": 110,
+          "title": "Licenses",
+          "description": "The license(s) under which this package is published.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "License",
+            "description": "A license for this descriptor.",
+            "type": "object",
+            "anyOf": [
+              {
+                "required": [
+                  "name"
+                ]
+              },
+              {
+                "required": [
+                  "path"
+                ]
+              }
+            ],
+            "properties": {
+              "name": {
+                "title": "Open Definition license identifier",
+                "description": "MUST be an Open Definition license identifier, see http://licenses.opendefinition.org/",
+                "type": "string",
+                "pattern": "^([-a-zA-Z0-9._])+$"
+              },
+              "path": {
+                "title": "Path",
+                "description": "A fully qualified URL, or a POSIX file path.",
+                "type": "string",
+                "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                "examples": [
+                  "{\n  \"path\": \"file.csv\"\n}\n",
+                  "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                ],
+                "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+              },
+              "title": {
+                "title": "Title",
+                "description": "A human-readable title.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"title\": \"My Package Title\"\n}\n"
+                ]
+              }
+            },
+            "context": "Use of this property does not imply that the person was the original creator of, or a contributor to, the data in the descriptor, but refers to the composition of the descriptor itself."
+          },
+          "context": "This property is not legally binding and does not guarantee that the package is licensed under the terms defined herein.",
+          "examples": [
+            "{\n  \"licenses\": [\n    {\n      \"name\": \"odc-pddl-1.0\",\n      \"path\": \"http://opendatacommons.org/licenses/pddl/\",\n      \"title\": \"Open Data Commons Public Domain Dedication and License v1.0\"\n    }\n  ]\n}\n"
+          ]
+        },
+        "resources": {
+          "propertyOrder": 120,
+          "title": "Data Resources",
+          "description": "An `array` of Data Resource objects, each compliant with the [Data Resource](/data-resource/) specification.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Data Resource",
+            "description": "Data Resource.",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "name",
+                  "data"
+                ]
+              },
+              {
+                "required": [
+                  "name",
+                  "path"
+                ]
+              }
+            ],
+            "properties": {
+              "profile": {
+                "propertyOrder": 10,
+                "default": "data-resource",
+                "title": "Profile",
+                "description": "The profile of this descriptor.",
+                "context": "Every Package and Resource descriptor has a profile. The default profile, if none is declared, is `data-package` for Package and `data-resource` for Resource.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"profile\": \"tabular-data-package\"\n}\n",
+                  "{\n  \"profile\": \"http://example.com/my-profiles-json-schema.json\"\n}\n"
+                ]
+              },
+              "name": {
+                "propertyOrder": 20,
+                "title": "Name",
+                "description": "An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.",
+                "type": "string",
+                "pattern": "^([-a-z0-9._/])+$",
+                "context": "This is ideally a url-usable and human-readable name. Name `SHOULD` be invariant, meaning it `SHOULD NOT` change when its parent descriptor is updated.",
+                "examples": [
+                  "{\n  \"name\": \"my-nice-name\"\n}\n"
+                ]
+              },
+              "path": {
+                "propertyOrder": 30,
+                "title": "Path",
+                "description": "A reference to the data for this resource, as either a path as a string, or an array of paths as strings. of valid URIs.",
+                "oneOf": [
+                  {
+                    "title": "Path",
+                    "description": "A fully qualified URL, or a POSIX file path.",
+                    "type": "string",
+                    "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                    "examples": [
+                      "{\n  \"path\": \"file.csv\"\n}\n",
+                      "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                    ],
+                    "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+                  },
+                  {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "title": "Path",
+                      "description": "A fully qualified URL, or a POSIX file path.",
+                      "type": "string",
+                      "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                      "examples": [
+                        "{\n  \"path\": \"file.csv\"\n}\n",
+                        "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                      ],
+                      "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+                    },
+                    "examples": [
+                      "[ \"file.csv\" ]\n",
+                      "[ \"http://example.com/file.csv\" ]\n"
+                    ]
+                  }
+                ],
+                "context": "The dereferenced value of each referenced data source in `path` `MUST` be commensurate with a native, dereferenced representation of the data the resource describes. For example, in a *Tabular* Data Resource, this means that the dereferenced value of `path` `MUST` be an array.",
+                "examples": [
+                  "{\n  \"path\": [\n    \"file.csv\",\n    \"file2.csv\"\n  ]\n}\n",
+                  "{\n  \"path\": [\n    \"http://example.com/file.csv\",\n    \"http://example.com/file2.csv\"\n  ]\n}\n",
+                  "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                ]
+              },
+              "data": {
+                "propertyOrder": 230,
+                "title": "Data",
+                "description": "Inline data for this resource."
+              },
+              "schema": {
+                "propertyOrder": 40,
+                "title": "Schema",
+                "description": "A schema for this resource.",
+                "type": [
+                  "string",
+                  "object"
+                ]
+              },
+              "title": {
+                "title": "Title",
+                "description": "A human-readable title.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"title\": \"My Package Title\"\n}\n"
+                ],
+                "propertyOrder": 50
+              },
+              "description": {
+                "propertyOrder": 60,
+                "format": "textarea",
+                "title": "Description",
+                "description": "A text description. Markdown is encouraged.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"description\": \"# My Package description\\nAll about my package.\"\n}\n"
+                ]
+              },
+              "homepage": {
+                "propertyOrder": 70,
+                "title": "Home Page",
+                "description": "The home on the web that is related to this data package.",
+                "type": "string",
+                "format": "uri",
+                "examples": [
+                  "{\n  \"homepage\": \"http://example.com/\"\n}\n"
+                ]
+              },
+              "sources": {
+                "propertyOrder": 140,
+                "options": {
+                  "hidden": true
+                },
+                "title": "Sources",
+                "description": "The raw sources for this resource.",
+                "type": "array",
+                "minItems": 0,
+                "items": {
+                  "title": "Source",
+                  "description": "A source file.",
+                  "type": "object",
+                  "required": [
+                    "title"
+                  ],
+                  "properties": {
+                    "title": {
+                      "title": "Title",
+                      "description": "A human-readable title.",
+                      "type": "string",
+                      "examples": [
+                        "{\n  \"title\": \"My Package Title\"\n}\n"
+                      ]
+                    },
+                    "path": {
+                      "title": "Path",
+                      "description": "A fully qualified URL, or a POSIX file path.",
+                      "type": "string",
+                      "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                      "examples": [
+                        "{\n  \"path\": \"file.csv\"\n}\n",
+                        "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                      ],
+                      "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+                    },
+                    "email": {
+                      "title": "Email",
+                      "description": "An email address.",
+                      "type": "string",
+                      "format": "email",
+                      "examples": [
+                        "{\n  \"email\": \"example@example.com\"\n}\n"
+                      ]
+                    }
+                  }
+                },
+                "examples": [
+                  "{\n  \"sources\": [\n    {\n      \"title\": \"World Bank and OECD\",\n      \"path\": \"http://data.worldbank.org/indicator/NY.GDP.MKTP.CD\"\n    }\n  ]\n}\n"
+                ]
+              },
+              "licenses": {
+                "description": "The license(s) under which the resource is published.",
+                "propertyOrder": 150,
+                "options": {
+                  "hidden": true
+                },
+                "title": "Licenses",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "title": "License",
+                  "description": "A license for this descriptor.",
+                  "type": "object",
+                  "anyOf": [
+                    {
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "path"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "name": {
+                      "title": "Open Definition license identifier",
+                      "description": "MUST be an Open Definition license identifier, see http://licenses.opendefinition.org/",
+                      "type": "string",
+                      "pattern": "^([-a-zA-Z0-9._])+$"
+                    },
+                    "path": {
+                      "title": "Path",
+                      "description": "A fully qualified URL, or a POSIX file path.",
+                      "type": "string",
+                      "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                      "examples": [
+                        "{\n  \"path\": \"file.csv\"\n}\n",
+                        "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                      ],
+                      "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+                    },
+                    "title": {
+                      "title": "Title",
+                      "description": "A human-readable title.",
+                      "type": "string",
+                      "examples": [
+                        "{\n  \"title\": \"My Package Title\"\n}\n"
+                      ]
+                    }
+                  },
+                  "context": "Use of this property does not imply that the person was the original creator of, or a contributor to, the data in the descriptor, but refers to the composition of the descriptor itself."
+                },
+                "context": "This property is not legally binding and does not guarantee that the package is licensed under the terms defined herein.",
+                "examples": [
+                  "{\n  \"licenses\": [\n    {\n      \"name\": \"odc-pddl-1.0\",\n      \"path\": \"http://opendatacommons.org/licenses/pddl/\",\n      \"title\": \"Open Data Commons Public Domain Dedication and License v1.0\"\n    }\n  ]\n}\n"
+                ]
+              },
+              "format": {
+                "propertyOrder": 80,
+                "title": "Format",
+                "description": "The file format of this resource.",
+                "context": "`csv`, `xls`, `json` are examples of common formats.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"format\": \"xls\"\n}\n"
+                ]
+              },
+              "mediatype": {
+                "propertyOrder": 90,
+                "title": "Media Type",
+                "description": "The media type of this resource. Can be any valid media type listed with [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+                "type": "string",
+                "pattern": "^(.+)/(.+)$",
+                "examples": [
+                  "{\n  \"mediatype\": \"text/csv\"\n}\n"
+                ]
+              },
+              "encoding": {
+                "propertyOrder": 100,
+                "title": "Encoding",
+                "description": "The file encoding of this resource.",
+                "type": "string",
+                "default": "utf-8",
+                "examples": [
+                  "{\n  \"encoding\": \"utf-8\"\n}\n"
+                ]
+              },
+              "bytes": {
+                "propertyOrder": 110,
+                "options": {
+                  "hidden": true
+                },
+                "title": "Bytes",
+                "description": "The size of this resource in bytes.",
+                "type": "integer",
+                "examples": [
+                  "{\n  \"bytes\": 2082\n}\n"
+                ]
+              },
+              "hash": {
+                "propertyOrder": 120,
+                "options": {
+                  "hidden": true
+                },
+                "title": "Hash",
+                "type": "string",
+                "description": "The MD5 hash of this resource. Indicate other hashing algorithms with the {algorithm}:{hash} format.",
+                "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32}|)$",
+                "examples": [
+                  "{\n  \"hash\": \"d25c9c77f588f5dc32059d2da1136c02\"\n}\n",
+                  "{\n  \"hash\": \"SHA256:5262f12512590031bbcc9a430452bfd75c2791ad6771320bb4b5728bfb78c4d0\"\n}\n"
+                ]
+              }
+            }
+          },
+          "examples": [
+            "{\n  \"resources\": [\n    {\n      \"name\": \"my-data\",\n      \"data\": [\n        \"data.csv\"\n      ],\n      \"mediatype\": \"text/csv\"\n    }\n  ]\n}\n"
+          ]
+        },
+        "sources": {
+          "propertyOrder": 200,
+          "options": {
+            "hidden": true
+          },
+          "title": "Sources",
+          "description": "The raw sources for this resource.",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "title": "Source",
+            "description": "A source file.",
+            "type": "object",
+            "required": [
+              "title"
+            ],
+            "properties": {
+              "title": {
+                "title": "Title",
+                "description": "A human-readable title.",
+                "type": "string",
+                "examples": [
+                  "{\n  \"title\": \"My Package Title\"\n}\n"
+                ]
+              },
+              "path": {
+                "title": "Path",
+                "description": "A fully qualified URL, or a POSIX file path.",
+                "type": "string",
+                "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
+                "examples": [
+                  "{\n  \"path\": \"file.csv\"\n}\n",
+                  "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"
+                ],
+                "context": "Implementations need to negotiate the type of path provided, and dereference the data accordingly."
+              },
+              "email": {
+                "title": "Email",
+                "description": "An email address.",
+                "type": "string",
+                "format": "email",
+                "examples": [
+                  "{\n  \"email\": \"example@example.com\"\n}\n"
+                ]
+              }
+            }
+          },
+          "examples": [
+            "{\n  \"sources\": [\n    {\n      \"title\": \"World Bank and OECD\",\n      \"path\": \"http://data.worldbank.org/indicator/NY.GDP.MKTP.CD\"\n    }\n  ]\n}\n"
+          ]
+        }
+      }
+    },
+    {
+      "required": [
+        "resources",
+        "profile",
+        "created",
+        "contributors",
+        "project",
+        "spatial",
+        "temporal",
+        "taxonomic"
+      ],
+      "properties": {
+        "resources": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#resource-information). Camtrap DP further requires each object to be a [Tabular Data Resource](https://specs.frictionlessdata.io/tabular-data-resource/) with a specific `name` and `schema`. See [Data](https://camtrap-dp.tdwg.org/data) for the requirements for those resources.",
+          "minItems": 3,
+          "items": {
+            "oneOf": [
+              {
+                "required": [
+                  "name",
+                  "path",
+                  "profile",
+                  "schema"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Identifier of the resource.",
+                    "enum": [
+                      "deployments",
+                      "media",
+                      "observations"
+                    ]
+                  },
+                  "path": {
+                    "description": "Path or URL to the data file."
+                  },
+                  "profile": {
+                    "description": "[Profile](https://specs.frictionlessdata.io/profiles/) of the resource.",
+                    "enum": [
+                      "tabular-data-resource"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "not": {
+                      "enum": [
+                        "deployments",
+                        "media",
+                        "observations"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "profile": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#profile). Camtrap DP further requires this to be the URL of the used Camtrap DP Profile version (e.g. `https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/camtrap-dp-profile.json`).",
+          "format": "uri"
+        },
+        "name": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#name)."
+        },
+        "id": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#id)."
+        },
+        "created": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#created). Camtrap DP makes this a required property."
+        },
+        "title": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#title). Not to be confused with the title of the project that originated the package (`package.project.title`)."
+        },
+        "contributors": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#contributors). Camtrap DP makes this a required property and restricts `role` values. Can include people and organizations.",
+          "items": {
+            "properties": {
+              "role": {
+                "description": "Role of the contributor. Defaults to `contributor`.",
+                "enum": [
+                  "contact",
+                  "principalInvestigator",
+                  "rightsHolder",
+                  "publisher",
+                  "contributor"
+                ]
+              }
+            }
+          }
+        },
+        "description": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#description). Not to be confused with the description of the project that originated the package (`package.project.description`)."
+        },
+        "version": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#version)."
+        },
+        "keywords": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#keywords)."
+        },
+        "image": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#image)."
+        },
+        "homepage": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#homepage)."
+        },
+        "sources": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#sources). Can include the data management platform from which the package was derived (e.g. Agouti, Trapper, Wildlife Insights).",
+          "items": {
+            "properties": {
+              "version": {
+                "description": "Version of the source.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "licenses": {
+          "description": "See [Data Package specification](https://specs.frictionlessdata.io/data-package/#licenses). If provided, Camtrap DP further requires at least a license for the content of the package and one for the media files.",
+          "minItems": 2,
+          "items": {
+            "required": [
+              "scope"
+            ],
+            "properties": {
+              "scope": {
+                "description": "Scope of the license. `data` applies to the content of the package and resources, `media` to the (locally or externally hosted) media files referenced in `media.filePath`.",
+                "type": "string",
+                "enum": [
+                  "data",
+                  "media"
+                ]
+              }
+            }
+          }
+        },
+        "bibliographicCitation": {
+          "description": "Bibliographic/recommended citation for the package.",
+          "skos:exactMatch": "http://purl.org/dc/terms/bibliographicCitation",
+          "type": "string"
+        },
+        "project": {
+          "description": "Camera trap project or study that originated the package.",
+          "type": "object",
+          "required": [
+            "title",
+            "samplingDesign",
+            "captureMethod",
+            "individualAnimals",
+            "observationLevel"
+          ],
+          "properties": {
+            "id": {
+              "description": "Unique identifier of the project.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Title of the project. Not to be confused with the title of the package (`package.title`).",
+              "type": "string"
+            },
+            "acronym": {
+              "description": "Project acronym.",
+              "type": "string"
+            },
+            "description": {
+              "description": "Description of the project. Preferably formatted as [Markdown](http://commonmark.org/). Not to be confused with the description of the package (`package.description`).",
+              "type": "string"
+            },
+            "path": {
+              "description": "Project website.",
+              "type": "string",
+              "format": "uri"
+            },
+            "protocolType": {
+              "description": "Recording type.",
+              "type": "string",
+              "enum": [
+                "camera-trapping",
+                "acoustic"
+              ]
+            },
+            "samplingDesign": {
+              "description": "Type of a sampling design/layout. The values are based on [Wearn & Glover-Kapfer (2017)](https://doi.org/10.13140/RG.2.2.23409.17767), pages 80-82: `simple random`: random distribution of sampling locations; `systematic random`: random distribution of sampling locations, but arranged in a regular pattern; `clustered random`: random distribution of sampling locations, but clustered in arrays; `experimental`: non-random distribution aimed to study an effect, including the before-after control-impact (BACI) design; `targeted`: non-random distribution optimized for capturing specific target species (often using various bait types); `opportunistic`: opportunistic camera trapping (usually with a small number of cameras).",
+              "skos:broadMatch": "http://rs.tdwg.org/eco/terms/inventoryTypes",
+              "type": "string",
+              "enum": [
+                "simpleRandom",
+                "systematicRandom",
+                "clusteredRandom",
+                "experimental",
+                "targeted",
+                "opportunistic"
+              ]
+            },
+            "captureMethod": {
+              "description": "Method(s) used to capture the media files.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "activityDetection",
+                  "continuous",
+                  "recordingSchedule"
+                ]
+              },
+              "uniqueItems": true,
+              "minItems": 1
+            },
+            "classificationEffort": {
+              "description": "To what extent the media have been classified.",
+              "type": "string"
+            },
+            "individualAnimals": {
+              "description": "`true` if the project includes marked or recognizable individuals. See also `observations.individualID`.",
+              "type": "boolean"
+            },
+            "observationLevel": {
+              "description": "Level at which observations are provided. See also `observations.observationLevel`.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "media",
+                  "event"
+                ]
+              }
+            }
+          }
+        },
+        "coordinatePrecision": {
+          "description": "Least precise coordinate precision of the `deployments.latitude` and `deployments.longitude` (e.g. `0.01` for coordinates with a precision of 0.01 and 0.001 degree). Especially relevant when coordinates have been rounded to protect sensitive species.",
+          "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/coordinatePrecision",
+          "type": "number",
+          "example": 0.001
+        },
+        "spatial": {
+          "$id": "https://geojson.org/schema/GeoJSON.json",
+          "title": "GeoJSON",
+          "oneOf": [
+            {
+              "title": "GeoJSON Point",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Point"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON LineString",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "LineString"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON Polygon",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Polygon"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiPoint",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MultiPoint"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiLineString",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MultiLineString"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiPolygon",
+              "type": "object",
+              "required": [
+                "type",
+                "coordinates"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MultiPolygon"
+                  ]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 4,
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON GeometryCollection",
+              "type": "object",
+              "required": [
+                "type",
+                "geometries"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "GeometryCollection"
+                  ]
+                },
+                "geometries": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "title": "GeoJSON Point",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "Point"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON LineString",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "LineString"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON Polygon",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "Polygon"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 4,
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiPoint",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MultiPoint"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiLineString",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MultiLineString"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiPolygon",
+                        "type": "object",
+                        "required": [
+                          "type",
+                          "coordinates"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "MultiPolygon"
+                            ]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON Feature",
+              "type": "object",
+              "required": [
+                "type",
+                "properties",
+                "geometry"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Feature"
+                  ]
+                },
+                "id": {
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "properties": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
+                },
+                "geometry": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "title": "GeoJSON Point",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "Point"
+                          ]
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "number"
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "title": "GeoJSON LineString",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "LineString"
+                          ]
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "title": "GeoJSON Polygon",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "Polygon"
+                          ]
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "title": "GeoJSON MultiPoint",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MultiPoint"
+                          ]
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "title": "GeoJSON MultiLineString",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MultiLineString"
+                          ]
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "title": "GeoJSON MultiPolygon",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MultiPolygon"
+                          ]
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 4,
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "title": "GeoJSON GeometryCollection",
+                      "type": "object",
+                      "required": [
+                        "type",
+                        "geometries"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "GeometryCollection"
+                          ]
+                        },
+                        "geometries": {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "title": "GeoJSON Point",
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "coordinates"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "Point"
+                                    ]
+                                  },
+                                  "coordinates": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "bbox": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "GeoJSON LineString",
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "coordinates"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "LineString"
+                                    ]
+                                  },
+                                  "coordinates": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  },
+                                  "bbox": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "GeoJSON Polygon",
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "coordinates"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "Polygon"
+                                    ]
+                                  },
+                                  "coordinates": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "bbox": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "GeoJSON MultiPoint",
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "coordinates"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "MultiPoint"
+                                    ]
+                                  },
+                                  "coordinates": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  },
+                                  "bbox": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "GeoJSON MultiLineString",
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "coordinates"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "MultiLineString"
+                                    ]
+                                  },
+                                  "coordinates": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "bbox": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "title": "GeoJSON MultiPolygon",
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "coordinates"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "MultiPolygon"
+                                    ]
+                                  },
+                                  "coordinates": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 4,
+                                        "items": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "bbox": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "bbox": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON FeatureCollection",
+              "type": "object",
+              "required": [
+                "type",
+                "features"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "FeatureCollection"
+                  ]
+                },
+                "features": {
+                  "type": "array",
+                  "items": {
+                    "title": "GeoJSON Feature",
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "properties",
+                      "geometry"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "Feature"
+                        ]
+                      },
+                      "id": {
+                        "oneOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "properties": {
+                        "oneOf": [
+                          {
+                            "type": "null"
+                          },
+                          {
+                            "type": "object"
+                          }
+                        ]
+                      },
+                      "geometry": {
+                        "oneOf": [
+                          {
+                            "type": "null"
+                          },
+                          {
+                            "title": "GeoJSON Point",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "coordinates"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "Point"
+                                ]
+                              },
+                              "coordinates": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "title": "GeoJSON LineString",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "coordinates"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "LineString"
+                                ]
+                              },
+                              "coordinates": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "title": "GeoJSON Polygon",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "coordinates"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "Polygon"
+                                ]
+                              },
+                              "coordinates": {
+                                "type": "array",
+                                "items": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "title": "GeoJSON MultiPoint",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "coordinates"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "MultiPoint"
+                                ]
+                              },
+                              "coordinates": {
+                                "type": "array",
+                                "items": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "title": "GeoJSON MultiLineString",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "coordinates"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "MultiLineString"
+                                ]
+                              },
+                              "coordinates": {
+                                "type": "array",
+                                "items": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "title": "GeoJSON MultiPolygon",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "coordinates"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "MultiPolygon"
+                                ]
+                              },
+                              "coordinates": {
+                                "type": "array",
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "title": "GeoJSON GeometryCollection",
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "geometries"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "GeometryCollection"
+                                ]
+                              },
+                              "geometries": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "title": "GeoJSON Point",
+                                      "type": "object",
+                                      "required": [
+                                        "type",
+                                        "coordinates"
+                                      ],
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "Point"
+                                          ]
+                                        },
+                                        "coordinates": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "bbox": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "title": "GeoJSON LineString",
+                                      "type": "object",
+                                      "required": [
+                                        "type",
+                                        "coordinates"
+                                      ],
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "LineString"
+                                          ]
+                                        },
+                                        "coordinates": {
+                                          "type": "array",
+                                          "minItems": 2,
+                                          "items": {
+                                            "type": "array",
+                                            "minItems": 2,
+                                            "items": {
+                                              "type": "number"
+                                            }
+                                          }
+                                        },
+                                        "bbox": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "title": "GeoJSON Polygon",
+                                      "type": "object",
+                                      "required": [
+                                        "type",
+                                        "coordinates"
+                                      ],
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "Polygon"
+                                          ]
+                                        },
+                                        "coordinates": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "minItems": 4,
+                                            "items": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "items": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "bbox": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "title": "GeoJSON MultiPoint",
+                                      "type": "object",
+                                      "required": [
+                                        "type",
+                                        "coordinates"
+                                      ],
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "MultiPoint"
+                                          ]
+                                        },
+                                        "coordinates": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "minItems": 2,
+                                            "items": {
+                                              "type": "number"
+                                            }
+                                          }
+                                        },
+                                        "bbox": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "title": "GeoJSON MultiLineString",
+                                      "type": "object",
+                                      "required": [
+                                        "type",
+                                        "coordinates"
+                                      ],
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "MultiLineString"
+                                          ]
+                                        },
+                                        "coordinates": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "minItems": 2,
+                                            "items": {
+                                              "type": "array",
+                                              "minItems": 2,
+                                              "items": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "bbox": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "title": "GeoJSON MultiPolygon",
+                                      "type": "object",
+                                      "required": [
+                                        "type",
+                                        "coordinates"
+                                      ],
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "MultiPolygon"
+                                          ]
+                                        },
+                                        "coordinates": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "array",
+                                              "minItems": 4,
+                                              "items": {
+                                                "type": "array",
+                                                "minItems": 2,
+                                                "items": {
+                                                  "type": "number"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "bbox": {
+                                          "type": "array",
+                                          "minItems": 4,
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "bbox": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "temporal": {
+          "description": "Temporal coverage of the package.",
+          "skos:exactMatch": "http://purl.org/dc/terms/temporal",
+          "type": "object",
+          "required": [
+            "start",
+            "end"
+          ],
+          "properties": {
+            "start": {
+              "description": "Start date of the first deployment. Formatted as an ISO 8601 string (`YYYY-MM-DD`).",
+              "type": "string",
+              "format": "date"
+            },
+            "end": {
+              "description": "End date of the last (completed) deployment. Formatted as an ISO 8601 string (`YYYY-MM-DD`).",
+              "type": "string",
+              "format": "date"
+            }
+          }
+        },
+        "taxonomic": {
+          "description": "Taxonomic coverage of the package, based on the unique `observations.scientificName`.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "scientificName"
+            ],
+            "properties": {
+              "scientificName": {
+                "description": "Scientific name of the taxon.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/scientificName",
+                "type": "string",
+                "example": "Canis lupus"
+              },
+              "taxonID": {
+                "description": "Unique identifier of the taxon. Preferably a global unique identifier issued by an authoritative checklist.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/taxonID",
+                "type": "string",
+                "example": "https://www.checklistbank.org/dataset/COL2023/taxon/QLXL"
+              },
+              "taxonRank": {
+                "description": "Taxonomic rank of the scientific name.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/taxonRank",
+                "type": "string",
+                "enum": [
+                  "kingdom",
+                  "phylum",
+                  "class",
+                  "order",
+                  "family",
+                  "genus",
+                  "species",
+                  "subspecies"
+                ],
+                "example": "species"
+              },
+              "kingdom": {
+                "description": "Kingdom in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/kingdom",
+                "type": "string",
+                "example": "Animalia"
+              },
+              "phylum": {
+                "description": "Phylum or division in which the taxon is classified",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/phylum",
+                "type": "string",
+                "example": "Chordata"
+              },
+              "class": {
+                "description": "Class in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/class",
+                "type": "string",
+                "example": "Mammalia"
+              },
+              "order": {
+                "description": "Order in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/order",
+                "type": "string",
+                "example": "Carnivora"
+              },
+              "family": {
+                "description": "Family in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/family",
+                "type": "string",
+                "example": "Canidae"
+              },
+              "genus": {
+                "description": "Genus in which the taxon is classified.",
+                "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/genus",
+                "type": "string",
+                "example": "Canis"
+              },
+              "vernacularNames": {
+                "description": "Common or vernacular names of the taxon, as `languageCode: vernacular name` pairs. Language codes should follow ISO 693-3 (e.g. `eng` for English).",
+                "type": "object",
+                "patternProperties": {
+                  "^[a-z]{3}$": {
+                    "description": "Common or vernacular name of the taxon in that language.",
+                    "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/vernacularName",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "example": "{'eng': 'wolf', 'fra': 'loup gris'}"
+              }
+            }
+          }
+        },
+        "relatedIdentifiers": {
+          "description": "Identifiers of resources related to the package (e.g. papers, project pages, derived datasets, APIs, etc.).",
+          "type": "array",
+          "items": {
+            "description": "Related identifier.",
+            "required": [
+              "relationType",
+              "relatedIdentifier",
+              "relatedIdentifierType"
+            ],
+            "properties": {
+              "relationType": {
+                "description": "Description of the relationship between the resource (the package) and the related resource.",
+                "skos:exactMatch": "https://schema.datacite.org/meta/kernel-4.4/include/datacite-relationType-v4.xsd",
+                "type": "string",
+                "enum": [
+                  "IsCitedBy",
+                  "Cites",
+                  "IsSupplementTo",
+                  "IsSupplementedBy",
+                  "IsContinuedBy",
+                  "Continues",
+                  "IsNewVersionOf",
+                  "IsPreviousVersionOf",
+                  "IsPartOf",
+                  "HasPart",
+                  "IsPublishedIn",
+                  "IsReferencedBy",
+                  "References",
+                  "IsDocumentedBy",
+                  "Documents",
+                  "IsCompiledBy",
+                  "Compiles",
+                  "IsVariantFormOf",
+                  "IsOriginalFormOf",
+                  "IsIdenticalTo",
+                  "HasMetadata",
+                  "IsMetadataFor",
+                  "Reviews",
+                  "IsReviewedBy",
+                  "IsDerivedFrom",
+                  "IsSourceOf",
+                  "Describes",
+                  "IsDescribedBy",
+                  "HasVersion",
+                  "IsVersionOf",
+                  "Requires",
+                  "IsRequiredBy",
+                  "Obsoletes",
+                  "IsObsoletedBy"
+                ]
+              },
+              "relatedIdentifier": {
+                "description": "Unique identifier of the related resource (e.g. a DOI or URL).",
+                "type": "string"
+              },
+              "resourceTypeGeneral": {
+                "description": "General type of the related resource.",
+                "skos:exactMatch": "https://schema.datacite.org/meta/kernel-4.4/include/datacite-resourceType-v4.xsd",
+                "type": "string",
+                "enum": [
+                  "Audiovisual",
+                  "Book",
+                  "BookChapter",
+                  "Collection",
+                  "ComputationalNotebook",
+                  "ConferencePaper",
+                  "ConferenceProceeding",
+                  "DataPaper",
+                  "Dataset",
+                  "Dissertation",
+                  "Event",
+                  "Image",
+                  "InteractiveResource",
+                  "Journal",
+                  "JournalArticle",
+                  "Model",
+                  "OutputManagementPlan",
+                  "PeerReview",
+                  "PhysicalObject",
+                  "Preprint",
+                  "Report",
+                  "Service",
+                  "Software",
+                  "Sound",
+                  "Standard",
+                  "Text",
+                  "Workflow",
+                  "Other"
+                ]
+              },
+              "relatedIdentifierType": {
+                "description": "Type of the `RelatedIdentifier`.",
+                "skos:exactMatch": "https://schema.datacite.org/meta/kernel-4.4/include/datacite-relatedIdentifierType-v4.xsd",
+                "type": "string",
+                "enum": [
+                  "ARK",
+                  "arXiv",
+                  "bibcode",
+                  "DOI",
+                  "EAN13",
+                  "EISSN",
+                  "Handle",
+                  "IGSN",
+                  "ISBN",
+                  "ISSN",
+                  "ISTC",
+                  "LISSN",
+                  "LSID",
+                  "PMID",
+                  "PURL",
+                  "UPC",
+                  "URL",
+                  "URN",
+                  "w3id"
+                ]
+              }
+            }
+          }
+        },
+        "references": {
+          "description": "List of references related to the package (e.g. references cited in `package.project.description`). References preferably include a DOI.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/deployments-table-schema-acoustic.json
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/deployments-table-schema-acoustic.json
@@ -1,0 +1,313 @@
+{
+  "name": "deployments",
+  "title": "Deployments",
+  "description": "Table with device trap placements (deployments). Includes `deploymentID`, start, end, location and device setup information.",
+  "fields": [
+    {
+      "name": "deploymentID",
+      "description": "Unique identifier of the deployment.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "unique": true
+      },
+      "example": "dep1"
+    },
+    {
+      "name": "locationID",
+      "description": "Identifier of the deployment location.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/locationID",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "loc1"
+    },
+    {
+      "name": "locationName",
+      "description": "Name given to the deployment location.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/locality",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "Białowieża MRI 01"
+    },
+    {
+      "name": "latitude",
+      "description": "Latitude of the deployment location in decimal degrees, using the WGS84 datum.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/decimalLatitude",
+      "type": "number",
+      "constraints": {
+        "required": true,
+        "minimum": -90,
+        "maximum": 90
+      },
+      "example": 52.70442
+    },
+    {
+      "name": "longitude",
+      "description": "Longitude of the deployment location in decimal degrees, using the WGS84 datum.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/decimalLongitude",
+      "type": "number",
+      "constraints": {
+        "required": true,
+        "minimum": -180,
+        "maximum": 180
+      },
+      "example": 23.84995
+    },
+    {
+      "name": "coordinateUncertainty",
+      "description": "Horizontal distance from the given `latitude` and `longitude` describing the smallest circle containing the deployment location. Expressed in meters. Especially relevant when coordinates are rounded to protect sensitive species.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "minimum": 1
+      },
+      "unit": "m",
+      "example": 100
+    },
+        {
+      "name": "elevation",
+      "description": "Elevation (altitude, usually above sea level) in meters",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/minimumElevationInMeters",
+      "type": "integer",
+      "constraints": {
+        "required": false
+      },
+      "unit": "m",
+      "example": 100
+    },
+    {
+      "name": "deploymentStart",
+      "description": "Date and time at which the deployment was started. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventDate",
+      "type": "datetime",
+      "format": "%Y-%m-%dT%H:%M:%S%z",
+      "constraints": {
+        "required": true
+      },
+      "example": "2020-03-01T22:00:00Z"
+    },
+    {
+      "name": "deploymentEnd",
+      "description": "Date and time at which the deployment was ended. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventDate",
+      "type": "datetime",
+      "format": "%Y-%m-%dT%H:%M:%S%z",
+      "constraints": {
+        "required": true
+      },
+      "example": "2020-04-01T22:00:00Z"
+    },
+    {
+      "name": "setupBy",
+      "description": "Name or identifier of the person or organization that deployed the device.",
+      "skos:broadMatch": "http://rs.tdwg.org/eco/terms/samplingPerformedBy",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "Jakub Bubnicki"
+    },
+    {
+      "name": "deviceID",
+      "description": "Identifier of the device used for the deployment (e.g. the device device serial number).",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "P800HG08192031"
+    },
+    {
+      "name": "deviceModel",
+      "description": "Manufacturer and model of the device. Formatted as `manufacturer-model`.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/captureDevice",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "Reconyx-PC800"
+    },
+    {
+      "name": "devicePlatform",
+      "description": "The substrate to which the device is mounted.",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "buoy",
+          "vegetation",
+          "building",
+          "structure",
+          "pole",
+          "unattached"
+        ]
+      },
+      "example": "unattached"
+    },
+    {
+      "name": "deviceDelay",
+      "description": "Predefined duration after detection when further activity is ignored. Expressed in seconds.",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "example": 120
+    },
+    {
+      "name": "deviceHeight",
+      "description": "Height at which the device was deployed. Expressed in meters. Not to be combined with `deviceDepth`.",
+      "skos:narrowMatch": [
+        "http://rs.tdwg.org/dwc/terms/minimumDistanceAboveSurfaceInMeters",
+        "http://rs.tdwg.org/dwc/terms/maximumDistanceAboveSurfaceInMeters"
+      ],
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "unit": "m",
+      "example": 1.2
+    },
+    {
+      "name": "deviceDepth",
+      "description": "Depth at which the device was deployed. Expressed in meters. Not to be combined with `deviceHeight`.",
+      "skos:narrowMatch": [
+        "http://rs.tdwg.org/dwc/terms/minimumDepthInMeters",
+        "http://rs.tdwg.org/dwc/terms/maximumDepthInMeters"
+      ],
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "unit": "m",
+      "example": 4.8
+    },
+    {
+      "name": "deviceTilt",
+      "description": "Angle at which the device was deployed in the vertical plane. Expressed in degrees, with `-90` facing down, `0` horizontal and `90` facing up.",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "minimum": -90,
+        "maximum": 90
+      },
+      "unit": "°",
+      "example": -90
+    },
+    {
+      "name": "deviceHeading",
+      "description": "Angle at which the device was deployed in the horizontal plane. Expressed in decimal degrees clockwise from north, with values ranging from `0` to `360`: `0` = north, `90` = east, `180` = south, `270` = west.",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "minimum": 0,
+        "maximum": 360
+      },
+      "unit": "°",
+      "example": 225
+    },
+    {
+      "name": "recordingSchedule",
+      "description": "Description of the recording schedule.",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "9AM and 9PM"
+    },
+    {
+      "name": "detectionDistance",
+      "description": "Maximum distance at which the device can reliably detect activity. Expressed in meters. Typically measured by having a human move in front of the device.",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "unit": "m",
+      "example": 9.5
+    },
+    {
+      "name": "baitUse",
+      "description": "`true` if bait was used for the deployment. More information can be provided in `tags` or `comments`.",
+      "type": "boolean",
+      "constraints": {
+        "required": false
+      },
+      "example": true
+    },
+    {
+      "name": "locationType",
+      "description": "Type of the feature (if any) associated with the deployment.",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "roadPaved",
+          "roadDirt",
+          "trailHiking",
+          "trailGame",
+          "roadUnderpass",
+          "roadOverpass",
+          "roadBridge",
+          "culvert",
+          "burrow",
+          "nestSite",
+          "carcass",
+          "waterSource",
+          "fruitingTree"
+        ]
+      },
+      "example": "culvert"
+    },
+    {
+      "name": "habitat",
+      "description": "Short characterization of the habitat at the deployment location.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/habitat",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "Mixed temperate low-land forest"
+    },
+    {
+      "name": "deploymentGroups",
+      "description": "Deployment group(s) associated with the deployment. Deployment groups can have a spatial (arrays, grids, clusters), temporal (sessions, seasons, months, years) or other context. Formatted as a pipe (`|`) separated list for multiple values, with values preferably formatted as `key:value` pairs.",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "season:winter 2020 | grid:A1"
+    },
+    {
+      "name": "deploymentTags",
+      "description": "Tag(s) associated with the deployment. Formatted as a pipe (`|`) separated list for multiple values, with values optionally formatted as `key:value` pairs.",
+      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/tag",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "forest edge | bait:food"
+    },
+    {
+      "name": "deploymentComments",
+      "description": "Comments or notes about the deployment.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/eventRemarks",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": ""
+    }
+  ],
+  "missingValues": [
+    "", "NA", "NaN", "nan"
+  ],
+  "primaryKey": "deploymentID"
+}

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/media-table-schema-acoustic.json
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/media-table-schema-acoustic.json
@@ -1,0 +1,191 @@
+{
+  "name": "media",
+  "title": "Media",
+  "description": "Table with media files (images/videos) recorded during deployments (`deploymentID`). Includes timestamp and file path.",
+  "fields": [
+    {
+      "name": "mediaID",
+      "description": "Unique identifier of the media file.",
+      "skos:broadMatch": "http://purl.org/dc/terms/identifier",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "unique": true
+      },
+      "example": "m1"
+    },
+    {
+      "name": "deploymentID",
+      "description": "Identifier of the deployment the media file belongs to. Foreign key to `deployments.deploymentID`.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/parentEventID",
+      "type": "string",
+      "constraints": {
+        "required": true
+      },
+      "example": "dep1"
+    },
+    {
+      "name": "captureMethod",
+      "description": "Method used to capture the media file.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/resourceCreationTechnique",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "activityDetection",
+          "continuous",
+          "recordingSchedule"
+        ]
+      },
+      "example": "activityDetection"
+    },
+    {
+      "name": "timestamp",
+      "description": "Date and time at which the media file was recorded. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
+      "skos:exactMatch": "http://ns.adobe.com/xap/1.0/CreateDate",
+      "type": "datetime",
+      "format": "%Y-%m-%dT%H:%M:%S.%f%z",
+      "constraints": {
+        "required": true
+      },
+      "example": "2020-03-24T11:21:46.356Z"
+    },
+    {
+      "name": "duration",
+      "description": "The playback duration of an audio or video file in seconds. This might be different from the time in seconds calculated as the difference of ac:endTimestamp and ac:startTimestamp if ac:mediaSpeed is not equal to 1.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/mediaDuration",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": ""
+    },
+    {
+      "name": "filePath",
+      "description": "URL or relative path to the media file, respectively for externally hosted files or files that are part of the package.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/accessURI",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$"
+      },
+      "example": "https://multimedia.agouti.eu/assets/6d65f3e4-4770-407b-b2bf-878983bf9872/file"
+    },
+    {
+      "name": "filePublic",
+      "description": "`false` if the media file is not publicly accessible (e.g. to protect the privacy of people).",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/serviceExpectation",
+      "type": "boolean",
+      "constraints": {
+        "required": true
+      },
+      "example": true
+    },
+    {
+      "name": "fileName",
+      "description": "Name of the media file. If provided, one should be able to sort media files chronologically within a deployment on `timestamp` (first) and `fileName` (second).",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "IMG0001.jpg"
+    },
+    {
+      "name": "fileMediatype",
+      "description": "Mediatype of the media file. Expressed as an [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+      "skos:broadMatch": "http://purl.org/dc/elements/1.1/format",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(image|video|audio)\/.*$"
+      },
+      "example": "image/jpeg"
+    },
+    {
+      "name": "exifData",
+      "description": "EXIF data of the media file. Formatted as a valid JSON object.",
+      "type": "any",
+      "constraints": {
+        "required": false
+      },
+      "example": "{\"EXIF\":{\"ISO\":200,\"Make\":\"RECONYX\"}}"
+    },
+    {
+      "name": "bitDepth",
+      "description": "Number of bits used to represent each sample in a digital audio file.",
+      "skos:broadMatch": "",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "enum": [
+          8,
+          16,
+          24,
+          32
+        ]
+      },
+      "example": 8
+    },
+    {
+      "name": "samplingFrequency",
+      "description": "Frequencies at which measurements are made. Expressed in Hertz.",
+      "type": "integer",
+      "constraints": {
+        "required": false
+      },
+      "example": 44100
+    },
+    {
+      "name": "gain",
+      "description": "Amplification of a signal. Expressed in decibels (dB).",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "example": 3
+    },
+    {
+      "name": "channels",
+      "description": "Index of an acoustic data stream within a recording.",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "minimum": 1
+      },
+      "example": 2
+    },
+    {
+      "name": "favorite",
+      "description": "`true` if the media file is deemed of interest (e.g. an exemplar image of an individual).",
+      "type": "boolean",
+      "constraints": {
+        "required": false
+      },
+      "example": true
+    },
+    {
+      "name": "mediaComments",
+      "description": "Comments or notes about the media file.",
+      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/comments",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "corrupted file"
+    }
+  ],
+  "missingValues": [
+    "", "NA", "NaN", "nan"
+  ],
+  "primaryKey": "mediaID",
+  "foreignKeys": [
+    {
+      "fields": "deploymentID",
+      "reference": {
+        "resource": "deployments",
+        "fields": "deploymentID"
+      }
+    }
+  ]
+}

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/observations-table-schema-acoustic.json
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/profile_assets/observations-table-schema-acoustic.json
@@ -1,0 +1,381 @@
+{
+  "name": "observations",
+  "title": "Observations",
+  "description": "Table with observations derived from the media files. Associated with deployments (`deploymentID`). Observations can mark non-animal events (camera setup, human, blank) or one or more animal observations (`observationType` = `animal`) of a certain taxon, count, life stage, sex, behavior and/or individual. Observations can be made at different levels (`observationLevel`).",
+  "fields": [
+    {
+      "name": "observationID",
+      "description": "Unique identifier of the observation.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/occurrenceID",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "unique": true
+      },
+      "example": "obs1"
+    },
+    {
+      "name": "deploymentID",
+      "description": "Identifier of the deployment the observation belongs to. Foreign key to `deployments.deploymentID`.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/parentEventID",
+      "type": "string",
+      "constraints": {
+        "required": true
+      },
+      "example": "dep1"
+    },
+    {
+      "name": "mediaID",
+      "description": "Identifier of the media file that was classified. Only applicable for media-based observations (`observationLevel` = `media`). Foreign key to `media.mediaID`.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/associatedMedia",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "m1"
+    },
+    {
+      "name": "eventID",
+      "description": "Identifier of the event the observation belongs to. Facilitates linking event-based and media-based observations with a permanent identifier.",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventID",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "sequence1"
+    },
+    {
+      "name": "eventStart",
+      "description": "Date and time at which the event started. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventDate",
+      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/startTimestamp",
+      "type": "datetime",
+      "format": "%Y-%m-%dT%H:%M:%S.%f%z",
+      "constraints": {
+        "required": true
+      },
+      "example": "2020-03-01T22:12:03.937Z"
+    },
+    {
+      "name": "eventEnd",
+      "description": "Date and time at which the event ended. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/eventDate",
+      "skos:narrowMatch": "http://rs.tdwg.org/ac/terms/endTimestamp",
+      "type": "datetime",
+      "format": "%Y-%m-%dT%H:%M:%S.%f%z",
+      "constraints": {
+        "required": true
+      },
+      "example": "2020-03-01T22:15:07.061Z"
+    },
+    {
+      "name": "observationLevel",
+      "description": "Level at which the observation was classified. `media` for media-based observations that are directly associated with a media file (`mediaID`). These are especially useful for machine learning and don't need to be mutually exclusive (e.g. multiple classifications are allowed). `event` for event-based observations that consider an event (comprising a collection of media files). These are especially useful for ecological research and should be mutually exclusive, so that their `count` can be summed.",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "media",
+          "event",
+          "interval"
+        ]
+      },
+      "example": "media"
+    },
+    {
+      "name": "observationType",
+      "description": "Type of the observation. All categories in this vocabulary have to be understandable from an AI point of view. `unknown` describes classifications with a `classificationProbability` below some predefined threshold i.e. neither humans nor AI can say what was recorded.",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "animal",
+          "human",
+          "vehicle",
+          "blank",
+          "unknown",
+          "unclassified"
+        ]
+      },
+      "example": "animal"
+    },
+    {
+      "name": "deviceSetupType",
+      "description": "Type of the device setup action (if any) associated with the observation.",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "setup",
+          "calibration"
+        ]
+      },
+      "example": "calibration"
+    },
+    {
+      "name": "scientificName",
+      "description": "Scientific name of the observed individual(s).",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/scientificName",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "Canis lupus"
+    },
+    {
+      "name": "count",
+      "description": "Number of observed individuals (optionally of given life stage, sex and behavior).",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/individualCount",
+      "type": "integer",
+      "constraints": {
+        "required": false,
+        "minimum": 1
+      },
+      "example": 5
+    },
+    {
+      "name": "lifeStage",
+      "description": "Age class or life stage of the observed individual(s).",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/lifeStage",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "adult",
+          "subadult",
+          "juvenile"
+        ]
+      },
+      "example": "adult"
+    },
+    {
+      "name": "sex",
+      "description": "Sex of the observed individual(s)",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/sex",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "female",
+          "male"
+        ]
+      },
+      "example": "female"
+    },
+    {
+      "name": "behavior",
+      "description": "Dominant behavior of the observed individual(s), preferably expressed as controlled values (e.g. grazing, browsing, rooting, vigilance, running, walking). Formatted as a pipe (`|`) separated list for multiple values, with the dominant behavior listed first.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/behavior",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "vigilance"
+    },
+    {
+      "name": "individualID",
+      "description": "Identifier of the observed individual.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/organismID",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "RD213"
+    },
+    {
+      "name": "individualPositionRadius",
+      "description": "Distance from the device to the observed individual identified by `individualID`. Expressed in meters. Required for distance analyses (e.g. [Howe et al. 2017](https://doi.org/10.1111/2041-210X.12790)) and random encounter modelling (e.g. [Rowcliffe et al. 2011](https://doi.org/10.1111/j.2041-210X.2011.00094.x)).",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "unit": "m",
+      "example": 6.81
+    },
+    {
+      "name": "individualPositionAngle",
+      "description": "Angular distance from the device view centerline to the observed individual identified by `individualID`. Expressed in degrees, with negative values left, `0` straight ahead and positive values right. Required for distance analyses (e.g. [Howe et al. 2017](https://doi.org/10.1111/2041-210X.12790)) and random encounter modelling (e.g. [Rowcliffe et al. 2011](https://doi.org/10.1111/j.2041-210X.2011.00094.x)).",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": -90,
+        "maximum": 90
+      },
+      "unit": "°",
+      "example": -8.56
+    },
+    {
+      "name": "individualSpeed",
+      "description": "Average movement speed of the observed individual identified by `individualID`. Expressed in meters per second. Required for random encounter modelling (e.g. [Rowcliffe et al. 2016](https://doi.org/10.1002/rse2.17)).",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0
+      },
+      "unit": "m/s",
+      "example": 1.75
+    },
+    {
+      "name": "bboxX",
+      "description": "Horizontal position of the top-left corner of a bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Or the horizontal position of an object in that media file. Measured from the left and relative to media file width.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/XFrac",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0,
+        "maximum": 1
+      },
+      "example": 0.2
+    },
+    {
+      "name": "bboxY",
+      "description": "Vertical position of the top-left corner of a bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Or the vertical position of an object in that media file. Measured from the top and relative to the media file height.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/YFrac",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0,
+        "maximum": 1
+      },
+      "example": 0.25
+    },
+    {
+      "name": "bboxWidth",
+      "description": "Width of a bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Measured from the left of the bounding box and relative to the media file width.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/widthFrac",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 1e-15,
+        "maximum": 1
+      },
+      "example": 0.4
+    },
+    {
+      "name": "bboxHeight",
+      "description": "Height of the bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Measured from the top of the bounding box and relative to the media file height.",
+      "skos:broadMatch": "http://rs.tdwg.org/ac/terms/heightFrac",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 1e-15,
+        "maximum": 1
+      },
+      "example": 0.5
+    },
+    {
+      "name": "frequencyLow",
+      "description": "Lower limit of the frequency range over which the observation applies. Expressed in Hertz. Must be lower than frequencyHigh.",
+      "type": "number",
+      "constraints": {
+        "required": false
+      },
+      "example": 1000
+    },
+    {
+      "name": "frequencyHigh",
+      "description": "Higher limit of the frequency range over which the observation applies. Expressed in Hertz. Must be higher than frequencyHigh.",
+      "type": "number",
+      "constraints": {
+        "required": false
+      },
+      "example": 5000
+    },
+    {
+      "name": "classificationMethod",
+      "description": "Method (most recently) used to classify the observation.",
+      "type": "string",
+      "constraints": {
+        "required": false,
+        "enum": [
+          "human",
+          "machine"
+        ]
+      },
+      "example": "human"
+    },
+    {
+      "name": "classifiedBy",
+      "description": "Name or identifier of the person or AI algorithm that (most recently) classified the observation.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/identifiedBy",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "MegaDetector V5"
+    },
+    {
+      "name": "classificationTimestamp",
+      "description": "Date and time of the (most recent) classification. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss±hh:mm`).",
+      "skos:broadMatch": "http://rs.tdwg.org/dwc/terms/dateIdentified",
+      "type": "datetime",
+      "format": "%Y-%m-%dT%H:%M:%S%z",
+      "constraints": {
+        "required": false
+      },
+      "example": "2020-08-22T10:25:19Z"
+    },
+    {
+      "name": "classificationProbability",
+      "description": "Degree of certainty of the (most recent) classification. Expressed as a probability, with `1` being maximum certainty. Omit or provide an approximate probability for human classifications.",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0,
+        "maximum": 1
+      },
+      "example": 0.95
+    },
+    {
+      "name": "classificationConfirmation",
+      "description": "A confirmation that the classified species was observed via other means.",
+      "type": "string",
+      "enum": [
+        "captured",
+        "heardOnSite",
+        "seenOnSite"
+      ]
+    },
+    {
+      "name": "observationTags",
+      "description": "Tag(s) associated with the observation. Formatted as a pipe (`|`) separated list for multiple values, with values optionally formatted as `key:value` pairs.",
+      "skos:exactMatch": "http://rs.tdwg.org/ac/terms/tag",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": "travelDirection:left"
+    },
+    {
+      "name": "observationComments",
+      "description": "Comments or notes about the observation.",
+      "skos:exactMatch": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks",
+      "type": "string",
+      "constraints": {
+        "required": false
+      },
+      "example": ""
+    }
+  ],
+  "missingValues": [
+    "", "NA", "NaN", "nan"
+  ],
+  "primaryKey": "observationID",
+  "foreignKeys": [
+    {
+      "fields": "deploymentID",
+      "reference": {
+        "resource": "deployments",
+        "fields": "deploymentID"
+      }
+    },
+    {
+      "fields": "mediaID",
+      "reference": {
+        "resource": "media",
+        "fields": "mediaID"
+      }
+    }
+  ]
+}

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/table/deployment.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/table/deployment.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Table
+        # Represents a row in the `deployment` table of the Camtrap Data Package.
+        #
+        # Attributes are defined in schema order (required for CSV validation).
+        class Deployment < BawWorkers::Dry::OrderedStruct
+          Types = BawWorkers::Export::CamtrapDp::Types
+
+          # Unique identifier of the deployment.
+          attribute :deploymentID, Types::Coercible::String
+
+          # Identifier of the deployment location.
+          attribute? :locationID, Types::Coercible::String
+
+          # Name given to the deployment location.
+          attribute? :locationName, Types::String
+
+          # Latitude of the deployment location in decimal degrees, using the WGS84 datum.
+          attribute :latitude, Types::Nominal::Decimal
+
+          # Longitude of the deployment location in decimal degrees, using the WGS84 datum.
+          attribute :longitude, Types::Nominal::Decimal
+
+          # Horizontal distance from the given `latitude` and `longitude` describing the smallest circle containing the deployment location. Expressed in meters. Especially relevant when coordinates are rounded to protect sensitive species.
+          attribute? :coordinateUncertainty, Types::Coercible::Integer.constrained(gteq: 1)
+
+          # Elevation (altitude, usually above sea level) in meters
+          attribute? :elevation, Types::Integer
+
+          # Date and time at which the deployment was started. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss¬±hh:mm`).
+          attribute :deploymentStart, Types::UtcTimeSeconds
+
+          # Date and time at which the deployment was ended. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss¬±hh:mm`).
+          attribute :deploymentEnd, Types::UtcTimeSeconds
+
+          # Name or identifier of the person or organization that deployed the device.
+          attribute? :setupBy, Types::String
+
+          # Identifier of the device used for the deployment (e.g. the device device serial number).
+          attribute? :deviceID, Types::String
+
+          # Manufacturer and model of the device. Formatted as `manufacturer-model`.
+          attribute? :deviceModel, Types::String
+
+          # The substrate to which the device is mounted.
+          attribute? :devicePlatform,
+            Types::String.enum('buoy', 'vegetation', 'building', 'structure', 'pole', 'unattached')
+
+          # Predefined duration after detection when further activity is ignored. Expressed in seconds.
+          attribute? :deviceDelay, Types::Integer
+
+          # Height at which the device was deployed. Expressed in meters. Not to be combined with `deviceDepth`.
+          attribute? :deviceHeight, Types::Coercible::Float
+
+          # Depth at which the device was deployed. Expressed in meters. Not to be combined with `deviceHeight`.
+          attribute? :deviceDepth, Types::Coercible::Float
+
+          # Angle at which the device was deployed in the vertical plane. Expressed in degrees, with `-90` facing down, `0` horizontal and `90` facing up.
+          attribute? :deviceTilt, Types::Integer
+
+          # Angle at which the device was deployed in the horizontal plane. Expressed in decimal degrees clockwise from north, with values ranging from `0` to `360`: `0` = north, `90` = east, `180` = south, `270` = west.
+          attribute? :deviceHeading, Types::Integer
+
+          # Description of the recording schedule.
+          attribute? :recordingSchedule, Types::String
+
+          # Maximum distance at which the device can reliably detect activity. Expressed in meters. Typically measured by having a human move in front of the device.
+          attribute? :detectionDistance, Types::Coercible::Float
+
+          # `true` if bait was used for the deployment. More information can be provided in `tags` or `comments`.
+          attribute? :baitUse, Types::Bool
+
+          # Type of the feature (if any) associated with the deployment.
+          attribute? :locationType,
+            Types::String.enum('roadPaved', 'roadDirt', 'trailHiking', 'trailGame', 'roadUnderpass', 'roadOverpass', 'roadBridge',
+              'culvert', 'burrow', 'nestSite', 'carcass', 'waterSource', 'fruitingTree')
+
+          # Short characterization of the habitat at the deployment location.
+          attribute? :habitat, Types::String
+
+          # Deployment group(s) associated with the deployment. Deployment groups can have a spatial (arrays, grids, clusters), temporal (sessions, seasons, months, years) or other context. Formatted as a pipe (`|`) separated list for multiple values, with values preferably formatted as `key:value` pairs.
+          attribute? :deploymentGroups, Types::String
+
+          # Tag(s) associated with the deployment. Formatted as a pipe (`|`) separated list for multiple values, with valuesly formatted as `key:value` pairs.
+          attribute? :deploymentTags, Types::String
+
+          # Comments or notes about the deployment.
+          attribute? :deploymentComments, Types::String
+
+          # @param deployment [DeploymentAccumulator::Deployment] the accumulated deployment metadata
+          #   whose `ensure_timezone` method applies the forced UTC offset, site timezone, or UTC fallback.
+          # @param should_obfuscate [Boolean] whether to obfuscate the latitude and longitude values for the deployment
+          # @return [Deployment] the deployment struct with the mapped values
+          def self.mapping(deployment, user:, should_obfuscate:)
+            site = deployment.site
+
+            # Because we are treating site as a single deployment, the same identifier is used for both deploymentID and locationID.
+            attributes = {
+              deploymentID: site.global_identifier,
+              locationID: site.global_identifier,
+              locationName: site.name,
+              latitude: site.public_latitude(user:, should_obfuscate:),
+              longitude: site.public_longitude(user:, should_obfuscate:),
+              coordinateUncertainty: site.total_coordinate_uncertainty_meters(user:, should_obfuscate:),
+              deploymentStart: deployment.ensure_timezone(deployment.start),
+              deploymentEnd: deployment.ensure_timezone(deployment.end),
+              deploymentTags: tags(site, user:, should_obfuscate:).presence
+            }.compact
+
+            Deployment.new(attributes)
+          end
+
+          # Build a pipe-delimited string of semi-structured tag key:value pairs.
+          # See https://camtrap-dp.tdwg.org/faq/#measurements.
+          #
+          # Includes the keys coordinatesObfuscated and dataGeneralizations.
+          # Blank values are omitted, and the result is empty if no tags are present.
+          # @return [String] the deployment tags string
+          def self.tags(site, user:, should_obfuscate:)
+            tag_values = {
+              coordinatesObfuscated:
+                site.coordinates_provided? ? site.location_obfuscated(user:, should_obfuscate:).to_s : nil,
+              dataGeneralizations: [
+                site.measurement_uncertainty_text(user:, should_obfuscate:),
+                site.obfuscation_uncertainty_text(user:, should_obfuscate:)
+              ].compact.join('; ')
+            }.compact_blank
+
+            tag_values.map { |key, value| "#{key}:#{value}" }.join(' | ')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/table/media.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/table/media.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Table
+        # Represents a row in the `media` table of the Camtrap Data Package.
+        #
+        # Attributes are defined in schema order (required for CSV validation).
+        class Media < BawWorkers::Dry::OrderedStruct
+          Types = BawWorkers::Export::CamtrapDp::Types
+
+          attribute :mediaID, Types::Coercible::String
+          attribute :deploymentID, Types::Coercible::String
+          attribute? :captureMethod, Types::String.enum('activityDetection', 'continuous', 'recordingSchedule')
+          attribute :timestamp, Types::UtcTimeMicroseconds
+          attribute? :duration, Types::Decimal
+          attribute :filePath, Types::String
+          attribute :filePublic, Types::Bool
+          attribute? :fileName, Types::String
+          attribute :fileMediatype, Types::String
+          attribute? :exifData, Types::Hash
+          attribute? :bitDepth, Types::Integer.enum(8, 16, 24, 32)
+          attribute? :samplingFrequency, Types::SampleRate
+          attribute? :gain, Types::Integer
+          attribute? :channels, Types::Channel
+          attribute? :favorite, Types::Bool
+          attribute? :mediaComments, Types::String
+
+          # @param audio_recording [AudioRecording] the audio recording to map
+          # @param deployment [DeploymentAccumulator::Deployment] the deployment metadata for the audio recording;
+          #   its `ensure_timezone` method applies the forced UTC offset, site timezone, or UTC fallback.
+          # @return [Media] the media struct with the mapped values
+          def self.mapping(audio_recording, deployment)
+            file_path = Api::UrlHelpers.audio_recording_media_original_url(audio_recording_id: audio_recording.id)
+
+            # TODO: add bitDepth when closed: https://github.com/QutEcoacoustics/baw-server/issues/1020
+            attributes = {
+              mediaID: audio_recording.global_identifier,
+              deploymentID: deployment.site.global_identifier,
+              # captureMethod:,
+              timestamp: deployment.ensure_timezone(audio_recording.recorded_date),
+              duration: audio_recording.duration_seconds,
+              filePath: file_path,
+              filePublic: deployment.file_public,
+              fileName: audio_recording.friendly_name,
+              fileMediatype: audio_recording.media_type,
+              # exifData:,
+              # bitDepth:,
+              samplingFrequency: audio_recording.sample_rate_hertz,
+              # gain:,
+              channels: audio_recording.channels
+              # favorite:,
+              # mediaComments:
+            }.compact
+
+            Media.new(attributes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/table/observation.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/table/observation.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Table
+        # Represents a row in the `observations` table of the Camtrap Data Package.
+        #
+        # Attributes are defined in schema order (required for CSV validation).
+        class Observation < BawWorkers::Dry::OrderedStruct
+          Types = BawWorkers::Export::CamtrapDp::Types
+
+          # Our concept of an event maps to the interval type of observation. See explanation on #observationLevel
+          OBSERVATION_LEVEL = 'interval'
+
+          # Unique identifier of the observation.
+          attribute :observationID, Types::Coercible::String
+
+          # Identifier of the deployment the observation belongs to. Foreign key to `deployments.deploymentID`.
+          attribute :deploymentID, Types::Coercible::String
+
+          # Identifier of the media file that was classified. Only applicable for media-based observations (`observationLevel` = `media`). Foreign key to `media.mediaID`.
+          attribute? :mediaID, Types::Coercible::String
+
+          # Identifier of the event the observation belongs to. Facilitates linking event-based and media-based observations with a permanent identifier.
+          attribute? :eventID, Types::String
+
+          # Date and time at which the event started. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss¬±hh:mm`).
+          attribute :eventStart, Types::UtcTimeMicroseconds
+
+          # Date and time at which the event ended. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss¬±hh:mm`).
+          attribute :eventEnd, Types::UtcTimeMicroseconds
+
+          # Level at which the observation was classified. `media` for media-based observations that are directly associated with a media file (`mediaID`). These are especially useful for machine learning and don't need to be mutually exclusive (e.g. multiple classifications are allowed). `event` for event-based observations that consider an event (comprising a collection of media files). These are especially useful for ecological research and should be mutually exclusive, so that their `count` can be summed. Acoustic extension adds 'interval' to accepted enum values but seemingly only to the field on observations table, not the package level observationLevel field
+          attribute :observationLevel, Types::String.enum('media', 'event', 'interval')
+
+          # Type of the observation. All categories in this vocabulary have to be understandable from an AI point of view. `unknown` describes classifications with a `classificationProbability` below some predefined threshold i.e. neither humans nor AI can say what was recorded.
+          attribute :observationType,
+            Types::String.enum('animal', 'human', 'vehicle', 'blank', 'unknown', 'unclassified')
+
+          # Type of the device setup action (if any) associated with the observation.
+          attribute? :deviceSetupType, Types::String.enum('setup', 'calibration')
+
+          # Scientific name of the observed individual(s).
+          attribute? :scientificName, Types::String
+
+          # Number of observed individuals (optionally of given life stage, sex and behavior).
+          attribute? :count, Types::Integer
+
+          # Age class or life stage of the observed individual(s).
+          attribute? :lifeStage, Types::String.enum('adult', 'subadult', 'juvenile')
+
+          # Sex of the observed individual(s)
+          attribute? :sex, Types::String.enum('female', 'male')
+
+          # Dominant behavior of the observed individual(s), preferably expressed as controlled values (e.g. grazing, browsing, rooting, vigilance, running, walking). Formatted as a pipe (`|`) separated list for multiple values, with the dominant behavior listed first.
+          attribute? :behavior, Types::String
+
+          # Identifier of the observed individual.
+          attribute? :individualID, Types::String
+
+          # Distance from the device to the observed individual identified by `individualID`. Expressed in meters. Required for distance analyses (e.g. [Howe et al. 2017](https://doi.org/10.1111/2041-210X.12790)) and random encounter modelling (e.g. [Rowcliffe et al. 2011](https://doi.org/10.1111/j.2041-210X.2011.00094.x)).
+          attribute? :individualPositionRadius, Types::Coercible::Float
+
+          # Angular distance from the device view centerline to the observed individual identified by `individualID`. Expressed in degrees, with negative values left, `0` straight ahead and positive values right. Required for distance analyses (e.g. [Howe et al. 2017](https://doi.org/10.1111/2041-210X.12790)) and random encounter modelling (e.g. [Rowcliffe et al. 2011](https://doi.org/10.1111/j.2041-210X.2011.00094.x)).
+          attribute? :individualPositionAngle, Types::Coercible::Float
+
+          # Average movement speed of the observed individual identified by `individualID`. Expressed in meters per second. Required for random encounter modelling (e.g. [Rowcliffe et al. 2016](https://doi.org/10.1002/rse2.17)).
+          attribute? :individualSpeed, Types::Coercible::Float
+
+          # Horizontal position of the top-left corner of a bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Or the horizontal position of an object in that media file. Measured from the left and relative to media file width.
+          attribute? :bboxX, Types::Coercible::Float
+
+          # Vertical position of the top-left corner of a bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Or the vertical position of an object in that media file. Measured from the top and relative to the media file height.
+          attribute? :bboxY, Types::Coercible::Float
+
+          # Width of a bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Measured from the left of the bounding box and relative to the media file width.
+          attribute? :bboxWidth, Types::Coercible::Float
+
+          # Height of the bounding box that encompasses the observed individual(s) in the media file identified by `mediaID`. Measured from the top of the bounding box and relative to the media file height.
+          attribute? :bboxHeight, Types::Coercible::Float
+
+          # Lower limit of the frequency range over which the observation applies. Expressed in Hertz. Must be lower than frequencyHigh.
+          attribute? :frequencyLow, Types::Coercible::Float
+
+          # Higher limit of the frequency range over which the observation applies. Expressed in Hertz. Must be higher than frequencyHigh.
+          attribute? :frequencyHigh, Types::Coercible::Float
+
+          # Method (most recently) used to classify the observation.
+          attribute? :classificationMethod, Types::String.enum('human', 'machine')
+
+          # Name or identifier of the person or AI algorithm that (most recently) classified the observation.
+          attribute? :classifiedBy, Types::String
+
+          # Date and time of the (most recent) classification. Formatted as an ISO 8601 string with timezone designator (`YYYY-MM-DDThh:mm:ssZ` or `YYYY-MM-DDThh:mm:ss¬±hh:mm`).
+          attribute? :classificationTimestamp, Types::UtcTimeSeconds
+
+          # Degree of certainty of the (most recent) classification. Expressed as a probability, with `1` being maximum certainty. Omit or provide an approximate probability for human classifications.
+          attribute? :classificationProbability, Types::Coercible::Float
+
+          # A confirmation that the classified species was observed via other means. Not related to our idea of confirmations. https://github.com/tdwg/camtrap-dp/issues/453
+          attribute? :classificationConfirmation, Types::String.enum('captured', 'heardOnSite', 'seenOnSite')
+
+          # Tag(s) associated with the observation. Formatted as a pipe (`|`) separated list for multiple values, with values optionally formatted as `key:value` pairs.
+          attribute? :observationTags, Types::String
+
+          # Comments or notes about the observation.
+          attribute? :observationComments, Types::String
+
+          def self.anchored_union(*patterns)
+            /\A#{Regexp.union(patterns)}\z/
+          end
+
+          TYPE_OF_ANIMAL = [
+            'species_name',
+            'common_name'
+          ]
+          GENERAL_TEXT_UNKNOWN = anchored_union(
+            /unknown/i,
+            /unknown_\d+/i,
+            /unsure/i
+          )
+          GENERAL_TEXT_HUMAN = anchored_union(
+            /baby/i,
+            /human voice/i
+          )
+          GENERAL_TEXT_VEHICLE = anchored_union(
+            /airplane/i,
+            /boat/i,
+            /car/i,
+            /chainsaw/i,
+            /engine/i,
+            /helicopter/i,
+            /motor/i,
+            /train/i,
+            /train passing/i,
+            /train horn/i,
+            /machine generated/i,
+            /vehicle/i
+          )
+
+          # Temporary solution; remove after https://github.com/QutEcoacoustics/baw-server/issues/1009.
+          def self.observation_type(tag)
+            case [tag.type_of_tag, tag.text]
+            in [type, _] if TYPE_OF_ANIMAL.include?(type)
+              'animal'
+            in ['general', GENERAL_TEXT_UNKNOWN]
+              'unknown'
+            in ['general', GENERAL_TEXT_HUMAN]
+              'human'
+            in ['general', GENERAL_TEXT_VEHICLE]
+              'vehicle'
+            else
+              'unclassified'
+            end
+          end
+
+          # Fields not covered by the standard that we would like to include in the export:
+          #
+          # audio_event.score - The score is unbounded and not a probability, so it cannot be used for classificationProbability.
+          # verifications - e.g. verification_correct count, ratio of correct to total verifications etc.#
+          #
+          # See Camtrap DP FAQ for ways to include additional fields https://camtrap-dp.tdwg.org/faq/#measurements;
+          # either as key:value pairs in the observationTags field, or as a custom table with a schema.  Also see the
+          # community feedback issue from the bioacoustic extension report https://github.com/tdwg/camtrap-dp/issues/457
+          #
+          # @param tagging [Tagging] the tagging to map
+          # @param deployment [DeploymentAccumulator::Deployment] the deployment metadata for the tagging; its
+          #   `ensure_timezone` method applies the forced UTC offset, site timezone, or UTC fallback.
+          # @return [Observation] the observation struct with the mapped values
+          def self.mapping(tagging, deployment)
+            audio_event = tagging.audio_event
+            audio_recording = audio_event.audio_recording
+
+            classification_method = audio_event.provenance&.machine_generated? ? 'machine' : nil
+
+            classified_by = audio_event.provenance&.name || tagging.creator.full_name
+
+            scientific_name = tagging.tag.type_of_tag == 'species_name' ? tagging.tag.text : nil
+
+            observation_type = observation_type(tagging.tag)
+
+            # Drop nil values before initializing the struct to prevent type errors.
+            attributes = {
+              observationID: tagging.global_identifier,
+              deploymentID: deployment.site.global_identifier,
+              mediaID: audio_recording.global_identifier,
+              # eventID:,
+              eventStart: deployment.ensure_timezone(audio_event.start_date),
+              eventEnd: deployment.ensure_timezone(audio_event.end_date),
+              observationLevel: OBSERVATION_LEVEL,
+              observationType: observation_type,
+              # deviceSetupType:,
+              scientificName: scientific_name,
+              # count:,
+              # lifeStage:,
+              # sex:,
+              # behavior:,
+              # individualID:,
+              # individualPositionRadius:,
+              # individualPositionAngle:,
+              # individualSpeed:,
+              # bboxX:,
+              # bboxY:,
+              # bboxWidth:,
+              # bboxHeight:,
+              frequencyLow: audio_event.low_frequency_hertz,
+              frequencyHigh: audio_event.high_frequency_hertz,
+              classificationMethod: classification_method,
+              classifiedBy: classified_by,
+              classificationTimestamp: deployment.ensure_timezone(tagging.created_at)
+              # classificationProbability:,
+              # classificationConfirmation:,
+              # observationTags:,
+              # observationComments
+            }.compact
+
+            Observation.new(attributes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/timestamp.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/timestamp.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      Timestamp = Data.define(:time, :precision) {
+        def to_s
+          time.iso8601(precision)
+        end
+
+        # Serialize to a string when as_json is called during our local package validation
+        alias_method :as_json, :to_s
+      }
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/types.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/types.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      module Types
+        include ::BawWorkers::Dry::Types
+
+        UtcTimeSeconds = Constructor(Timestamp) { |input|
+          next nil if input.blank?
+
+          Timestamp.new(UtcTime[input], 0)
+        }
+
+        UtcTimeMicroseconds = Constructor(Timestamp) { |input|
+          next nil if input.blank?
+
+          Timestamp.new(UtcTime[input], 6)
+        }
+
+        Url = Types::String.constructor { |input|
+          URI.parse(input)
+          input.to_s
+        }
+
+        SafePath = Types::String.constructor { |input|
+          path = ::Pathname.new(input)
+          first_path_component = path.to_s.split('/').first
+
+          raise ArgumentError, 'value must be a safe relative path' if path.absolute?
+          raise ArgumentError, 'value must be a safe relative path' unless /\A\.+\z/.match(first_path_component).nil?
+
+          input
+        }
+
+        UrlOrPath = Url | SafePath
+        Schema = Types::Hash | UrlOrPath
+
+        Role = Types::String.default('contributor').enum(
+          'contact',
+          'principalInvestigator',
+          'rightsHolder',
+          'publisher',
+          'contributor'
+        )
+
+        SamplingDesign = Types::String.default('simpleRandom').enum(
+          'simpleRandom',
+          'systematicRandom',
+          'clusteredRandom',
+          'experimental',
+          'targeted',
+          'opportunistic'
+        )
+
+        CaptureMethod = Types::String.enum(
+          'activityDetection',
+          'continuous',
+          'recordingSchedule'
+        )
+
+        TaxonRank = Types::String.enum(
+          'kingdom', 'phylum', 'class', 'order',
+          'family', 'genus', 'species', 'subspecies'
+        )
+
+        GeoJSON = Types::Hash
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/validator.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/export/camtrap_dp/validator.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative 'errors/camtrap_dp_error'
+
+module BawWorkers
+  module Export
+    module CamtrapDp
+      # Data package validation.
+      class Validator
+        # Validation wrapper around the DataPackage and TableSchema gem validation methods.
+        #
+        # @param package [Descriptor::Package] in-memory package descriptor to validate.
+        # @param package_path [String] path to the package directory containing CSV resources.
+        # @return [Boolean] true if the package is valid, raises an error otherwise.
+        def self.validate_package(package, package_path:)
+          data_package = load_package(package, package_path:)
+
+          validate_descriptors(data_package)
+          validate_csv_headers(data_package)
+          validate_csv_data(data_package)
+
+          true
+        end
+
+        # Create a DataPackage::Package with the `profile` path set to our local validation profile path.
+        # See {CamtrapDp::Profile} for more information on the local validation profile.
+        #
+        # @raise [Errors::PackageLoadError] if the package cannot be loaded.
+        # @return [DataPackage::Package]
+        def self.load_package(package, package_path:)
+          # DataPackage gem expects a parsed JSON object, so we need to serialize our Dry::Struct
+          package_descriptor = package.as_json
+
+          # DataPackage::Profile will raise an error if profile is not a string
+          package_descriptor['profile'] = Profile::LOCAL_VALIDATION_PROFILE_PATH.to_s
+
+          DataPackage::Package.new(package_descriptor, opts: { base: package_path.to_s })
+        rescue DataPackage::Exception => e
+          raise Errors::PackageLoadError, "Could not load data package: #{e.detailed_message}"
+        end
+
+        # Validate the package descriptor and each resource descriptor against their profiles.
+        # @param package [DataPackage::Package]
+        # @raise [Errors::DescriptorValidationError]
+        def self.validate_descriptors(package)
+          package.validate
+        rescue DataPackage::ValidationError => e
+          raise Errors::DescriptorValidationError,
+            "Package descriptor validation error: #{descriptor_validation_message(package, e)}"
+        end
+
+        def self.descriptor_validation_message(package, error)
+          details = package.iter_errors {}
+          return error.detailed_message if details.empty?
+
+          details.map(&:squish)
+        end
+
+        # Validate the CSV headers are equal to the schema field names for all package resources.
+        #
+        # The TableSchema gem validation assumes CSV columns are ordered according to the schema. If they aren't,
+        # it can lead to confusing validation errors. CSV headers past the length of the expected schema fields are
+        # ignored, which allows for our additional columns.
+        # @param package [DataPackage::Package]
+        # @raise [Errors::CsvValidationError] if the CSV headers are invalid.
+        def self.validate_csv_headers(package)
+          package.resources.each do |resource|
+            next if resource.schema.field_names == resource.headers.take(resource.schema.field_names.length)
+
+            raise Errors::CsvValidationError,
+              "CSV header validation error in resource '#{resource.name}': " \
+              "expected #{resource.schema.field_names}, got #{resource.headers}"
+          end
+        end
+
+        # Wrapper around the TableSchema gem to validate the CSV data against their schemas. Calling `resource.read`
+        # will validate the data row by row and raise an exception if it is invalid.
+        # @param package [DataPackage::Package]
+        # @raise [Errors::CsvValidationError] if the CSV data is invalid.
+        def self.validate_csv_data(package)
+          package.resources.each do |resource|
+            resource.read
+          rescue DataPackage::ResourceException, TableSchema::Exception => e
+            raise Errors::CsvValidationError,
+              "CSV data validation error in resource '#{resource.name}': #{e.detailed_message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gems/baw-workers/lib/patches/data_package.rb
+++ b/lib/gems/baw-workers/lib/patches/data_package.rb
@@ -1,0 +1,113 @@
+module Baw
+  # TODO: remove when merged https://github.com/frictionlessdata/datapackage-rb/pull/59
+  module DataPackage
+    module Profile
+      # Our output packages use a GitHub URI for the camtrap-dp-acoustic profile. We want to
+      # resolve this locally rather than fetch it over HTTP, but the gem only supports loading
+      # profiles from HTTP URIs or its internal registry and local file paths aren't handled.
+      # This patch adds a local file check to Profile#get_profile_from_registry before
+      # falling back to the registry lookup.
+      def get_profile_from_registry(descriptor)
+        return load_json(descriptor) if File.exist?(descriptor)
+
+        # Original behaviour below
+        @registry = ::DataPackage::Registry.new
+        profile_metadata = @registry.profiles.fetch(descriptor)
+        profile_path = if profile_metadata.fetch('schema_path', nil)
+                         join_paths(base_path(@registry.path), profile_metadata['schema_path'])
+                       else
+                         profile_metadata['schema']
+                       end
+        load_json(profile_path)
+      rescue KeyError
+        raise DataPackage::ProfileException.new "Couldn't find profile with id `#{descriptor}` in registry"
+      end
+    end
+  end
+
+  # TODO: remove when merged https://github.com/frictionlessdata/tableschema-rb/pull/46
+  module TableSchema
+    # Patches the issue https://github.com/frictionlessdata/tableschema-rb/issues/40
+    # Don't want to fail validation if a value is nil and not required.
+    module Field
+      def cast_value(value, constraints: true)
+        cast_value = cast_type(value)
+        return cast_value if constraints == false
+        return cast_value if cast_value.nil? && @required == false
+
+        ::TableSchema::Constraints.new(self, cast_value).validate!
+        cast_value
+      end
+
+      def is_null?(value)
+        value.nil? || @missing_values.include?(value)
+      end
+    end
+
+    module Types
+      module Base
+        private
+
+        # 1) Patches the issue https://github.com/frictionlessdata/tableschema-rb/issues/38
+        # TableSchema expects date/datetime format strings to have a `fmt:` prefix (from an outdated
+        # Data Package Standard), but our schemas omit it. Without the prefix, TableSchema's dynamic
+        # dispatch would try to call `cast_%Y-%m...`, raising a NoMethodError. So we also check for
+        # a bare strptime string and handle it the same way.
+        # 2) Also, ruby doesn't have %f for fractional seconds, but the schema uses it.
+        # So replace %f with %N to correctly parse fractional seconds with microsecond precision.
+        # The cast fmt method uses DateTime.strptime, which doesn't support a digit count, so any number of fractional seconds will be parsed.
+        def set_format
+          field_format = @field[:format] || ''
+
+          if field_format.start_with?('fmt:')
+            @format, @format_string = field_format.split(':', 2)
+          elsif field_format.include?('%')
+            @format = 'fmt'
+            @format_string = field_format.gsub('%f', '%N')
+          else
+            @format = field_format.presence || ::TableSchema::DEFAULTS[:format]
+          end
+        end
+      end
+    end
+
+    # `check_pattern` calls `@value.to_json` before passing it to the regex matcher. For string values, `to_json` wraps
+    # the output in double quotes, so `audio/mpeg` becomes `"audio/mpeg"`. A pattern anchored with `^` then fails
+    # because the leading `"` sits before the expected match position.
+    # Instead, if the value is a string, pass it directly to the matcher, otherwise call `to_json` as before to preserve
+    # the original behaviour for non-string values.
+    module Constraints
+      module Pattern
+        def check_pattern
+          constraint = ->(value) { value.match(/#{@constraints[:pattern]}/) }
+          valid = if @field.type == 'yearmonth'
+                    constraint.call(Date.new(@value[:year], @value[:month]).strftime('%Y-%m'))
+                  else
+                    constraint.call(@value.is_a?(String) ? @value : @value.to_json)
+                  end
+
+          unless valid
+            raise ::TableSchema::ConstraintError.new("The value for the field `#{@field[:name]}` must match the pattern")
+          end
+
+          true
+        end
+      end
+    end
+  end
+end
+
+# For some reason, the patch causes a 'stray' nested constant to appear DataPackage::Resource::DataPackage
+# This breaks constant resolution when Resource#initialize evaluates `@profile = DataPackage::Profile.new()`:
+# <NameError: uninitialized constant DataPackage::Resource::DataPackage::Profile>
+# The fix is to remove the nested constant
+if defined?(DataPackage::Resource) && DataPackage::Resource.const_defined?(:DataPackage, false)
+  DataPackage::Resource.send(:remove_const, :DataPackage)
+end
+
+DataPackage::Profile.prepend(Baw::DataPackage::Profile) if defined?(DataPackage::Profile)
+TableSchema::Field.prepend(Baw::TableSchema::Field) if defined?(TableSchema::Field)
+TableSchema::Types::Base.prepend(Baw::TableSchema::Types::Base) if defined?(TableSchema::Types::Base)
+if defined?(TableSchema::Constraints::Pattern)
+  TableSchema::Constraints::Pattern.prepend(Baw::TableSchema::Constraints::Pattern)
+end

--- a/lib/tasks/camtrap_dp_profile_update.rake
+++ b/lib/tasks/camtrap_dp_profile_update.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :baw do
+  namespace :camtrap_dp do
+    profile = BawWorkers::Export::CamtrapDp::Profile
+
+    desc 'Download the pinned camtrap-dp profile assets and build the local validation profile.'
+    task :update do
+      download_result = profile.download
+      validation_result = profile.create_local_validation_profile
+      readme = profile.build_readme(download_result, validation_result)
+
+      print readme
+      profile.write_readme(readme)
+    end
+  end
+end

--- a/spec/factories/tag_factory.rb
+++ b/spec/factories/tag_factory.rb
@@ -34,6 +34,12 @@ FactoryBot.define do
     type_of_tag { 'general' }
     is_taxonomic { false }
 
+    trait :taxonomic_true_species do
+      is_taxonomic { true }
+      type_of_tag { :species_name }
+      sequence(:text, 'a') { |n| "Species #{n}" }
+    end
+
     trait :taxonomic_true_common do
       is_taxonomic { true }
       type_of_tag { :common_name }
@@ -52,6 +58,7 @@ FactoryBot.define do
       notes { { 'comment' => 'value' } }
     end
 
+    factory :tag_taxonomic_true_species, traits: [:taxonomic_true_species]
     factory :tag_taxonomic_true_common, traits: [:taxonomic_true_common]
     factory :tag_taxonomic_true_common_notes, traits: [:tag_taxonomic_true_common, :notes]
     factory :tag_taxonomic_false_sounds_like, traits: [:taxonomic_false_sounds_like]

--- a/spec/lib/gems/baw_workers/dry/ordered_struct_spec.rb
+++ b/spec/lib/gems/baw_workers/dry/ordered_struct_spec.rb
@@ -1,0 +1,15 @@
+describe BawWorkers::Dry::OrderedStruct do
+  let(:struct_class) do
+    Class.new(described_class) do
+      attribute :shape, BawWorkers::Dry::Types::String
+      attribute? :color, BawWorkers::Dry::Types::String
+      attribute :count, BawWorkers::Dry::Types::Integer
+    end
+  end
+
+  it 'returns values in schema order including nils for optional attributes' do
+    instance = struct_class.new(count: 3, shape: 'circle')
+
+    expect(instance.ordered_values).to eq(['circle', nil, 3])
+  end
+end

--- a/spec/lib/gems/baw_workers/export/camtrap_dp/exporter_spec.rb
+++ b/spec/lib/gems/baw_workers/export/camtrap_dp/exporter_spec.rb
@@ -1,0 +1,379 @@
+# frozen_string_literal: true
+
+describe BawWorkers::Export::CamtrapDp::Exporter do
+  create_entire_hierarchy
+
+  subject(:exporter) { BawWorkers::Export::CamtrapDp::Exporter.new(filter, export_options) }
+
+  let(:export_options) do
+    BawWorkers::Export::CamtrapDp::Exporter::RequiredExporterOptions.new(
+      user: nil,
+      should_obfuscate: nil,
+      contributors: [{ title: 'Alice', path: 'http://www.test' }],
+      project_capture_method: ['continuous', 'recordingSchedule'],
+      project_sampling_design: 'systematicRandom',
+      package_title: 'Test Package Title',
+      emit_project_license: true,
+      forced_timezone: nil
+    )
+  end
+
+  let(:filter) {
+    Tagging.joins(:tag).where(tags: { type_of_tag: 'species_name', is_taxonomic: true })
+  }
+
+  let!(:export_tagging) do
+    create(:tagging, audio_event:, tag: create(:tag_taxonomic_true_species), creator: writer_user)
+  end
+
+  context 'with invalid filter object' do
+    let(:filter) { 'not a relation' }
+
+    it { expect { subject }.to raise_error(ArgumentError, 'Expected filter to be ActiveRecord::Relation') }
+  end
+
+  context 'with a missing Tagging relation on filter' do
+    let(:filter) { AudioEvent.all }
+
+    it { expect { subject }.to raise_error(ArgumentError, /Expected filter to be Tagging relation/) }
+  end
+
+  context 'with invalid exporter options' do
+    let(:export_options) { 'not a RequiredExporterOptions' }
+
+    error_message = 'exporter_options must be a RequiredExporterOptions object'
+    it { expect { subject }.to raise_error(ArgumentError, error_message) }
+  end
+
+  describe '#call' do
+    let(:package_filenames) { BawWorkers::Export::CamtrapDp::PACKAGE_FILENAMES }
+    let(:manifest) { @manifest }
+    let(:package_path) { manifest.package_path }
+
+    def with_export_manifest
+      subject.call do |manifest|
+        @manifest = manifest
+        yield manifest
+      end
+    end
+
+    def csv_row(filename) = CSV.read(package_path.join(filename), headers: true).first.to_h
+
+    def package_data
+      {
+        deployments: csv_row('deployments.csv'),
+        media: csv_row('media.csv'),
+        observations: csv_row('observations.csv'),
+        descriptor: JSON.parse(package_path.join('datapackage.json').read)
+      }
+    end
+
+    def expect_exported_times_in(time_zone)
+      ensure_timezone_with_precision = ->(precision, time) { time.in_time_zone(time_zone).iso8601(precision) }.curry
+      ensure_timezone_with_seconds = ensure_timezone_with_precision.call(0)
+      ensure_timezone_with_microseconds = ensure_timezone_with_precision.call(6)
+
+      with_export_manifest do
+        rows = package_data
+        expect(rows[:deployments]).to include(
+          'deploymentStart' => ensure_timezone_with_seconds.call(audio_recording.recorded_date),
+          'deploymentEnd' => ensure_timezone_with_seconds.call(audio_recording.recorded_end_date)
+        )
+
+        expect(rows[:media]).to include(
+          'timestamp' => ensure_timezone_with_microseconds.call(audio_recording.recorded_date)
+        )
+
+        expect(rows[:observations]).to include(
+          'eventStart' => ensure_timezone_with_microseconds.call(audio_recording.recorded_date + audio_event.start_time_seconds.seconds),
+          'eventEnd' => ensure_timezone_with_microseconds.call(audio_recording.recorded_date + audio_event.end_time_seconds.seconds),
+          'classificationTimestamp' => ensure_timezone_with_seconds.call(export_tagging.created_at)
+        )
+
+        expect(rows[:descriptor]['temporal']).to include(
+          'start' => ensure_timezone_with_seconds.call(audio_recording.recorded_date),
+          'end' => ensure_timezone_with_seconds.call(audio_recording.recorded_end_date)
+        )
+      end
+    end
+
+    it 'requires a block' do
+      expect { subject.call }.to raise_error(ArgumentError, 'block is required')
+    end
+
+    context 'with invalid options that populate schema fields' do
+      let(:export_options) { super().with(project_capture_method: 1) }
+
+      it {
+        expect { subject.call { nil } }.to raise_error(
+          Dry::Struct::Error,
+          /1 \(Integer\) has invalid type for :captureMethod violates constraints/
+        )
+      }
+    end
+
+    context 'with invalid forced_timezone type' do
+      let(:export_options) { super().with(forced_timezone: 'invalid') }
+      let(:error_message) { /forced_timezone: got String, expected ActiveSupport::TimeZone or TZInfo::Timezone/ }
+
+      it { expect { subject.call { nil } }.to raise_error(ArgumentError, error_message) }
+    end
+
+    context 'with zero rows returned by the filter' do
+      let(:filter) { Tagging.none }
+
+      it 'raises an error' do
+        expect { subject.call { nil } }.to raise_error(ArgumentError, 'Filter returned no data, cannot export')
+      end
+    end
+
+    it 'yields a manifest with the package file paths and stats' do
+      with_export_manifest do
+        temp_dir = package_path.parent
+        expected_files = package_filenames.transform_values { |filename|
+          package_path.join(filename)
+        }
+
+        expected_file_stats = expected_files.transform_values { |file|
+          { size: file.size, mtime: file.mtime }
+        }
+
+        expected_manifest = {
+          package_path: temp_dir.join(BawWorkers::Export::CamtrapDp::PACKAGE_PATH),
+          zip_path: temp_dir.join(BawWorkers::Export::CamtrapDp::ZIP_PATH),
+          file_stats: expected_file_stats
+        }
+
+        expect(expected_files.values).to all(exist)
+        expect(manifest.to_h).to eq(expected_manifest)
+      end
+    end
+
+    it 'when yielding, includes all package files in the zip' do
+      zip_entries = with_export_manifest {
+        Zip::File.open(manifest.zip_path) { |zip| zip.entries.map(&:name) }
+      }
+
+      expect(zip_entries).to match_array(package_filenames.values.map(&:to_s))
+    end
+
+    it 'cleans up the temporary directory after yielding' do
+      temp_dir = nil
+
+      with_export_manifest do
+        temp_dir = package_path.parent
+        expect(Dir).to exist(temp_dir)
+      end
+
+      expect(Dir).not_to exist(temp_dir)
+    end
+
+    it 'calculates deployment start and end times from all site audio recordings' do
+      earliest_recording = create(:audio_recording, recorded_date: audio_recording.recorded_date - 1.day, site:,
+        creator: writer_user)
+      latest_recording = create(:audio_recording, recorded_date: audio_recording.recorded_date + 1.day, site:,
+        creator: writer_user)
+
+      with_export_manifest do
+        rows = package_data
+        expect(rows[:deployments]).to include(
+          'deploymentStart' => earliest_recording.recorded_date.utc.iso8601(0),
+          'deploymentEnd' => latest_recording.recorded_end_date.utc.iso8601(0)
+        )
+        expect(rows[:descriptor]['temporal']).to include(
+          'start' => earliest_recording.recorded_date.utc.iso8601(0),
+          'end' => latest_recording.recorded_end_date.utc.iso8601(0)
+        )
+      end
+    end
+
+    it 'writes configured client-host identifiers for table ids and foreign keys' do
+      rows = with_export_manifest { package_data }
+
+      expect(rows[:deployments]).to include(
+        'deploymentID' => "ecosounds.org/sites/#{site.id}",
+        'locationID' => "ecosounds.org/sites/#{site.id}"
+      )
+      expect(rows[:media]).to include(
+        'mediaID' => "ecosounds.org/audio_recordings/#{audio_recording.id}",
+        'deploymentID' => "ecosounds.org/sites/#{site.id}"
+      )
+      expect(rows[:observations]).to include(
+        'observationID' => "ecosounds.org/audio_recordings/#{audio_recording.id}/audio_events/#{audio_event.id}/taggings/#{export_tagging.id}",
+        'deploymentID' => "ecosounds.org/sites/#{site.id}",
+        'mediaID' => "ecosounds.org/audio_recordings/#{audio_recording.id}"
+      )
+    end
+
+    it 'writes machine classification details from audio event provenance' do
+      audio_event.update!(provenance:)
+
+      result = with_export_manifest {
+        CSV.read(package_path.join('observations.csv'), headers: true).first.to_h
+      }
+
+      expect(result).to include(
+        'classificationMethod' => 'machine',
+        'classifiedBy' => provenance.name
+      )
+    end
+
+    it 'writes a default package source using the client settings' do
+      allow(Settings.client).to receive(:host).and_return('ecoacoustics')
+
+      result = with_export_manifest {
+        JSON.parse(package_path.join('datapackage.json').read).fetch('sources')
+      }
+
+      expect(result).to contain_exactly(
+        include(
+          'title' => 'Ecoacoustics',
+          'path' => Settings.client_routes.home_url
+        )
+      )
+    end
+
+    context 'with no user or obfuscation override' do
+      it 'writes public coordinates' do
+        result = with_export_manifest {
+          CSV.read(package_path.join('deployments.csv'), headers: true).first.to_h
+        }
+
+        coordinate_uncertainty = site.total_coordinate_uncertainty_meters
+        obfuscation_uncertainty = coordinate_uncertainty - site.effective_measurement_uncertainty_meters
+        expected_tags = 'coordinatesObfuscated:true | ' \
+                        'dataGeneralizations:coordinates have an assumed measurement uncertainty of 30 meters; ' \
+                        "coordinates have an obfuscation uncertainty of #{obfuscation_uncertainty} meters"
+
+        expect(result).to include(
+          'latitude' => site.public_latitude.to_s,
+          'longitude' => site.public_longitude.to_s,
+          'coordinateUncertainty' => coordinate_uncertainty.to_i.to_s,
+          'deploymentTags' => expected_tags
+        )
+      end
+    end
+
+    context 'when a user with permission is supplied' do
+      let(:export_options) { super().with(user: owner_user) }
+
+      it 'writes real coordinates' do
+        result = with_export_manifest {
+          CSV.read(package_path.join('deployments.csv'), headers: true).first.to_h
+        }
+
+        expect(result).to include(
+          'latitude' => site.latitude.to_s,
+          'longitude' => site.longitude.to_s,
+          'coordinateUncertainty' => '30',
+          'deploymentTags' => 'coordinatesObfuscated:false | dataGeneralizations:coordinates have an assumed measurement uncertainty of 30 meters'
+        )
+      end
+    end
+
+    context 'when obfuscation is enabled' do
+      let(:export_options) { super().with(should_obfuscate: true) }
+
+      it 'writes obfuscated coordinates' do
+        result = with_export_manifest {
+          CSV.read(package_path.join('deployments.csv'), headers: true).first.to_h
+        }
+
+        coordinate_uncertainty = site.total_coordinate_uncertainty_meters(should_obfuscate: true)
+        obfuscation_uncertainty = coordinate_uncertainty - site.effective_measurement_uncertainty_meters
+        expected_tags = 'coordinatesObfuscated:true | ' \
+                        'dataGeneralizations:coordinates have an assumed measurement uncertainty of 30 meters; ' \
+                        "coordinates have an obfuscation uncertainty of #{obfuscation_uncertainty} meters"
+
+        expect(result).to include(
+          'latitude' => site.obfuscated_latitude.to_s,
+          'longitude' => site.obfuscated_longitude.to_s,
+          'coordinateUncertainty' => coordinate_uncertainty.to_i.to_s,
+          'deploymentTags' => expected_tags
+        )
+      end
+    end
+
+    context 'when obfuscation is disabled' do
+      let(:export_options) { super().with(should_obfuscate: false) }
+
+      it 'writes real coordinates' do
+        result = with_export_manifest {
+          CSV.read(package_path.join('deployments.csv'), headers: true).first.to_h
+        }
+
+        expect(result).to include(
+          'latitude' => site.latitude.to_s,
+          'longitude' => site.longitude.to_s,
+          'coordinateUncertainty' => '30',
+          'deploymentTags' => 'coordinatesObfuscated:false | dataGeneralizations:coordinates have an assumed measurement uncertainty of 30 meters'
+        )
+      end
+    end
+
+    context 'when the site has custom obfuscated coordinates' do
+      before { site.update!(custom_obfuscated_location: true) }
+
+      it 'writes unknown uncertainty due to custom obfuscation' do
+        result = with_export_manifest {
+          CSV.read(package_path.join('deployments.csv'), headers: true).first.to_h
+        }
+
+        expected_tags = 'coordinatesObfuscated:true | ' \
+                        'dataGeneralizations:coordinates have an assumed measurement uncertainty of 30 meters; ' \
+                        'coordinates have an unknown obfuscation uncertainty'
+
+        expect(result).to include(
+          'latitude' => site.obfuscated_latitude.to_s,
+          'longitude' => site.obfuscated_longitude.to_s,
+          'coordinateUncertainty' => '',
+          'deploymentTags' => expected_tags
+        )
+      end
+    end
+
+    it 'writes taxonomic coverage from observed scientific names' do
+      result = with_export_manifest {
+        JSON.parse(package_path.join('datapackage.json').read).fetch('taxonomic')
+      }
+
+      expect(result).to contain_exactly(
+        include('scientificName' => export_tagging.tag.text)
+      )
+    end
+
+    context 'when the site has no timezone' do
+      before { site.update!(tzinfo_tz: nil) }
+
+      it 'falls back to UTC for exported time fields' do
+        expect_exported_times_in(ActiveSupport::TimeZone['UTC'])
+      end
+    end
+
+    context 'when the site has a timezone' do
+      before { site.update!(tzinfo_tz: 'Australia/Brisbane') }
+
+      it 'writes exported time fields in the site timezone' do
+        expect_exported_times_in(ActiveSupport::TimeZone['Australia/Brisbane'])
+      end
+    end
+
+    context 'when the site timezone is UTC' do
+      before { site.update!(tzinfo_tz: 'UTC') }
+
+      it 'leaves exported time fields in UTC' do
+        expect_exported_times_in(ActiveSupport::TimeZone['UTC'])
+      end
+    end
+
+    context 'when a force UTC offset is supplied' do
+      let(:export_options) { super().with(forced_timezone: ActiveSupport::TimeZone['America/Sao_Paulo']) }
+
+      before { site.update!(tzinfo_tz: 'Australia/Brisbane') }
+
+      it 'writes exported time fields with the offset' do
+        expect_exported_times_in(ActiveSupport::TimeZone['America/Sao_Paulo'])
+      end
+    end
+  end
+end

--- a/spec/lib/gems/baw_workers/export/camtrap_dp/table/observation_spec.rb
+++ b/spec/lib/gems/baw_workers/export/camtrap_dp/table/observation_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe BawWorkers::Export::CamtrapDp::Table::Observation do
+  describe '.observation_type' do
+    let(:observation_table) { BawWorkers::Export::CamtrapDp::Table::Observation }
+
+    it 'maps taxonomic tags to animal', :aggregate_failures do
+      expect(observation_table.observation_type(build(
+        :tag,
+        type_of_tag: 'species_name',
+        text: 'Species test',
+        is_taxonomic: true
+      ))).to eq('animal')
+
+      expect(observation_table.observation_type(build(
+        :tag,
+        type_of_tag: 'common_name',
+        text: 'Common test',
+        is_taxonomic: true
+      ))).to eq('animal')
+    end
+
+    it 'maps known general tags to their observation types', :aggregate_failures do
+      expect(observation_table.observation_type(build(
+        :tag,
+        type_of_tag: 'general',
+        text: 'unknown'
+      ))).to eq('unknown')
+
+      expect(observation_table.observation_type(build(
+        :tag,
+        type_of_tag: 'general',
+        text: 'Human Voice'
+      ))).to eq('human')
+
+      expect(observation_table.observation_type(build(
+        :tag,
+        type_of_tag: 'general',
+        text: 'chainsaw'
+      ))).to eq('vehicle')
+    end
+
+    it 'maps unmatched general tags to unclassified' do
+      expect(observation_table.observation_type(build(
+        :tag,
+        type_of_tag: 'general',
+        text: 'weather'
+      ))).to eq('unclassified')
+    end
+  end
+end

--- a/spec/lib/gems/baw_workers/export/camtrap_dp/validator_spec.rb
+++ b/spec/lib/gems/baw_workers/export/camtrap_dp/validator_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe BawWorkers::Export::CamtrapDp::Validator do
+  create_entire_hierarchy
+
+  subject(:validator) { described_class }
+
+  let(:export_options) do
+    BawWorkers::Export::CamtrapDp::Exporter::RequiredExporterOptions.new(
+      user: nil,
+      should_obfuscate: true,
+      contributors: [{ title: 'Alice', path: 'http://www.test' }],
+      project_capture_method: ['continuous', 'recordingSchedule'],
+      project_sampling_design: 'systematicRandom',
+      package_title: 'Test Package',
+      emit_project_license: true,
+      forced_timezone: nil
+    )
+  end
+
+  let(:filter) { Tagging.joins(:tag).where(tags: { type_of_tag: 'species_name', is_taxonomic: true }) }
+
+  let!(:export_tagging) {
+    create(:tagging, audio_event:, tag: create(:tag_taxonomic_true_species), creator: writer_user)
+  }
+
+  let(:exporter) { BawWorkers::Export::CamtrapDp::Exporter.new(filter, export_options) }
+
+  let(:manifest) { @manifest }
+  let(:package_path) { manifest.package_path }
+  let(:package_descriptor) { JSON.parse(package_path.join('datapackage.json').read) }
+  let(:local_validation_profile_path) { BawWorkers::Export::CamtrapDp::Profile::LOCAL_VALIDATION_PROFILE_PATH }
+
+  def with_export_manifest
+    exporter.call do |manifest|
+      @manifest = manifest
+      yield manifest
+    end
+  end
+
+  describe '.load_package' do
+    it 'replaces the profile path in the package descriptor with the local validation profile path string' do
+      with_export_manifest do
+        package = validator.load_package(package_descriptor, package_path:)
+
+        expect(package.profile.name).to eq(local_validation_profile_path.to_s)
+      end
+    end
+  end
+
+  describe '.validate_package' do
+    it 'raises on invalid package metadata' do
+      with_export_manifest do
+        package_descriptor.delete('contributors')
+
+        expect {
+          validator.validate_package(package_descriptor, package_path:)
+        }.to raise_error(
+          BawWorkers::Export::CamtrapDp::Errors::DescriptorValidationError
+        ) { |error|
+          expect(error.message).to include(
+            'Package descriptor validation error',
+            "The property '#/' of type object did not match all of the required schemas",
+            "The property '#/' did not contain a required property of 'contributors'"
+          )
+        }
+      end
+    end
+
+    it 'raises when CSV headers do not match the schema field order' do
+      with_export_manifest do
+        invalid_csv = "\"wrong\",\"headers\"\ndata,data\n"
+        File.write(package_path.join('deployments.csv'), invalid_csv)
+
+        expect {
+          validator.validate_package(package_descriptor, package_path:)
+        }.to raise_error(
+          BawWorkers::Export::CamtrapDp::Errors::CsvValidationError
+        ) { |error|
+          expect(error.message).to include(
+            "CSV header validation error in resource 'deployments'",
+            'expected ["deploymentID", "locationID"',
+            'got ["wrong", "headers"]'
+          )
+        }
+      end
+    end
+
+    it 'raises on invalid CSV data' do
+      with_export_manifest do
+        deployments_path = package_path.join('deployments.csv')
+
+        deployments = CSV.read(deployments_path, headers: true)
+        deployments[0]['latitude'] = 'invalid'
+        deployments_path.write(deployments.to_csv)
+
+        expect {
+          validator.validate_package(package_descriptor, package_path:)
+        }.to raise_error(
+          BawWorkers::Export::CamtrapDp::Errors::CsvValidationError,
+          /CSV data validation error in resource 'deployments': invalid is not a number/
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/camtrap_dp_profile_update_spec.rb
+++ b/spec/lib/tasks/camtrap_dp_profile_update_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require(Rails.root / 'spec' / 'support' / 'shared_context' / 'rake_context')
+
+describe 'baw:camtrap_dp:update' do
+  include_context 'rake_spec_context'
+
+  let(:profile) { BawWorkers::Export::CamtrapDp::Profile }
+  let(:written_readme) { {} }
+  let(:written_local_validation_profile) { {} }
+
+  before do
+    # Capture the README content without rewriting the checked-in fixture file.
+    allow(File).to receive(:write) do |path, content|
+      written_readme[:path] = path
+      written_readme[:content] = content
+    end
+
+    # Capture the generated local profile so the example can assert the real inlined schema bodies.
+    allow(profile.const_get(:LOCAL_VALIDATION_PROFILE_PATH)).to receive(:write) do |content|
+      written_local_validation_profile[:content] = content
+    end
+
+    # Stub the pinned profile asset requests so Profile.download exercises its HTTP fetch logic without network access.
+    profile.const_get(:ASSET_FILES).each_value do |filename|
+      stub_request(:get, URI.join(profile.const_get(:SOURCE_URL), filename).to_s)
+        .to_return(body: (profile.const_get(:DIRECTORY) / filename).read)
+    end
+
+    stub_request(:get, 'https://specs.frictionlessdata.io/schemas/data-package.json')
+      .to_return(body: JSON.generate(data_package_schema))
+
+    stub_request(:get, 'http://json.schemastore.org/geojson.json')
+      .to_return(body: JSON.generate(schema_store_geojson_schema))
+
+    stub_request(:get, 'https://geojson.org/schema/GeoJSON.json')
+      .to_return(body: JSON.generate(geojson_schema))
+  end
+
+  around do |example|
+    Timecop.freeze(generated_at)
+    example.run
+  ensure
+    Timecop.return
+  end
+
+  let(:generated_at) { Time.utc(2026, 7, 29, 3, 50, 44) }
+  let(:data_package_schema) do
+    # This is not the main camtrap profile file. It is the fake JSON document returned when the
+    # code follows the data-package ref inside camtrap-dp-profile-acoustic.json.
+    {
+      '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+      'title' => 'Data Package Schema',
+      'type' => 'object',
+      'properties' => {
+        # The main camtrap profile already has refs to the data-package URL and the schemastore
+        # URL. This nested ref is what makes the real code discover the third geojson.org URL.
+        # If this ref changes, the test should fail because that third URL will stop appearing in
+        # the README and its JSON document will stop appearing in the generated local profile.
+        'spatial' => {
+          '$ref' => 'https://geojson.org/schema/GeoJSON.json'
+        }
+      }
+    }
+  end
+  let(:schema_store_geojson_schema) do
+    # Fake JSON document returned for the schemastore ref that already exists in the main profile.
+    {
+      '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+      'title' => 'Schema Store GeoJSON',
+      'type' => 'object'
+    }
+  end
+  let(:geojson_schema) do
+    # Fake JSON document returned for the nested geojson.org ref introduced above.
+    {
+      '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+      'title' => 'GeoJSON Org Schema',
+      'type' => 'object'
+    }
+  end
+  let(:expected_readme_output) do
+    <<~MARKDOWN
+      # CamTrap DP Bioacoustics Downloaded profile assets
+
+      The files in this directory (including this readme) are generated with the `baw:camtrap_dp:update` rake task. Do not edit these files manually.
+
+      Generation date: 2026-07-29 03:50:44 UTC
+      Source: https://raw.githubusercontent.com/camera-traps/bioacoustics/e4b4722fb453f5ca39c39ea3c4f348e9953f0084/camtrap-dp/1.0.2/
+
+      ---
+
+      ## Downloaded profile assets
+
+      - Profile: ./camtrap-dp-profile-acoustic.json
+      - Deployments: ./deployments-table-schema-acoustic.json
+      - Media: ./media-table-schema-acoustic.json
+      - Observations: ./observations-table-schema-acoustic.json
+
+      ## Local validation profile
+
+      - Profile: ./camtrap-dp-profile-acoustic.local.json
+      - External references inlined:
+        - https://specs.frictionlessdata.io/schemas/data-package.json
+        - https://geojson.org/schema/GeoJSON.json
+        - http://json.schemastore.org/geojson.json
+    MARKDOWN
+  end
+
+  it 'downloads the assets, builds the local validation profile, and writes the README' do
+    expect { subject.invoke }.to output(expected_readme_output).to_stdout
+
+    expect(written_readme).to eq(
+      path: profile.const_get(:README_PATH),
+      content: expected_readme_output
+    )
+
+    expect(written_local_validation_profile.fetch(:content)).to include('"title": "Data Package Schema"')
+    expect(written_local_validation_profile.fetch(:content)).to include('"title": "GeoJSON Org Schema"')
+    expect(written_local_validation_profile.fetch(:content)).to include('"title": "Schema Store GeoJSON"')
+  end
+end

--- a/spec/models/audio_event_spec.rb
+++ b/spec/models/audio_event_spec.rb
@@ -134,18 +134,18 @@ describe AudioEvent do
       AudioEvent
         .joins(:audio_recording)
         .select(
-          AudioEvent.start_date_arel.as('start_date'),
-          AudioEvent.end_date_arel.as('end_date')
+          AudioEvent.start_date_arel.as('event_start_date'),
+          AudioEvent.end_date_arel.as('event_end_date')
         )
         .find(audio_event.id)
     }
 
     it 'has a start_date arel expression' do
-      expect(event.start_date).to eq(Time.zone.parse('2023-10-01 12:02:03.456'))
+      expect(event.event_start_date).to eq(Time.zone.parse('2023-10-01 12:02:03.456'))
     end
 
     it 'has a end_date arel expression' do
-      expect(event.end_date).to eq(Time.zone.parse('2023-10-01 12:07:36.789'))
+      expect(event.event_end_date).to eq(Time.zone.parse('2023-10-01 12:07:36.789'))
     end
   end
 

--- a/spec/models/audio_recording_spec.rb
+++ b/spec/models/audio_recording_spec.rb
@@ -638,6 +638,14 @@ describe AudioRecording do
     expect(audio_recording.simple_name).to eq("#{audio_recording.id}.#{audio_recording.original_format_calculated}")
   end
 
+  it 'can emit recorded end date' do
+    duration_seconds = 60
+    recorded_date = Time.current
+    audio_recording = create(:audio_recording, duration_seconds:, recorded_date:)
+
+    expect(audio_recording.recorded_end_date).to eq(recorded_date + duration_seconds.seconds)
+  end
+
   it_behaves_like 'cascade deletes for', :audio_recording, {
     audio_events: {
       taggings: nil,

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -65,6 +65,26 @@ describe Permission, type: :model do
   it { is_expected.not_to allow_value(nil).for(:allow_anonymous) }
   it { is_expected.not_to allow_value(nil).for(:allow_logged_in) }
 
+  describe '#public_access?' do
+    it 'is true when anonymous access is allowed' do
+      permission = build(:read_anon_permission)
+
+      expect(permission).to be_public_access
+    end
+
+    it 'is true when logged-in access is allowed' do
+      permission = build(:read_logged_in_permission)
+
+      expect(permission).to be_public_access
+    end
+
+    it 'is false for user-specific permissions' do
+      permission = build(:read_permission)
+
+      expect(permission).not_to be_public_access
+    end
+  end
+
   context 'special tests' do
     let(:user) { create(:user) }
     let(:project) { create(:project, creator: user) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -65,6 +65,127 @@ describe Site do
     expect(s.errors[:name].size).to eq 1
   end
 
+  describe '#public_site?' do
+    let(:site) { create(:site) }
+    let(:project) { site.projects.first }
+
+    it 'is false when permissions are user-specific' do
+      expect(site).not_to be_public_site
+    end
+
+    it 'is true when any project allows anonymous access' do
+      create(:read_anon_permission, creator: project.creator, project:)
+
+      expect(site).to be_public_site
+    end
+
+    it 'is true when any project allows logged-in access' do
+      create(:read_logged_in_permission, creator: project.creator, project:)
+
+      expect(site).to be_public_site
+    end
+  end
+
+  describe '#public_latitude and #public_longitude' do
+    let(:site) { create(:site, :with_lat_long) }
+
+    it 'returns obfuscated coordinates when there is no user' do
+      expect(site.public_latitude).to eq(site.obfuscated_latitude)
+      expect(site.public_longitude).to eq(site.obfuscated_longitude)
+    end
+
+    it 'returns real coordinates when user override has permission' do
+      expect(site.public_latitude(user: site.projects.first.creator)).to eq(site.latitude)
+      expect(site.public_longitude(user: site.projects.first.creator)).to eq(site.longitude)
+    end
+
+    it 'returns obfuscated coordinates when user override does not have permission' do
+      user = create(:user)
+      expect(site.public_latitude(user:)).to eq(site.obfuscated_latitude)
+      expect(site.public_longitude(user:)).to eq(site.obfuscated_longitude)
+    end
+
+    it 'returns real coordinates when should_obfuscate is false' do
+      expect(site.public_latitude(should_obfuscate: false)).to eq(site.latitude)
+      expect(site.public_longitude(should_obfuscate: false)).to eq(site.longitude)
+    end
+  end
+
+  describe 'coordinate uncertainty' do
+    # rubocop:disable Layout/LineLength
+    # Cases cover the product of the following conditions, not including invalid cases:
+    #  - coordinates provided or not (latitude/longitude.present?)
+    #  - uncertainty provided or not (measurement_uncertainty_provided?)
+    #  - obfuscated or not (location_obfuscated)
+    #  - custom obfuscation or not (custom_obfuscated_location)
+    #  - nil obfuscated coordinates or not (obfuscated_latitude/longitude.nil?)
+    a = 30
+    b = 666
+    c = 1000
+    d = 367.35435
+    assumed = "coordinates have an assumed measurement uncertainty of #{a} meters"
+    provided = "coordinates have a measurement uncertainty of #{b} meters"
+    default = "coordinates have an obfuscation uncertainty of #{d} meters"
+    custom = "coordinates have an obfuscation uncertainty of #{c} meters"
+    hidden = 'coordinates are intentionally hidden'
+
+    cases =
+      # coordinates_provided, uncertainty_provided, obfuscated, custom_obfuscation, nil_obfuscated_coordinates, uncertainty, tag_coordinates_obfuscated, measurement_text, obfuscation_text
+      [
+        [true,  false, false, true,  false, a,     false, assumed,  nil],
+        [true,  true,  false, true,  false, b,     false, provided, nil],
+        [true,  false, true,  true,  false, a + c, true,  assumed,  custom],
+        [true,  true,  true,  true,  false, b + c, true,  provided, custom],
+        [true,  false, false, false, false, a,     false, assumed,  nil],
+        [false, false, false, false, false, nil,   nil,   nil,      nil],
+        [true,  true,  false, false, false, b,     false, provided, nil],
+        [true,  false, true,  false, false, a + d, true,  assumed,  default],
+        [true,  true,  true,  false, false, b + d, true,  provided, default],
+        [true,  false, false, true,  true,  a,     false, assumed,  nil],
+        [true,  true,  false, true,  true,  b,     false, provided, nil],
+        [true,  false, true,  true,  true,  nil,   true,  hidden,   hidden],
+        [true,  true,  true,  true,  true,  nil,   true,  hidden,   hidden]
+      ]
+
+    cases.each_with_index do |single_case, index|
+      it "resolves uncertainty values correctly — Case: #{index}" do
+        coordinates_provided, uncertainty_provided, obfuscated,
+        custom_obfuscation, nil_obfuscated_coordinates, uncertainty,
+        coordinates_obfuscated_tag, measurement_text,
+        obfuscated_text = single_case
+
+        latitude, longitude = coordinates_provided ? [-27, 152] : [nil, nil]
+
+        # When custom_obfuscated_location is false, site has default obfuscation.
+        # When custom_obfuscated_location is true, site has nil obfuscated coordinates by default (which means 'intentionally hidden by user').
+        site_new = create(:site, latitude:, longitude:, custom_obfuscated_location: custom_obfuscation)
+
+        # When custom_obfuscated_location is true and nil_obfuscated_coordinates: false, this site was obfuscated by the user (e.g. a 1000m buffer).
+        if custom_obfuscation && (nil_obfuscated_coordinates == false)
+          site_new.obfuscated_latitude = -27.0001
+          site_new.obfuscated_longitude = 152.0001
+        end
+
+        # Simulate a provided measurement uncertainty since we don't have a DB field for it.
+        allow(site_new).to receive(:measurement_uncertainty_meters).and_return(uncertainty_provided ? 666 : nil)
+        expect(site_new.measurement_uncertainty_provided?).to eq(uncertainty_provided)
+
+        # TODO: remove when closed https://github.com/QutEcoacoustics/baw-server/issues/1025.
+        # Until then, override the relevant cases to expect the interim behaviour.
+        if obfuscated && custom_obfuscation && !nil_obfuscated_coordinates
+          uncertainty = nil
+          obfuscated_text = 'coordinates have an unknown obfuscation uncertainty'
+        end
+
+        expect(site_new.total_coordinate_uncertainty_meters(should_obfuscate: obfuscated)).to uncertainty.nil? ? eq(uncertainty) : be_within(2).of(uncertainty)
+        expect(site_new.coordinates_provided? ? site_new.location_obfuscated(user: nil, should_obfuscate: obfuscated) : nil).to eq(coordinates_obfuscated_tag)
+        expect(site_new.measurement_uncertainty_text(user: nil, should_obfuscate: obfuscated)).to eq(measurement_text)
+        expect(site_new.obfuscation_uncertainty_text(user: nil, should_obfuscate: obfuscated)).to eq(obfuscated_text)
+      end
+    end
+    # rubocop:enable Layout/LineLength
+  end
+
   describe 'location obfuscation' do
     latitudes = [
       { -100 => false },
@@ -97,7 +218,7 @@ describe Site do
         expect(s.obfuscated_latitude).to be_within(Site::JITTER_RANGE).of(s.latitude)
         expect(s.obfuscated_longitude).to be_within(Site::JITTER_RANGE).of(s.longitude)
 
-        jitter_exclude_range = Site::JITTER_RANGE * 0.1
+        jitter_exclude_range = Site::JITTER_EXCLUSION_RANGE
         expect(s.obfuscated_latitude).not_to be_within(jitter_exclude_range).of(s.latitude)
         expect(s.obfuscated_longitude).not_to be_within(jitter_exclude_range).of(s.longitude)
       end
@@ -130,7 +251,7 @@ describe Site do
       s = build(:site, :with_lat_long)
 
       jitter_range = Site::JITTER_RANGE
-      jitter_exclude_range = Site::JITTER_RANGE * 0.1
+      jitter_exclude_range = Site::JITTER_EXCLUSION_RANGE
 
       lat_min = Site::LATITUDE_MIN
       lat_max = Site::LATITUDE_MAX
@@ -224,7 +345,7 @@ describe Site do
         site = create(:site, :with_lat_long)
         original_obfuscated_lat = site.obfuscated_latitude
 
-        site.update!(latitude: site.latitude + 1.0)
+        site.update!(latitude: site.latitude - site.latitude)
 
         expect(site.obfuscated_latitude).not_to eq(original_obfuscated_lat)
         expect(site.obfuscated_latitude).to be_within(Site::JITTER_RANGE).of(site.latitude)
@@ -234,7 +355,7 @@ describe Site do
         site = create(:site, :with_lat_long)
         original_obfuscated_lng = site.obfuscated_longitude
 
-        site.update!(longitude: site.longitude + 1.0)
+        site.update!(longitude: site.longitude - site.longitude)
 
         expect(site.obfuscated_longitude).not_to eq(original_obfuscated_lng)
         expect(site.obfuscated_longitude).to be_within(Site::JITTER_RANGE).of(site.longitude)


### PR DESCRIPTION
# feat: add camtrap-dp export module 

The purpose is to export validated Camtrap Data Packages from filtered audio event taggings. Fixes #984 
## Changes

Add a `BawWorkers::Export::CamtrapDp` exporter that writes deployments, media, observations, and `datapackage.json` into a zipped package
Add Camtrap DP descriptor, table, metadata, validator, error, and profile modules backed by dry-struct types
Add pinned acoustic Camtrap DP profile assets and a `baw:camtrap_dp:update` task for refreshing the local validation profile
Add DataPackage/TableSchema patches needed for local profile loading and schema-compatible CSV validation

Add export options for coordinate obfuscation, contributors, project metadata, project license emission, and forced UTC offsets
Add timezone-aware deployment accumulation using site timezones with UTC fallback
Map audio recordings and taggings into Camtrap DP media and interval observation rows
Derive package spatial, temporal, taxonomic, project, and license metadata from exported deployments

Add `AudioRecording#recorded_end_date`, `Permission#broad_access?`, and `Site#public_site?` helpers used by export mapping
Update audio recording overlap logic to reuse `recorded_end_date`

Add specs for exporter validation and package output, observation type mapping, profile update task, and the new model helpers

## Problems

Observation type mapping is temporary and should be revisited with #1009.

## Visual Changes

No visual changes.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [ ] Ensure CI build is passing