### PR TITLE
fix: enhance analysis job item state machine to handle discarded audio recordings

### DIFF
--- a/app/models/analysis_jobs_item.rb
+++ b/app/models/analysis_jobs_item.rb
@@ -58,10 +58,23 @@ class AnalysisJobsItem < ApplicationRecord
 
   belongs_to :analysis_jobs_script, optional: true, foreign_key: [:analysis_job_id, :script_id]
 
-  # ensure we allow with_discarded here for race conditions where parent
-  # records are soft deleted while job items are still updating
-  belongs_to :analysis_job, -> { with_discarded }, inverse_of: :analysis_jobs_items
-  belongs_to :audio_recording, -> { with_discarded }, inverse_of: :analysis_jobs_items
+  # keep default associations safely scoped to non-discarded parents.
+  # for special lifecycle paths that need to see discarded parents (e.g. for race conditions),
+  # use the explicit `*_with_discarded` associations below.
+  belongs_to :analysis_job, inverse_of: :analysis_jobs_items
+  belongs_to :audio_recording, inverse_of: :analysis_jobs_items
+  belongs_to :analysis_job_with_discarded,
+    -> { with_discarded },
+    class_name: 'AnalysisJob',
+    foreign_key: :analysis_job_id,
+    inverse_of: false,
+    optional: true
+  belongs_to :audio_recording_with_discarded,
+    -> { with_discarded },
+    class_name: 'AudioRecording',
+    foreign_key: :audio_recording_id,
+    inverse_of: false,
+    optional: true
   belongs_to :script, inverse_of: :analysis_jobs_items
 
   # we use all the following associations to help with filtering for virtual directories
@@ -550,7 +563,7 @@ class AnalysisJobsItem < ApplicationRecord
       .analysis_cache_helper
       .possible_paths_dir({
         job_id: analysis_job_id,
-        uuid: audio_recording.uuid,
+        uuid: audio_recording_with_discarded.uuid,
         script_id:,
         sub_folders: []
       })
@@ -568,7 +581,7 @@ class AnalysisJobsItem < ApplicationRecord
       .analysis_cache_helper
       .possible_paths_dir({
         job_id: analysis_job_id,
-        uuid: audio_recording.uuid,
+        uuid: audio_recording_with_discarded.uuid,
         sub_folders: []
       })
       .first => path

--- a/app/models/analysis_jobs_item.rb
+++ b/app/models/analysis_jobs_item.rb
@@ -58,10 +58,10 @@ class AnalysisJobsItem < ApplicationRecord
 
   belongs_to :analysis_jobs_script, optional: true, foreign_key: [:analysis_job_id, :script_id]
 
-  # ensure we allow with_discarded here for race condition where analysis job
-  # has been soft deleted while job items are still updating
+  # ensure we allow with_discarded here for race conditions where parent
+  # records are soft deleted while job items are still updating
   belongs_to :analysis_job, -> { with_discarded }, inverse_of: :analysis_jobs_items
-  belongs_to :audio_recording, inverse_of: :analysis_jobs_items
+  belongs_to :audio_recording, -> { with_discarded }, inverse_of: :analysis_jobs_items
   belongs_to :script, inverse_of: :analysis_jobs_items
 
   # we use all the following associations to help with filtering for virtual directories

--- a/app/models/analysis_jobs_item/state_machine.rb
+++ b/app/models/analysis_jobs_item/state_machine.rb
@@ -129,10 +129,21 @@ class AnalysisJobsItem
         #  @return [Boolean]
         # @!method may_queue?
         #  @return [Boolean] true if the item can be queued
-        event :queue, guards: [:not_cancelled?] do
+        event :queue do
+          # If the associated audio recording was deleted (race condition where
+          # audio recording was deleted between job creation and remote enqueue), this will
+          # skip submission and just cancel the job.
+          transitions(
+            from: STATUS_NEW_SYM,
+            to: STATUS_FINISHED_SYM,
+            guards: [:source_recording_discarded?],
+            after: [:clear_transition_queue, :set_result_cancelled]
+          )
+
           transitions(
             from: STATUS_NEW_SYM,
             to: STATUS_QUEUED_SYM,
+            guards: [:not_cancelled?, :source_recording_kept?],
             after: [:clear_transition_queue]
           )
         end
