### PR TITLE
fix: redirect to client home_url after confirming password reset

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # https://github.com/heartcombo/devise/blob/v5.0.3/app/controllers/devise/passwords_controller.rb
+  #
+  # We want to redirect to `client_routes.home_url` after a password reset, but
+  # Rails protects against redirecting to external hosts by default. To bypass,
+  # copy Devise's update action and allow the external redirect.
+  def update
+    self.resource = resource_class.reset_password_by_token(resource_params)
+    yield resource if block_given?
+
+    if resource.errors.empty?
+      resource.unlock_access! if unlockable?(resource)
+      if sign_in_after_reset_password?
+        flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
+        set_flash_message!(:notice, flash_message)
+        resource.after_database_authentication
+        sign_in(resource_name, resource)
+      else
+        set_flash_message!(:notice, :updated_not_active)
+      end
+      respond_with_navigational(resource) do
+        redirect_to after_resetting_password_path_for(resource), allow_other_host: true
+      end
+    else
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  protected
+
+  def after_resetting_password_path_for(_resource)
+    Settings.client_routes.home_url.to_s
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,11 +17,11 @@
 #                                      new_user_session GET                                          /my_account/sign_in(.:format)                                                                                                        users/sessions#new
 #                                          user_session POST                                         /my_account/sign_in(.:format)                                                                                                        users/sessions#create
 #                                  destroy_user_session GET                                          /my_account/sign_out(.:format)                                                                                                       users/sessions#destroy
-#                                     new_user_password GET                                          /my_account/password/new(.:format)                                                                                                   devise/passwords#new
-#                                    edit_user_password GET                                          /my_account/password/edit(.:format)                                                                                                  devise/passwords#edit
-#                                         user_password PATCH                                        /my_account/password(.:format)                                                                                                       devise/passwords#update
-#                                                       PUT                                          /my_account/password(.:format)                                                                                                       devise/passwords#update
-#                                                       POST                                         /my_account/password(.:format)                                                                                                       devise/passwords#create
+#                                     new_user_password GET                                          /my_account/password/new(.:format)                                                                                                   users/passwords#new
+#                                    edit_user_password GET                                          /my_account/password/edit(.:format)                                                                                                  users/passwords#edit
+#                                         user_password PATCH                                        /my_account/password(.:format)                                                                                                       users/passwords#update
+#                                                       PUT                                          /my_account/password(.:format)                                                                                                       users/passwords#update
+#                                                       POST                                         /my_account/password(.:format)                                                                                                       users/passwords#create
 #                              cancel_user_registration GET                                          /my_account/cancel(.:format)                                                                                                         users/registrations#cancel
 #                                 new_user_registration GET                                          /my_account/sign_up(.:format)                                                                                                        users/registrations#new
 #                                edit_user_registration GET                                          /my_account/edit(.:format)                                                                                                           users/registrations#edit
@@ -620,7 +620,7 @@ Rails.application.routes.draw do
   devise_for :users,
     path: :my_account,
     controllers: { sessions: 'users/sessions', registrations: 'users/registrations',
-                   confirmations: 'users/confirmations' }
+                   confirmations: 'users/confirmations', passwords: 'users/passwords' }
 
   # devise for RESTful API Authentication, see sessions_controller.rb
   devise_for :users,

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe 'user passwords', type: :request do
+  describe 'PUT /my_account/password' do
+    let(:user) { create(:confirmed_user) }
+    let(:reset_password_token) { user.send(:set_reset_password_token) }
+
+    it 'updates the password and redirects to the client home page' do
+      put user_password_path, params: {
+        user: {
+          reset_password_token: reset_password_token,
+          password: 'new password',
+          password_confirmation: 'new password'
+        }
+      }
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(Settings.client_routes.home_url.to_s)
+      expect(user.reload.valid_password?('new password')).to be true
+    end
+  end
+end

--- a/spec/routing/devise_routing_spec.rb
+++ b/spec/routing/devise_routing_spec.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-
-
 describe SessionsController, type: :routing do
   describe :routing do
     it { expect(get('/my_account/sign_in')).to route_to('users/sessions#new') }
     it { expect(post('/my_account/sign_in')).to route_to('users/sessions#create') }
     it { expect(get('/my_account/sign_out')).to route_to('users/sessions#destroy') }
 
-    it { expect(post('/my_account/password')).to route_to('devise/passwords#create') }
-    it { expect(get('/my_account/password/new')).to route_to('devise/passwords#new') }
-    it { expect(get('/my_account/password/edit')).to route_to('devise/passwords#edit') }
-    it { expect(put('/my_account/password')).to route_to('devise/passwords#update') }
+    it { expect(post('/my_account/password')).to route_to('users/passwords#create') }
+    it { expect(get('/my_account/password/new')).to route_to('users/passwords#new') }
+    it { expect(get('/my_account/password/edit')).to route_to('users/passwords#edit') }
+    it { expect(put('/my_account/password')).to route_to('users/passwords#update') }
 
     it { expect(get('/my_account/cancel')).to route_to('users/registrations#cancel') }
     it { expect(post('/my_account')).to route_to('users/registrations#create') }


### PR DESCRIPTION
# fix: redirect to client home_url after confirming password reset

Prevent users getting stuck in `api` subdomain after resetting their password. 

## Changes

Add passwords controller and tests.

## Problems

Silent breaking change, tracked in https://github.com/QutEcoacoustics/baw-server/issues/1036

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Remove/Reduce warnings from edited files
- [x] Unit tests have been added for changes
- [x] Ensure CI build is passing
