### PR TITLE
fix(permissions): resolve effective access once per site

### DIFF
--- a/app/modules/access/by_permission_table.rb
+++ b/app/modules/access/by_permission_table.rb
@@ -21,7 +21,7 @@ module Access
     # @param levels [Array<Symbol>] alternative to level, an array of specific permission levels (see Permission levels)
     # @return [ActiveRecord::Relation<Project>] the approved projects
     def projects(user, level: nil, levels: nil)
-      query = Project.all
+      query = add_effective_permissions_cte(Project.all, user)
 
       apply(user, query, level:, levels:)
     end
@@ -33,9 +33,9 @@ module Access
     # @param project_ids [Array<Integer>] optional list of project IDs to further restrict results
     # @return [ActiveRecord::Relation<Site>] the approved sites
     def sites(user, level: nil, levels: nil, project_ids: nil)
-      query = Site.joins(:projects)
+      query = add_effective_site_permissions_cte(Site.all, user, project_ids:)
 
-      apply(user, query, level:, levels:, project_ids:)
+      apply(user, query, level:, levels:)
     end
 
     # Returns a query for audio events the user has at least the given level of permission for.
@@ -47,9 +47,9 @@ module Access
     # @param project_ids [Array<Integer>] optional list of project IDs to reduce the scale of permissions joined
     # @return [ActiveRecord::Relation<AudioEvent>] the approved audio events
     def audio_events(user, level: nil, levels: nil, project_ids: nil)
-      query = AudioEvent.joins(audio_recording: { site: :projects })
+      query = add_effective_site_permissions_cte(AudioEvent.joins(audio_recording: :site), user, project_ids:)
 
-      apply(user, query, level:, levels:, project_ids:) { |predicate|
+      apply(user, query, level:, levels:) { |predicate|
         # Reference audio events are always accessible regardless of permission
         ae = AudioEvent.arel_table
         reference_predicate = ae[:is_reference].eq(true)
@@ -67,12 +67,12 @@ module Access
     # @param project_ids [Array<Integer>] optional list of project IDs to reduce the scale of permissions joined
     # @return [ActiveRecord::Relation<AudioRecording>] the approved audio recordings
     def audio_recordings(user, level: nil, levels: nil, project_ids: nil)
-      query = AudioRecording.joins(site: :projects)
+      query = add_effective_site_permissions_cte(AudioRecording.joins(:site), user, project_ids:)
 
-      apply(user, query, level:, levels:, project_ids:)
+      apply(user, query, level:, levels:)
     end
 
-    def apply(user, query, level:, levels: nil, project_ids: nil)
+    def apply(user, query, level:, levels: nil)
       user = Access::Validate.user(user)
       validate_levels(level, levels)
 
@@ -88,9 +88,7 @@ module Access
 
       predicate = yield predicate if block_given?
 
-      predicate = predicate.and(Project.arel_table[:id].in(project_ids)) if project_ids.present?
-
-      add_effective_permissions_cte(query, user, project_ids:).where(predicate)
+      query.where(predicate)
     end
 
     def validate_levels(level, levels)

--- a/app/modules/access/effective_permission.rb
+++ b/app/modules/access/effective_permission.rb
@@ -8,6 +8,9 @@ module Access
     TABLE_NAME = TABLE.name.freeze
     LEVEL_NAME = 'level'
 
+    PROJECT_TABLE = Arel::Table.new(:effective_project_permissions).freeze
+    PROJECT_TABLE_NAME = PROJECT_TABLE.name.freeze
+
     module_function
 
     # Joins the effective permissions CTE to the given query.
@@ -27,6 +30,33 @@ module Access
           project_table
             .join(TABLE, Arel::Nodes::OuterJoin)
             .on(project_table[:id].eq(TABLE[:project_id]))
+            .join_sources
+        )
+    end
+
+    # Joins effective permissions to a query containing the sites table without changing the query's cardinality.
+    # A site can belong to multiple projects, so joining project permissions directly emits one row per project.
+    # Instead, retain the performant CTE-and-join design but resolve those project permissions to one row per site.
+    # The strongest project permission is exposed as effective_permissions.level for downstream projections.
+    # TODO: remove when fixing https://github.com/QutEcoacoustics/baw-server/issues/743
+    # @param query [ActiveRecord::Relation] query containing the sites table
+    # @param user [User]
+    # @param project_ids [Array<Integer>] optional projects through which sites may be accessed
+    # @return [ActiveRecord::Relation]
+    def add_effective_site_permissions_cte(query, user, project_ids: nil)
+      project_permissions = effective_permissions_for_projects_query(user, project_ids:)
+      site_permissions = effective_permissions_for_sites_query(project_ids:)
+      site_table = Site.arel_table
+
+      query
+        .with(
+          PROJECT_TABLE_NAME.to_s => project_permissions,
+          TABLE_NAME.to_s => site_permissions
+        )
+        .joins(
+          site_table
+            .join(TABLE)
+            .on(site_table[:id].eq(TABLE[:site_id]))
             .join_sources
         )
     end
@@ -90,6 +120,27 @@ module Access
           pm[:project_id],
           case_statement.maximum.as(LEVEL_NAME)
         )