@@ -177,9 +188,20 @@ class AnalysisJobsItem
         # @!method may_retry?
         #  @return [Boolean] true if the item can be retried
         event :retry do
+          # If the associated audio recording was deleted (race condition where
+          # audio recording was deleted between job creation and remote enqueue), this will
+          # skip submission and just cancel the job.
+          transitions(
+            from: STATUS_FINISHED_SYM,
+            to: STATUS_FINISHED_SYM,
+            guards: [:source_recording_discarded?],
+            after: [:clear_error, :clear_result, :clear_transition_retry, :set_result_cancelled]
+          )
+
           transitions(
             from: STATUS_FINISHED_SYM,
             to: STATUS_QUEUED_SYM,
+            guards: [:source_recording_kept?],
             after: [:clear_error, :clear_result, :clear_transition_retry]
           )
         end
@@ -194,6 +216,14 @@ class AnalysisJobsItem
 
     def not_cancelled?
       !transition_cancel?
+    end
+
+    def source_recording_discarded?
+      audio_recording&.discarded?
+    end
+
+    def source_recording_kept?
+      !source_recording_discarded?
     end
 
     def failed?
@@ -233,6 +263,8 @@ class AnalysisJobsItem
     # It's important to do this as soon as possible to free up resources on the
     # remote queue.
     def clear_from_queue
+      return if queue_id.blank?
+
       result = BawWorkers::Config.batch_analysis.clear_job(self)
       unwrap_failure(result)
     rescue ::PBS::Errors::JobNotFoundError => e

--- a/app/models/analysis_jobs_item/state_machine.rb
+++ b/app/models/analysis_jobs_item/state_machine.rb
@@ -48,10 +48,10 @@ class AnalysisJobsItem
       #
       # Slow/background worker transitions:
       #
-      #   - :queue (:new → :queued)
+      #   - :queue (:new → :queued | :finished if audio recording was discarded)
       #   - :cancel (* → :finish)
       #   - :finish (:working → :finished)
-      #   - :retry (:finished → :queued)
+      #   - :retry (:finished → :queued | :finished if audio recording was discarded)
       #
       # Background worker transitions are signalled by setting the `transition`
       # column to the desired transition. Then a background job will process
@@ -126,12 +126,14 @@ class AnalysisJobsItem
         ]
 
         # @!method queue!
+        #  Can transition to :queued or :finished (cancelled) depending on the state of the associated audio recording.
+        #  Return value only indicated a successful transition, not which transition was taken.
         #  @return [Boolean]
         # @!method may_queue?
         #  @return [Boolean] true if the item can be queued
         event :queue do
-          # If the associated audio recording was deleted (race condition where
-          # audio recording was deleted between job creation and remote enqueue), this will
+          # If the associated audio recording was discarded (race condition where
+          # audio recording was discarded between job creation and remote enqueue), this will
           # skip submission and just cancel the job.
           transitions(
             from: STATUS_NEW_SYM,
@@ -188,8 +190,8 @@ class AnalysisJobsItem
         # @!method may_retry?
         #  @return [Boolean] true if the item can be retried
         event :retry do
-          # If the associated audio recording was deleted (race condition where
-          # audio recording was deleted between job creation and remote enqueue), this will
+          # If the associated audio recording was discarded (race condition where
+          # audio recording was discarded between job creation and remote enqueue), this will
           # skip submission and just cancel the job.
           transitions(
             from: STATUS_FINISHED_SYM,
@@ -219,7 +221,10 @@ class AnalysisJobsItem
     end
 
     def source_recording_discarded?
-      audio_recording&.discarded?
+      recording = audio_recording_with_discarded
+      raise "Audio recording is missing for analysis_jobs_item #{id}" if recording.nil?
+
+      recording.discarded?
     end
 
     def source_recording_kept?
@@ -273,7 +278,7 @@ class AnalysisJobsItem
     end
 
     def check_overall_progress
-      analysis_job.check_progress!
+      analysis_job_with_discarded.check_progress!
     end
 
     def enqueue_import_results
@@ -324,11 +329,13 @@ class AnalysisJobsItem
       # increment on a failure
       return unless result_success?
 
+      recording = audio_recording_with_discarded
+
       Statistics::UserStatistics.increment_analysis_count(
-        analysis_job.creator,
-        duration: audio_recording.duration_seconds
+        analysis_job_with_discarded.creator,
+        duration: recording.duration_seconds
       )
-      Statistics::AudioRecordingStatistics.increment_analysis_count(audio_recording)
+      Statistics::AudioRecordingStatistics.increment_analysis_count(recording)
     end
 
     def unwrap_failure(result)

--- a/app/modules/access/by_permission.rb
+++ b/app/modules/access/by_permission.rb
@@ -236,7 +236,7 @@ module Access
         query = AnalysisJobsItem
           .joins(audio_recording: :site)
           .order(audio_recording_id: :asc)
-          .joins(:analysis_job) # this join ensures only non-deleted results are returned
+          .joins(:analysis_job)
           .where(analysis_jobs: { id: analysis_job.id })
 
         permission_sites(user, levels, query)

--- a/lib/gems/baw-workers/lib/baw_workers/batch_analysis/communicator.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/batch_analysis/communicator.rb
@@ -144,8 +144,11 @@ module BawWorkers
       # @param analysis_job_item [::AnalysisJobsItem] the script execute
       # @return [::Dry::Monads::Result<string>] the created job id
       def submit_job(analysis_job_item)
-        analysis_job = analysis_job_item.analysis_job
-        audio_recording = analysis_job_item.audio_recording
+        # We've had multiple guards for race conditions up to this point, but
+        # if we still hit this case where one of the things has been soft deleted,
+        # # then we just give up and run the job.
+        analysis_job = analysis_job_item.analysis_job_with_discarded
+        audio_recording = analysis_job_item.audio_recording_with_discarded
         script = analysis_job_item.script
 
         raise ArgumentError, 'analysis_job_item must have an AnalysisJob' unless analysis_job.is_a?(AnalysisJob)

--- a/lib/gems/baw-workers/lib/baw_workers/jobs/analysis/remote_enqueue_job.rb
+++ b/lib/gems/baw-workers/lib/baw_workers/jobs/analysis/remote_enqueue_job.rb
@@ -78,34 +78,49 @@ module BawWorkers
           report_progress(0, size)
 
           # then for each job item, attempt to enqueue it
+
+          results = Hash.new(0)
           count = 0
+
           sampled.each do |item|
-            success = logger.measure_debug("Enqueued analysis job item #{item.id}") {
+            status = logger.measure_debug("Enqueued analysis job item #{item.id}") {
               enqueue_item(item)
             }
-            count += 1 if success
+            count += 1
+            results[status] += 1
 
             report_progress(count, size)
           end
 
-          logger.info('Enqueued', count:, of_batch_size: size)
-          completed!("Enqueued #{count} of #{size} jobs, sleeping now")
+          logger.info('Enqueued', count:, of_batch_size: size, results:)
+
+          completed!(
+            results.to_s,
+            "Enqueued #{count} of #{size} jobs, sleeping now"
+          )
         end
 
         # @param item_id [Integer]
-        # @return [Boolean]
+        # @return [Symbol] the status of the item after attempting to enqueue it
+        #   (including a special tokens :not_queueable and :already_queued)
         def enqueue_item(item)
           # submits the job to the remote queue
           # and saves the record
           if item.may_queue?
             # slow warning: contacting remote system!
             item.queue!
+
+            item.status.to_sym
           elsif item.may_retry?
             # slow warning: contacting remote system!
             item.retry!
+
+            item.status.to_sym
           elsif item.queued?
             item.clear_transition_queue_or_retry
             item.save!
+
+            :already_queued
           else
             # we assume that whatever state we're in now that it will be resolved soon
             logger.warn(
@@ -113,7 +128,7 @@ module BawWorkers
               item_id: item.id,
               status: item.status
             )
-            false
+            :not_queueable
           end
         end
 

--- a/spec/lib/gems/baw_workers/batch_analysis/communicator_spec.rb
+++ b/spec/lib/gems/baw_workers/batch_analysis/communicator_spec.rb
@@ -102,12 +102,18 @@ describe BawWorkers::BatchAnalysis::Communicator, :clean_by_truncation, { web_se
 
   # https://github.com/QutEcoacoustics/baw-server/issues/781
   it 'can handle when friendly name is nil' do
-    analysis_jobs_item.audio_recording.site = nil
+    # this can happen when the site is soft deleted.
+    analysis_jobs_item.audio_recording_with_discarded.site = nil
+
+    # when the association is loaded, site is nil, even though the FK constraint
+    # # guarantees there is a site in the dB
+
     analysis_jobs_item.script.executable_command = <<~BASH
       echo 'source={{source}} {{output_dir}}'
     BASH
 
-    analysis_jobs_item.queue!
+    expect(analysis_jobs_item.queue!).to eq true
+    expect(analysis_jobs_item).to be_queued
     release_all_held_pbs_jobs
     wait_for_pbs_job analysis_jobs_item.queue_id
 

--- a/spec/lib/gems/baw_workers/jobs/analysis/remote_enqueue_job_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/analysis/remote_enqueue_job_spec.rb
@@ -51,6 +51,21 @@ describe BawWorkers::Jobs::Analysis::RemoteEnqueueJob do
     expect(status.messages).to include 'Enqueued 5 of 5 jobs, sleeping now'
   end
 
+  it 'cancels items with discarded source recordings instead of enqueueing them' do
+    item = create(:analysis_jobs_item, queue_id: nil)
+    item.audio_recording.discard!
+
+    job = BawWorkers::Jobs::Analysis::RemoteEnqueueJob.new
+
+    expect(job.enqueue_item(item)).to be true
+
+    item.reload
+    expect(item).to be_finished
+    expect(item).to be_result_cancelled
+    expect(item.transition).to be_nil
+    expect(item.queue_id).to be_nil
+  end
+
   stepwise 'the remote enqueue job' do
     step 'check initial state' do
       expect(AnalysisJobsItem.count).to eq(40)

--- a/spec/lib/gems/baw_workers/jobs/analysis/remote_enqueue_job_spec.rb
+++ b/spec/lib/gems/baw_workers/jobs/analysis/remote_enqueue_job_spec.rb
@@ -57,7 +57,7 @@ describe BawWorkers::Jobs::Analysis::RemoteEnqueueJob do
 
     job = BawWorkers::Jobs::Analysis::RemoteEnqueueJob.new
 
-    expect(job.enqueue_item(item)).to be true
+    expect(job.enqueue_item(item)).to be :finished
 
     item.reload
     expect(item).to be_finished

--- a/spec/lib/gems/emu/emu_spec.rb
+++ b/spec/lib/gems/emu/emu_spec.rb
@@ -206,7 +206,7 @@ describe Emu do
         success: true,
         log: "\n",
         records: an_instance_of(Array),
-        time_taken: a_value_within(2.0).of(4.5)
+        time_taken: a_value_within(2.5).of(4.0)
       )
 
       expect(actual.records.first).to match(

--- a/spec/lib/modules/filter/query_spec.rb
+++ b/spec/lib/modules/filter/query_spec.rb
@@ -1173,10 +1173,10 @@ describe Filter::Query do
         FROM "analysis_jobs_items"
           INNER
           JOIN "audio_recordings"
-            ON ("audio_recordings"."deleted_at"
-              IS
-              NULL)
-               AND ("audio_recordings"."id" = "analysis_jobs_items"."audio_recording_id")
+        ON ("audio_recordings"."deleted_at"
+        IS
+        NULL)
+        AND ("audio_recordings"."id" = "analysis_jobs_items"."audio_recording_id")
           INNER
           JOIN "sites"
             ON ("sites"."deleted_at"
@@ -1185,7 +1185,10 @@ describe Filter::Query do
                AND ("sites"."id" = "audio_recordings"."site_id")
         INNER
         JOIN "analysis_jobs"
-        ON "analysis_jobs"."id" = "analysis_jobs_items"."analysis_job_id"
+        ON ("analysis_jobs"."deleted_at"
+        IS
+        NULL)
+        AND ("analysis_jobs"."id" = "analysis_jobs_items"."analysis_job_id")
         WHERE ("analysis_jobs"."id" = #{analysis_job.id})
         AND (
           EXISTS (

--- a/spec/models/analysis_jobs_item/state_machine_spec.rb
+++ b/spec/models/analysis_jobs_item/state_machine_spec.rb
@@ -127,7 +127,7 @@ describe AnalysisJobsItem do
           item.queue!
         }.to raise_error(
           AASM::InvalidTransition,
-          "Event 'queue' cannot transition from 'new'. Failed callback(s): [:source_recording_discarded?, :not_cancelled?]."
+          /Event 'queue' cannot transition from 'new'\. Failed callback\(s\): \[(?=.*source_recording_discarded\?)(?=.*not_cancelled\?).*\]\./
         )
 
         expect(item).to be_new

--- a/spec/models/analysis_jobs_item/state_machine_spec.rb
+++ b/spec/models/analysis_jobs_item/state_machine_spec.rb
@@ -105,6 +105,20 @@ describe AnalysisJobsItem do
         assert_stats(analysis_jobs_item)
       end
 
+      example 'new -> finished (cancelled) when source recording is discarded' do
+        item.audio_recording.discard!
+        item.transition_queue!
+
+        expect(item.queue!).to be true
+
+        expect(item).to be_finished
+        expect(item).to be_result_cancelled
+        expect(item).to be_transition_empty
+        expect(item.queue_id).to be_nil
+
+        assert_stats(analysis_jobs_item)
+      end
+
       example 'new -> queued (when cancelling)' do
         item.transition_cancel!
         expect(item).to be_transition_cancel
@@ -113,7 +127,7 @@ describe AnalysisJobsItem do
           item.queue!
         }.to raise_error(
           AASM::InvalidTransition,
-          "Event 'queue' cannot transition from 'new'. Failed callback(s): [:not_cancelled?]."
+          "Event 'queue' cannot transition from 'new'. Failed callback(s): [:source_recording_discarded?, :not_cancelled?]."
         )
 
         expect(item).to be_new

--- a/spec/models/analysis_jobs_item_spec.rb
+++ b/spec/models/analysis_jobs_item_spec.rb
@@ -67,6 +67,18 @@ describe AnalysisJobsItem do
   it { is_expected.to belong_to(:audio_recording) }
   it { is_expected.to belong_to(:script) }
 
+  it 'keeps access to a discarded audio_recording association' do
+    item = create(:analysis_jobs_item)
+    recording_id = item.audio_recording_id
+
+    item.audio_recording.discard!
+    item.reload
+
+    expect(item.audio_recording).to be_a(AudioRecording)
+    expect(item.audio_recording.id).to eq(recording_id)
+    expect(item.audio_recording).to be_discarded
+  end
+
   # it { should validate_presence_of(:status) }
   #
   # it { should validate_length_of(:status).is_at_least(2).is_at_most(255) }

--- a/spec/models/analysis_jobs_item_spec.rb
+++ b/spec/models/analysis_jobs_item_spec.rb
@@ -67,16 +67,17 @@ describe AnalysisJobsItem do
   it { is_expected.to belong_to(:audio_recording) }
   it { is_expected.to belong_to(:script) }
 
-  it 'keeps access to a discarded audio_recording association' do
+  it 'hides discarded audio_recording on default association but allows explicit with_discarded association' do
     item = create(:analysis_jobs_item)
     recording_id = item.audio_recording_id
 
     item.audio_recording.discard!
     item.reload
 
-    expect(item.audio_recording).to be_a(AudioRecording)
-    expect(item.audio_recording.id).to eq(recording_id)
-    expect(item.audio_recording).to be_discarded
+    expect(item.audio_recording).to be_nil
+    expect(item.audio_recording_with_discarded).to be_a(AudioRecording)
+    expect(item.audio_recording_with_discarded.id).to eq(recording_id)
+    expect(item.audio_recording_with_discarded).to be_discarded
   end
 
   # it { should validate_presence_of(:status) }


### PR DESCRIPTION
Fixes #996.

This handles the case where recordings are deleted after the job items have been generated.