+    end
+
+    # Resolves project permissions to one effective permission row per site.
+    # MAX is intentional: access through any associated project grants the strongest available level, while the
+    # left join and COALESCE retain sites whose associated projects grant no permission. Returning exactly one row
+    # per site prevents projects_sites fan-out from duplicating sites and every record derived from them.
+    # @param project_ids [Array<Integer>] optional projects through which sites may be accessed
+    # @return [Arel::SelectManager] query returning site_id and level
+    def effective_permissions_for_sites_query(project_ids: nil)
+      projects_sites = ProjectsSite.arel_table
+      level = Arel.coalesce(PROJECT_TABLE[LEVEL_NAME], Permission.none_value).maximum.as(LEVEL_NAME)
+
+      query = projects_sites
+        .join(PROJECT_TABLE, Arel::Nodes::OuterJoin)
+        .on(projects_sites[:project_id].eq(PROJECT_TABLE[:project_id]))
+        .group(projects_sites[:site_id])
+        .project(projects_sites[:site_id], level)
+
+      query = query.where(projects_sites[:project_id].in(project_ids)) if project_ids.present?
+
+      query
     end
 
     # Builds an Arel predicate for filtering by effective permission level.

--- a/spec/unit/modules/access/by_permission_table_spec.rb
+++ b/spec/unit/modules/access/by_permission_table_spec.rb
@@ -216,6 +216,58 @@ describe Access::ByPermissionTable do
     end
   end
 
+  context 'when a site belongs to multiple accessible projects' do
+    before do
+      site.projects << another_project
+      create(:write_permission,
+        project: another_project,
+        creator: another_project.creator,
+        user: reader_user)
+    end
+
+    example 'resolves the strongest permission level for the site' do
+      result = Access::ByPermissionTable
+        .sites(reader_user, level: Access::Permission::READER)
+        .where(id: site.id)
+        .pluck(:id, 'effective_permissions.level')
+
+      expect(result).to eq([
+        [site.id, Access::Permission::LEVEL_TO_INTEGER_MAP[Access::Permission::WRITER]]
+      ])
+    end
+
+    example 'returns the site once' do
+      result = Access::ByPermissionTable
+        .sites(reader_user, level: Access::Permission::READER)
+        .where(id: site.id)
+        .pluck(:id)
+
+      expect(result).to eq([site.id])
+    end
+
+    example 'returns the audio recording once with the strongest site permission' do
+      result = Access::ByPermissionTable
+        .audio_recordings(reader_user, level: Access::Permission::READER)
+        .where(id: audio_recording.id)
+        .pluck(:id, 'effective_permissions.level')
+
+      expect(result).to eq([
+        [audio_recording.id, Access::Permission::LEVEL_TO_INTEGER_MAP[Access::Permission::WRITER]]
+      ])
+    end
+
+    example 'returns the audio event once with the strongest site permission' do
+      result = Access::ByPermissionTable
+        .audio_events(reader_user, level: Access::Permission::READER)
+        .where(id: audio_event.id)
+        .pluck(:id, 'effective_permissions.level')
+
+      expect(result).to eq([
+        [audio_event.id, Access::Permission::LEVEL_TO_INTEGER_MAP[Access::Permission::WRITER]]
+      ])
+    end
+  end
+
   context 'with Access::ByPermission the behaviour is identical' do
     # audio_event_anon needed for audio_events equivalence test
     let!(:audio_event_anon) {


### PR DESCRIPTION
Prevent permission joins from duplicating sites, recordings, and audio events when a site belongs to multiple accessible projects.

The existing effective-permission CTE already reduces multiple permission records to one row per project by grouping on project_id and selecting the strongest level. However, joining those project-level rows through projects_sites still produces one source row for every project associated with a site. This changes the cardinality of permission-scoped queries and can inflate downstream aggregates such as accumulated coverage density.

Introduce a second aggregation stage for site-derived resources:

- calculate one effective permission row per project as before;
- join those permissions through projects_sites;
- group the result by site_id;
- expose the maximum permission level across the site's scoped projects;
- join the resulting one-row-per-site CTE to sites, recordings, and events.

Using MAX intentionally grants the strongest permission available through any associated project. Filtering projects_sites by project_ids before aggregation ensures that only the requested project paths contribute to the site's effective permission.

Keep the CTE-and-join architecture rather than switching to EXISTS. The joined form has previously benchmarked better and, importantly, keeps effective_permissions.level available to downstream expressions such as site location obfuscation.

Avoid applying DISTINCT to the outer query. DISTINCT would conceal the permission join's cardinality bug, could interfere with later projections and reselect calls, and would not define which permission level should represent a site accessible through projects with different levels.

Move CTE selection into the public permission query methods so the shared apply method only validates levels, constructs permission predicates, and filters the prepared relation. This removes the need for separate project/site application paths while keeping their different aggregation requirements explicit.

Add regressions proving that a site associated with multiple accessible projects:

- is returned only once;
- resolves to the strongest available permission;
- does not duplicate its audio recordings;
- does not duplicate its audio events;
- continues exposing effective_permissions.level.

This ensures permission joins do not alter source cardinality while preserving project scoping, reference-event access, and permission-level projections.

Refs #1033, Fixes #1038

